### PR TITLE
minor tuneups, runwhen_local optimization

### DIFF
--- a/codebundles/k8s-jenkins-healthcheck/runbook.robot
+++ b/codebundles/k8s-jenkins-healthcheck/runbook.robot
@@ -76,7 +76,7 @@ Query The Jenkins Kubernetes Workload HTTP Endpoint
     [Documentation]    Performs a curl within the jenkins statefulset kubernetes workload to determine if the pod is up and healthy, and can serve requests.
     [Tags]    HTTP    Curl    Web    Code    OK    Available    Jenkins    HTTP    Endpoint    API
     ${rsp}=    RW.CLI.Run Cli
-    ...    cmd=${KUBERNETES_DISTRIBUTION_BINARY} exec statefulset/${STATEFULSET_NAME} --context=${CONTEXT} -n ${NAMESPACE} -- curl -s -o /dev/null -w "%\{http_code\}" localhost:8080/login
+    ...    cmd=${KUBERNETES_DISTRIBUTION_BINARY} exec statefulset/${STATEFULSET_NAME} --context=${CONTEXT} -n ${NAMESPACE} -- curl -s -o /dev/null -w "\%{http_code}" localhost:8080/login
     ...    render_in_commandlist=true
     ...    env=${env}
     ...    secret_file__kubeconfig=${kubeconfig}
@@ -94,6 +94,7 @@ Query The Jenkins Kubernetes Workload HTTP Endpoint
     ...    secret__jenkins_sa_token=${JENKINS_SA_TOKEN}
     ...    env=${env}
     ...    secret_file__kubeconfig=${kubeconfig}
+    ...    render_in_commandlist=true
     RW.Core.Add Pre To Report    Remote API Info:\n${rsp.stdout}
     ${history}=    RW.CLI.Pop Shell History
     RW.Core.Add Pre To Report    Commands Used: ${history}
@@ -109,6 +110,7 @@ Query For Stuck Jenkins Jobs
     ...    env=${env}
     ...    target_service=${kubectl}
     ...    secret_file__kubeconfig=${kubeconfig}
+    ...    render_in_commandlist=true
     RW.CLI.Parse Cli Output By Line
     ...    rsp=${rsp}
     ...    set_severity_level=2


### PR DESCRIPTION
Minor jenkins fixups to render additional commands in commandlist and fix up the curl response code output for command list interpretation. I've tested the runbook as is, and also with some runwhen-local fixups. 

I think I have an idea on how to handle the secrets / username / passwords - which helps to render more content in the troubleshooting command list: 

![image](https://github.com/runwhen-contrib/rw-cli-codecollection/assets/18314168/181feb51-28fa-4d5c-ab16-4dc50c86abc4)
