### PR TITLE
Update parsers

### DIFF
--- a/libraries/RW/CLI/CLI.py
+++ b/libraries/RW/CLI/CLI.py
@@ -4,6 +4,7 @@ CLI Generic keyword library for running and parsing CLI stdout
 Scope: Global
 """
 import re, logging, json, jmespath
+from datetime import datetime
 from robot.libraries.BuiltIn import BuiltIn
 
 from RW import platform

--- a/libraries/RW/CLI/cli_utils.py
+++ b/libraries/RW/CLI/cli_utils.py
@@ -96,7 +96,7 @@ def escape_str_for_exec(string: str, escapes: int = 1) -> str:
     return string
 
 
-@dataclass(frozen=True)
+@dataclass
 class IssueCheckResults:
     """
     Used to keep function signatures from getting too busy when passing issue data around.
@@ -109,3 +109,4 @@ class IssueCheckResults:
     actual: str = ""
     reproduce_hint: str = ""
     issue_found: bool = False
+    details: str = ""

--- a/libraries/RW/CLI/json_parser.py
+++ b/libraries/RW/CLI/json_parser.py
@@ -262,7 +262,7 @@ def _check_for_json_issue(
         if not numeric_castable and (query_value == "True" or query_value == "False"):
             query_value = True if query_value == "True" else False
         if query == "raise_issue_if_eq" and (
-            query_value == variable_value or (variable_is_list and query_value in variable_value)
+            str(query_value) == str(variable_value) or (variable_is_list and query_value in variable_value)
         ):
             issue_found = True
             title = f"Value Of {prefix} Was {variable_value}"
@@ -271,7 +271,7 @@ def _check_for_json_issue(
             reproduce_hint = f"Run {rsp.cmd} and apply the jmespath '{variable_from_path[prefix]}' to the output"
             details = f"{set_issue_details} ({variable_value})"
         elif query == "raise_issue_if_neq" and (
-            query_value != variable_value or (variable_is_list and query_value not in variable_value)
+            str(query_value) != str(variable_value) or (variable_is_list and query_value not in variable_value)
         ):
             issue_found = True
             title = f"Value of {prefix} ({variable_value}) Was Not {query_value}"

--- a/libraries/RW/CLI/json_parser.py
+++ b/libraries/RW/CLI/json_parser.py
@@ -7,6 +7,8 @@ from . import cli_utils
 logger = logging.getLogger(__name__)
 ROBOT_LIBRARY_SCOPE = "GLOBAL"
 
+MAX_ISSUE_STRING_LENGTH: int = 255
+
 RECOGNIZED_JSON_PARSE_QUERIES = [
     "raise_issue_if_eq",
     "raise_issue_if_neq",
@@ -49,6 +51,7 @@ def parse_cli_json_output(
     _core: Core = Core()
     logger.info(f"kwargs: {kwargs}")
     found_issue: bool = False
+    variable_results["_stdout"] = rsp.stdout
     # check we've got an expected rsp
     try:
         cli_utils.verify_rsp(rsp, expected_rsp_statuscodes, expected_rsp_returncodes, contains_stderr_ok)
@@ -148,6 +151,7 @@ def parse_cli_json_output(
     # begin searching for issues
     # break at first found issue
     # TODO: revisit how we submit multiple chained issues
+    # TODO: cleanup, reorg this
     issue_results = _check_for_json_issue(
         rsp,
         variable_from_path,
@@ -157,17 +161,24 @@ def parse_cli_json_output(
         set_issue_actual,
         set_issue_reproduce_hint,
         set_issue_title,
+        set_issue_details,
         **kwargs,
     )
     if issue_results.issue_found:
-        _core.add_issue(
-            severity=issue_results.severity,
-            title=issue_results.title,
-            expected=issue_results.expected,
-            actual=issue_results.actual,
-            reproduce_hint=issue_results.reproduce_hint,
-            details=f"{set_issue_details} ({variable_from_path}: {variable_results})",
-        )
+        known_symbols = {**kwargs, **variable_results}
+        issue_data = {
+            "title": f"{issue_results.title}".format_map(known_symbols),
+            "severity": issue_results.severity,
+            "expected": f"{issue_results.expected}".format_map(known_symbols),
+            "actual": f"{issue_results.actual}".format_map(known_symbols),
+            "reproduce_hint": f"{issue_results.reproduce_hint}".format_map(known_symbols),
+            "details": f"{issue_results.details}".format_map(known_symbols),
+        }
+        # truncate long strings
+        for key, value in issue_data.items():
+            if isinstance(value, str) and len(value) > MAX_ISSUE_STRING_LENGTH:
+                issue_data[key] = value[:MAX_ISSUE_STRING_LENGTH] + "..."
+        _core.add_issue(**issue_data)
     # override rsp stdout for parse chaining
     for key in kwargs.keys():
         kwarg_parts = key.split("__")
@@ -199,12 +210,14 @@ def _check_for_json_issue(
     set_issue_actual: str = "",
     set_issue_reproduce_hint: str = "",
     set_issue_title: str = "",
+    set_issue_details: str = "",
     **kwargs,
 ) -> cli_utils.IssueCheckResults:
     severity: int = 4
     title: str = ""
     expected: str = ""
     actual: str = ""
+    details: str = ""
     reproduce_hint: str = ""
     issue_found: bool = False
     parse_queries = kwargs
@@ -256,6 +269,7 @@ def _check_for_json_issue(
             expected = f"The parsed output {variable_value} stored in {prefix} using the path: {variable_from_path[prefix]} should not be equal to {query_value}"
             actual = f"The parsed output {variable_value} stored in {prefix} using the path: {variable_from_path[prefix]} is equal to {variable_value}"
             reproduce_hint = f"Run {rsp.cmd} and apply the jmespath '{variable_from_path[prefix]}' to the output"
+            details = f"{set_issue_details} ({variable_value})"
         elif query == "raise_issue_if_neq" and (
             query_value != variable_value or (variable_is_list and query_value not in variable_value)
         ):
@@ -264,6 +278,7 @@ def _check_for_json_issue(
             expected = f"The parsed output {variable_value} stored in {prefix} using the path: {variable_from_path[prefix]} should be equal to {variable_value}"
             actual = f"The parsed output {variable_value} stored in {prefix} using the path: {variable_from_path[prefix]} does not contain the expected value of: {prefix}=={query_value} and is actually {variable_value}"
             reproduce_hint = f"Run {rsp.cmd} and apply the jmespath '{variable_from_path[prefix]}' to the output"
+            details = f"{set_issue_details} ({variable_value})"
 
         elif query == "raise_issue_if_lt" and numeric_castable and variable_value < query_value:
             issue_found = True
@@ -271,24 +286,28 @@ def _check_for_json_issue(
             expected = f"The parsed output {variable_value} stored in {prefix} using the path: {variable_from_path[prefix]} should have a value >= {query_value}"
             actual = f"The parsed output {variable_value} stored in {prefix} using the path: {variable_from_path[prefix]} found value: {variable_value} and it's less than {query_value}"
             reproduce_hint = f"Run {rsp.cmd} and apply the jmespath '{variable_from_path[prefix]}' to the output"
+            details = f"{set_issue_details} ({variable_value})"
         elif query == "raise_issue_if_gt" and numeric_castable and variable_value > query_value:
             issue_found = True
             title = f"Value of {prefix} ({variable_value}) Was Greater Than {query_value}"
             expected = f"The parsed output {variable_value} stored in {prefix} using the path: {variable_from_path[prefix]} should have a value <= {query_value}"
             actual = f"The parsed output {variable_value} stored in {prefix} using the path: {variable_from_path[prefix]} found value: {variable_value} and it's greater than {query_value}"
             reproduce_hint = f"Run {rsp.cmd} and apply the jmespath '{variable_from_path[prefix]}' to the output"
+            details = f"{set_issue_details} ({variable_value})"
         elif query == "raise_issue_if_contains" and query_value in variable_value:
             issue_found = True
             title = f"Value of {prefix} ({variable_value}) Contained {query_value}"
             expected = f"The parsed output {variable_value} stored in {prefix} using the path: {variable_from_path[prefix]} resulted in {variable_value} and should not contain {query_value}"
             actual = f"The parsed output {variable_value} stored in {prefix} using the path: {variable_from_path[prefix]} resulted in {variable_value} and it contains {query_value} when it should not"
             reproduce_hint = f"Run {rsp.cmd} and apply the jmespath '{variable_from_path[prefix]}' to the output"
+            details = f"{set_issue_details} ({variable_value})"
         elif query == "raise_issue_if_ncontains" and query_value not in variable_value:
             issue_found = True
             title = f"Value of {prefix} ({variable_value}) Did Not Contain {query_value}"
             expected = f"The parsed output {variable_value} stored in {prefix} using the path: {variable_from_path[prefix]} resulted in {variable_value} and should contain {query_value}"
             actual = f"The parsed output {variable_value} stored in {prefix} using the path: {variable_from_path[prefix]} resulted in {variable_value} and we expected to find {query_value} in the result"
             reproduce_hint = f"Run {rsp.cmd} and apply the jmespath '{variable_from_path[prefix]}' to the output"
+            details = f"{set_issue_details} ({variable_value})"
         # Explicit sets
         if set_severity_level:
             severity = set_severity_level
@@ -311,4 +330,5 @@ def _check_for_json_issue(
         actual=actual,
         reproduce_hint=reproduce_hint,
         issue_found=issue_found,
+        details=details,
     )

--- a/libraries/RW/CLI/local_process.py
+++ b/libraries/RW/CLI/local_process.py
@@ -64,7 +64,7 @@ def execute_local_command(
             with open(file_path, "w") as tmp:
                 tmp.write(content)
         logger.debug(
-            f"running {parsed_cmd} with env {run_with_env} and files {files.keys()}, secret names {secret_keys}"
+            f"running {parsed_cmd} with env {run_with_env.keys()} and files {files.keys()}, secret names {secret_keys}"
         )
         p = subprocess.run(
             parsed_cmd,
@@ -78,11 +78,11 @@ def execute_local_command(
         err = p.stderr
         rc = p.returncode
         logger.debug(
-            f"ran {parsed_cmd} with env {run_with_env} and files {files.keys()}, secret names {secret_keys}, resulted in returncode {rc}, stdout {out}, stderr {err}"
+            f"ran {parsed_cmd} with env {run_with_env.keys()} and files {files.keys()}, secret names {secret_keys}, resulted in returncode {rc}, stdout {out}, stderr {err}"
         )
     except Exception as e:
         s = traceback.format_exception(*sys.exc_info())
-        msg = f"Exception while running {parsed_cmd} with env {run_with_env} and files {files.keys()}, secret names {secret_keys}: {type(e)}: {e}\n{s}"
+        msg = f"Exception while running {parsed_cmd} with env {run_with_env.keys()} and files {files.keys()}, secret names {secret_keys}: {type(e)}: {e}\n{s}"
         errors.append(msg)
         rc = -1
         logger.error(msg)

--- a/libraries/RW/CLI/stdout_parser.py
+++ b/libraries/RW/CLI/stdout_parser.py
@@ -7,12 +7,14 @@ import re, logging
 from RW import platform
 from RW.Core import Core
 
-from .cli_utils import *
+from . import cli_utils
 
 ROBOT_LIBRARY_SCOPE = "GLOBAL"
 
 
 logger = logging.getLogger(__name__)
+
+MAX_ISSUE_STRING_LENGTH: int = 255
 
 RECOGNIZED_STDOUT_PARSE_QUERIES = [
     "raise_issue_if_eq",
@@ -38,25 +40,56 @@ def parse_cli_output_by_line(
     expected_rsp_returncodes: list[int] = [0],
     contains_stderr_ok: bool = True,
     raise_issue_if_no_groups_found: bool = True,
+    raise_issue_from_rsp_code: bool = False,
     **kwargs,
-) -> int:
+) -> platform.ShellServiceResponse:
     _core: Core = Core()
     issue_count: int = 0
+    capture_groups: dict = {}
+    stdout: str = rsp.stdout
+    capture_groups["_stdout"] = stdout
     logger.info(f"stdout: {rsp.stdout}")
     logger.info(lines_like_regexp)
     logger.info(f"kwargs: {kwargs}")
-    if not contains_stderr_ok and rsp.stderr:
-        raise ValueError(f"rsp {rsp} contains unexpected stderr {rsp.stderr}")
-    if rsp.status not in expected_rsp_statuscodes:
-        raise ValueError(f"rsp {rsp} has unexpected HTTP status {rsp.status}")
-    if rsp.returncode not in expected_rsp_returncodes:
-        raise ValueError(f"rsp {rsp} has unexpected shell return code {rsp.returncode}")
-    stdout: str = rsp.stdout
-    logger.info(rsp.stdout.split("\n"))
+    squelch_further_warnings: bool = False
+    first_issue: dict = {}
+    # check we've got an expected rsp
+    try:
+        cli_utils.verify_rsp(rsp, expected_rsp_statuscodes, expected_rsp_returncodes, contains_stderr_ok)
+    except Exception as e:
+        if raise_issue_from_rsp_code:
+            rsp_code_title = set_issue_title if set_issue_title else "Error/Unexpected Response Code"
+            rsp_code_expected = (
+                set_issue_expected
+                if set_issue_expected
+                else f"The internal response of {rsp.cmd} should be within {expected_rsp_statuscodes} and the process response should be within {expected_rsp_returncodes}"
+            )
+            rsp_code_actual = (
+                set_issue_actual if set_issue_actual else f"Encountered {e} as a result of running: {rsp.cmd}"
+            )
+            rsp_code_reproduce_hint = (
+                set_issue_reproduce_hint
+                if set_issue_reproduce_hint
+                else f"Run command: {rsp.cmd} and check the return code"
+            )
+            _core.add_issue(
+                severity=set_severity_level,
+                title=rsp_code_title,
+                expected=rsp_code_expected,
+                actual=rsp_code_actual,
+                reproduce_hint=rsp_code_reproduce_hint,
+                details=f"{set_issue_details} ({e})",
+            )
+            issue_count += 1
+        else:
+            raise e
+    # begin line processing
     for line in rsp.stdout.split("\n"):
         if not line:
             continue
-        capture_grps = None
+        capture_groups["_line"] = line
+        # attempt to create capture groups and values
+        regexp_results = {}
         if lines_like_regexp:
             regexp_results = re.match(rf"{lines_like_regexp}", line)
             if regexp_results:
@@ -64,25 +97,32 @@ def parse_cli_output_by_line(
             logger.info(f"regexp results: {regexp_results}")
             if issue_if_no_capture_groups and (not regexp_results or len(regexp_results.keys()) == 0):
                 _core.add_issue(
-                    set_severity_level,
-                    "No Capture Groups Found With Supplied Regex",
-                    f"Expected to create capture groups from line: {line} using regexp: {lines_like_regexp}",
-                    f"Actual result: {regexp_results}",
-                    f"Try apply the regex: {lines_like_regexp} to lines produced by the command: {rsp.parsed_cmd}",
-                    details=set_issue_details
+                    severity=set_severity_level,
+                    title="No Capture Groups Found With Supplied Regex",
+                    expected=f"Expected to create capture groups from line: {line} using regexp: {lines_like_regexp}",
+                    actual=f"Actual result: {regexp_results}",
+                    reproduce_hints=f"Try apply the regex: {lines_like_regexp} to lines produced by the command: {rsp.parsed_cmd}",
+                    details=f"{set_issue_details}",
                 )
                 issue_count += 1
                 continue
-        else:
-            regexp_results = {}
         parse_queries = kwargs
-        capture_groups = regexp_results
-        # Always allow direct parsing of the line as a capture group named _line
-        capture_groups["_line"] = line
+        # if valid  regexp results and we got 1 or more capture groups, append
+        if regexp_results and isinstance(regexp_results, dict) and len(regexp_results.keys()) > 0:
+            capture_groups = {**regexp_results, **capture_groups}
+        # begin processing kwarg queries
         for parse_query, query_value in parse_queries.items():
+            severity: int = 4
+            title: str = ""
+            expected: str = ""
+            actual: str = ""
+            reproduce_hint: str = ""
+            details: str = ""
             query_parts = parse_query.split("__")
             if len(query_parts) != 2:
-                logger.warning(f"Could not parse query: {parse_query}")
+                if not squelch_further_warnings:
+                    logger.warning(f"Could not parse query: {parse_query}")
+                squelch_further_warnings = True
                 continue
             prefix = query_parts[0]
             query = query_parts[1]
@@ -103,103 +143,171 @@ def parse_cli_output_by_line(
                         logger.warning(
                             f"Numeric parse query requested but values not castable: {query_value} and {capture_group_value}"
                         )
+                # process applicable query
                 if query == "raise_issue_if_eq" and query_value == capture_group_value:
-                    _core.add_issue(
-                        severity=set_severity_level,
-                        title = f"Value Of {prefix} ({capture_group_value}) Was {query_value}" if not set_issue_title else set_issue_title,
-                        expected=f"The parsed output {line} with regex: {lines_like_regexp} with the capture group: {prefix} should not be equal to {capture_group_value}"
+                    severity = set_severity_level
+                    title = (
+                        f"Value Of {prefix} ({capture_group_value}) Was {query_value}"
+                        if not set_issue_title
+                        else set_issue_title,
+                    )
+                    expected = (
+                        f"The parsed output {line} with regex: {lines_like_regexp} with the capture group: {prefix} should not be equal to {capture_group_value}"
                         if not set_issue_expected
                         else set_issue_expected,
-                        actual=f"The parsed output {line} with regex: {lines_like_regexp} contains {prefix}=={capture_group_value} and should not be equal to {capture_group_value}"
-                        if not set_issue_actual
-                        else set_issue_actual,
-                        reproduce_hint=f"Run {rsp.cmd} and apply the regex {lines_like_regexp} per line"
-                        if not set_issue_reproduce_hint
-                        else set_issue_reproduce_hint,
-                        details=f"{set_issue_details} ({line})"
                     )
+                    actual = (
+                        f"The parsed output {line} with regex: {lines_like_regexp} contains {prefix}=={capture_group_value} and should not be equal to {capture_group_value}"
+                        if not set_issue_actual
+                        else set_issue_actual
+                    )
+                    reproduce_hint = (
+                        f"Run {rsp.cmd} and apply the regex {lines_like_regexp} per line"
+                        if not set_issue_reproduce_hint
+                        else set_issue_reproduce_hint
+                    )
+                    details = f"{set_issue_details} ({line})"
                     issue_count += 1
                 elif query == "raise_issue_if_neq" and query_value != capture_group_value:
-                    _core.add_issue(
-                        severity=set_severity_level,
-                        title = f"Value Of {prefix} ({capture_group_value}) Was Not {query_value}" if not set_issue_title else set_issue_title,
-                        expected=f"The parsed output {line} with regex: {lines_like_regexp} with the capture group: {prefix} should be equal to {capture_group_value}"
-                        if not set_issue_expected
-                        else set_issue_expected,
-                        actual=f"The parsed output {line} with regex: {lines_like_regexp} does not contain the expected value of: {prefix}=={capture_group_value}"
-                        if not set_issue_actual
-                        else set_issue_actual,
-                        reproduce_hint=f"Run {rsp.cmd} and apply the regex {lines_like_regexp} per line"
-                        if not set_issue_reproduce_hint
-                        else set_issue_reproduce_hint,
-                        details=f"{set_issue_details} ({line})"
+                    severity = set_severity_level
+                    title = (
+                        f"Value Of {prefix} ({capture_group_value}) Was Not {query_value}"
+                        if not set_issue_title
+                        else set_issue_title
                     )
+                    expected = (
+                        f"The parsed output {line} with regex: {lines_like_regexp} with the capture group: {prefix} should be equal to {capture_group_value}"
+                        if not set_issue_expected
+                        else set_issue_expected
+                    )
+                    actual = (
+                        f"The parsed output {line} with regex: {lines_like_regexp} does not contain the expected value of: {prefix}=={capture_group_value}"
+                        if not set_issue_actual
+                        else set_issue_actual
+                    )
+                    reproduce_hint = (
+                        f"Run {rsp.cmd} and apply the regex {lines_like_regexp} per line"
+                        if not set_issue_reproduce_hint
+                        else set_issue_reproduce_hint
+                    )
+                    details = f"{set_issue_details} ({line})"
                     issue_count += 1
                 elif query == "raise_issue_if_lt" and numeric_castable and capture_group_value < query_value:
-                    _core.add_issue(
-                        severity=set_severity_level,
-                        title = f"Value of {prefix} ({capture_group_value}) Was Less Than {query_value}" if not set_issue_title else set_issue_title,
-                        expected=f"The parsed output {line} with regex: {lines_like_regexp} should have a value >= {query_value}"
-                        if not set_issue_expected
-                        else set_issue_expected,
-                        actual=f"The parsed output {line} with regex: {lines_like_regexp} found value: {capture_group_value} and it's less than {query_value}"
-                        if not set_issue_actual
-                        else set_issue_actual,
-                        reproduce_hint=f"Run {rsp.cmd} and apply the regex {lines_like_regexp} per line"
-                        if not set_issue_reproduce_hint
-                        else set_issue_reproduce_hint,
-                        details=f"{set_issue_details} ({line})",
+                    severity = set_severity_level
+                    title = (
+                        f"Value of {prefix} ({capture_group_value}) Was Less Than {query_value}"
+                        if not set_issue_title
+                        else set_issue_title
                     )
+                    expected = (
+                        f"The parsed output {line} with regex: {lines_like_regexp} should have a value >= {query_value}"
+                        if not set_issue_expected
+                        else set_issue_expected
+                    )
+                    actual = (
+                        f"The parsed output {line} with regex: {lines_like_regexp} found value: {capture_group_value} and it's less than {query_value}"
+                        if not set_issue_actual
+                        else set_issue_actual
+                    )
+                    reproduce_hint = (
+                        f"Run {rsp.cmd} and apply the regex {lines_like_regexp} per line"
+                        if not set_issue_reproduce_hint
+                        else set_issue_reproduce_hint
+                    )
+                    details = f"{set_issue_details} ({line})"
                     issue_count += 1
                 elif query == "raise_issue_if_gt" and numeric_castable and capture_group_value > query_value:
-                    _core.add_issue(
-                        severity=set_severity_level,
-                        title = f"Value of {prefix} ({capture_group_value}) Was Greater Than {query_value}" if not set_issue_title else set_issue_title,
-                        expected=f"The parsed output {line} with regex: {lines_like_regexp} should have a value <= {query_value}"
-                        if not set_issue_expected
-                        else set_issue_expected,
-                        actual=f"The parsed output {line} with regex: {lines_like_regexp} found value: {capture_group_value} and it's greater than {query_value}"
-                        if not set_issue_actual
-                        else set_issue_actual,
-                        reproduce_hint=f"Run {rsp.cmd} and apply the regex {lines_like_regexp} per line"
-                        if not set_issue_reproduce_hint
-                        else set_issue_reproduce_hint,
-                        details=f"{set_issue_details} ({line})"
+                    severity = set_severity_level
+                    title = (
+                        f"Value of {prefix} ({capture_group_value}) Was Greater Than {query_value}"
+                        if not set_issue_title
+                        else set_issue_title
                     )
+                    expected = (
+                        f"The parsed output {line} with regex: {lines_like_regexp} should have a value <= {query_value}"
+                        if not set_issue_expected
+                        else set_issue_expected
+                    )
+                    actual = (
+                        f"The parsed output {line} with regex: {lines_like_regexp} found value: {capture_group_value} and it's greater than {query_value}"
+                        if not set_issue_actual
+                        else set_issue_actual
+                    )
+                    reproduce_hint = (
+                        f"Run {rsp.cmd} and apply the regex {lines_like_regexp} per line"
+                        if not set_issue_reproduce_hint
+                        else set_issue_reproduce_hint
+                    )
+                    details = f"{set_issue_details} ({line})"
                     issue_count += 1
                 elif query == "raise_issue_if_contains" and query_value in capture_group_value:
-                    _core.add_issue(
-                        severity=set_severity_level,
-                        title = f"Value of {prefix} ({variable_value}) Contained {query_value}" if not set_issue_title else set_issue_title,
-                        expected=f"The parsed output {line} with regex: {lines_like_regexp} resulted in {capture_group_value} and should not contain {query_value}"
-                        if not set_issue_expected
-                        else set_issue_expected,
-                        actual=f"The parsed output {line} with regex: {lines_like_regexp} resulted in {capture_group_value} and it contains {query_value} when it should not"
-                        if not set_issue_actual
-                        else set_issue_actual,
-                        reproduce_hint=f"Run {rsp.cmd} and apply the regex {lines_like_regexp} per line"
-                        if not set_issue_reproduce_hint
-                        else set_issue_reproduce_hint,
-                        details=f"{set_issue_details} ({line})"
+                    severity = set_severity_level
+                    title = (
+                        f"Value of {prefix} ({variable_value}) Contained {query_value}"
+                        if not set_issue_title
+                        else set_issue_title
                     )
+                    expected = (
+                        f"The parsed output {line} with regex: {lines_like_regexp} resulted in {capture_group_value} and should not contain {query_value}"
+                        if not set_issue_expected
+                        else set_issue_expected
+                    )
+                    actual = (
+                        f"The parsed output {line} with regex: {lines_like_regexp} resulted in {capture_group_value} and it contains {query_value} when it should not"
+                        if not set_issue_actual
+                        else set_issue_actual
+                    )
+                    reproduce_hint = (
+                        f"Run {rsp.cmd} and apply the regex {lines_like_regexp} per line"
+                        if not set_issue_reproduce_hint
+                        else set_issue_reproduce_hint
+                    )
+                    details = f"{set_issue_details} ({line})"
                     issue_count += 1
                 elif query == "raise_issue_if_ncontains" and query_value not in capture_group_value:
-                    _core.add_issue(
-                        severity=set_severity_level,
-                        title = f"Value of {prefix} ({variable_value}) Did Not Contain {query_value}" if not set_issue_title else set_issue_title,
-                        expected=f"The parsed output {line} with regex: {lines_like_regexp} resulted in {capture_group_value} and should contain {query_value}"
-                        if not set_issue_expected
-                        else set_issue_expected,
-                        actual=f"The parsed output {line} with regex: {lines_like_regexp} resulted in {capture_group_value} and we expected to find {query_value} in the result"
-                        if not set_issue_actual
-                        else set_issue_actual,
-                        reproduce_hint=f"Run {rsp.cmd} and apply the regex {lines_like_regexp} per line"
-                        if not set_issue_reproduce_hint
-                        else set_issue_reproduce_hint,
-                        details=f"{set_issue_details} ({line})"
+                    severity = set_severity_level
+                    title = (
+                        f"Value of {prefix} ({variable_value}) Did Not Contain {query_value}"
+                        if not set_issue_title
+                        else set_issue_title
                     )
+                    expected = (
+                        f"The parsed output {line} with regex: {lines_like_regexp} resulted in {capture_group_value} and should contain {query_value}"
+                        if not set_issue_expected
+                        else set_issue_expected
+                    )
+                    actual = (
+                        f"The parsed output {line} with regex: {lines_like_regexp} resulted in {capture_group_value} and we expected to find {query_value} in the result"
+                        if not set_issue_actual
+                        else set_issue_actual
+                    )
+                    reproduce_hint = (
+                        f"Run {rsp.cmd} and apply the regex {lines_like_regexp} per line"
+                        if not set_issue_reproduce_hint
+                        else set_issue_reproduce_hint
+                    )
+                    details = f"{set_issue_details} ({line})"
                     issue_count += 1
+                if title and len(first_issue.keys()) == 0:
+                    known_symbols = {**kwargs, **capture_groups}
+                    first_issue = {
+                        "title": f"{title}".format_map(known_symbols),
+                        "severity": severity,
+                        "expected": f"{expected}".format_map(known_symbols),
+                        "actual": f"{actual}".format_map(known_symbols),
+                        "reproduce_hint": f"{reproduce_hint}".format_map(known_symbols),
+                        "details": f"{details}".format_map(known_symbols),
+                    }
             else:
                 logger.info(f"Prefix {prefix} not found in capture groups: {capture_groups.keys()}")
                 continue
-    return issue_count
+    if first_issue:
+        # truncate long strings
+        for key, value in first_issue.items():
+            if isinstance(value, str) and len(value) > MAX_ISSUE_STRING_LENGTH:
+                first_issue[key] = value[:MAX_ISSUE_STRING_LENGTH] + "..."
+        # aggregate count into title
+        if issue_count > 1:
+            first_issue["title"] += f" and {issue_count-1} more"
+        _core.add_issue(**first_issue)
+    return rsp


### PR DESCRIPTION
- FInishes details addition to issues
- Adds ability to show capture group / json data in issue strings via {var} notation in the string, eg:
`We found the issue on line: {_line}` and arbitrary kwargs can also be used when passed in from the robot layer
- Issue strings are capped at 255 chars
- Stdout parse issues when iterating over stdout by line, if multiple issues are detected during iteration, only the first is shown with a `and X more.` appended to the message.