### PR TITLE
add cmd_list integration

### DIFF
--- a/codebundles/k8s-statefulset-healthcheck/runbook.robot
+++ b/codebundles/k8s-statefulset-healthcheck/runbook.robot
@@ -69,6 +69,7 @@ Fetch StatefulSet Logs
     ...    target_service=${kubectl}
     ...    env=${env}
     ...    secret_file__kubeconfig=${kubeconfig}
+    ...    render_in_commandlist=true
     ${history}=    RW.CLI.Pop Shell History
     RW.Core.Add Pre To Report    ${logs.stdout}
     RW.Core.Add Pre To Report    Commands Used: ${history}
@@ -81,6 +82,7 @@ Get Related StatefulSet Events
     ...    target_service=${kubectl}
     ...    env=${env}
     ...    secret_file__kubeconfig=${kubeconfig}
+    ...    render_in_commandlist=true
     ${history}=    RW.CLI.Pop Shell History
     RW.Core.Add Pre To Report    ${events.stdout}
     RW.Core.Add Pre To Report    Commands Used: ${history}
@@ -93,6 +95,7 @@ Fetch StatefulSet Manifest Details
     ...    target_service=${kubectl}
     ...    env=${env}
     ...    secret_file__kubeconfig=${kubeconfig}
+    ...    render_in_commandlist=true
     ${history}=    RW.CLI.Pop Shell History
     RW.Core.Add Pre To Report    ${statefulset.stdout}
     RW.Core.Add Pre To Report    Commands Used: ${history}
@@ -101,6 +104,12 @@ Check StatefulSet Replicas
     [Documentation]    Pulls the replica information for a given StatefulSet and checks if it's highly available
     ...                , if the replica counts are the expected / healthy values, and if not, what they should be.
     [Tags]    StatefulSet    Replicas    Desired    Actual    Available    Ready    Unhealthy    Rollout    Stuck    Pods
+    RW.CLI.Run Cli
+    ...    cmd=${BINARY_USED} get statefulset -n ${NAMESPACE} -o json | jq -r '.items[] | select(.status.availableReplicas < .status.replicas) | "---\nStatefulSet Name: " + (.metadata.name|tostring) + "\nDesired Replicas: " + (.status.replicas|tostring) + "\nAvailable Replicas: " + (.status.availableReplicas|tostring)'  
+    ...    target_service=${kubectl}
+    ...    env=${env}
+    ...    secret_file__kubeconfig=${kubeconfig}
+    ...    render_in_commandlist=true
     ${statefulset}=    RW.CLI.Run Cli
     ...    cmd=${BINARY_USED} get statefulset ${LABELS} --context=${CONTEXT} -n ${NAMESPACE} -o=jsonpath='{.items[0]}'
     ...    target_service=${kubectl}


### PR DESCRIPTION
This only adds in the command_list render capabilities, but doesn't touch the rest of the logic. As we chatted about, the last task could be reworked possibly to support both use cases, but this is the fastest path towards command list integration for now. 