### PR TITLE
Fix recursive json formatting

### DIFF
--- a/codebundles/gcloud-log-inspection/runbook.robot
+++ b/codebundles/gcloud-log-inspection/runbook.robot
@@ -80,7 +80,7 @@ Inspect GCP Logs For Common Errors
     ...    set_issue_expected=No filtered log entries returned by the gcloud query: ${cmd} 
     ...    set_issue_title=Found Errors During GCP Log Inspection
     ...    set_issue_actual=Found results from the command: ${cmd}
-    ...    set_issue_details=We found: {_stdout}
+    ...    set_issue_details=We found: $_stdout
     ...    assign_stdout_from_var=count
     RW.Core.Add Pre To Report    Log Inspection Results:
     RW.Core.Add Pre To Report    Entries Count Of Potential Issues: ${entry_count.stdout}

--- a/codebundles/k8s-jenkins-healthcheck/runbook.robot
+++ b/codebundles/k8s-jenkins-healthcheck/runbook.robot
@@ -117,7 +117,7 @@ Query For Stuck Jenkins Jobs
     ...    set_issue_expected=The Jenkins pipeline should not have any stuck jobs
     ...    set_issue_actual=The Jenkins pipeline has stuck jobs in the queue
     ...    set_issue_title=Stuck Jobs in Jenkins Pipeline
-    ...    set_issue_details=We found stuck jobs in the stdout: {_stdout} - check the jenkins console for further details on how to unstuck them.
+    ...    set_issue_details=We found stuck jobs in the stdout: $_stdout - check the jenkins console for further details on how to unstuck them.
     ...    _line__raise_issue_if_contains=Stuck
     RW.Core.Add Pre To Report    Queue Information:\n${rsp.stdout}
     ${history}=    RW.CLI.Pop Shell History

--- a/libraries/RW/CLI/json_parser.py
+++ b/libraries/RW/CLI/json_parser.py
@@ -1,4 +1,5 @@
 import logging, json, jmespath
+from string import Template
 from RW import platform
 from RW.Core import Core
 
@@ -166,13 +167,14 @@ def parse_cli_json_output(
     )
     if issue_results.issue_found:
         known_symbols = {**kwargs, **variable_results}
+        logger.info(f"Known symbols: {known_symbols}")
         issue_data = {
-            "title": f"{issue_results.title}".format_map(known_symbols),
+            "title": Template(issue_results.title).safe_substitute(known_symbols),
             "severity": issue_results.severity,
-            "expected": f"{issue_results.expected}".format_map(known_symbols),
-            "actual": f"{issue_results.actual}".format_map(known_symbols),
-            "reproduce_hint": f"{issue_results.reproduce_hint}".format_map(known_symbols),
-            "details": f"{issue_results.details}".format_map(known_symbols),
+            "expected": Template(issue_results.expected).safe_substitute(known_symbols),
+            "actual": Template(issue_results.actual).safe_substitute(known_symbols),
+            "reproduce_hint": Template(issue_results.reproduce_hint).safe_substitute(known_symbols),
+            "details": Template(issue_results.details).safe_substitute(known_symbols),
         }
         # truncate long strings
         for key, value in issue_data.items():

--- a/libraries/RW/CLI/json_parser.py
+++ b/libraries/RW/CLI/json_parser.py
@@ -167,7 +167,6 @@ def parse_cli_json_output(
     )
     if issue_results.issue_found:
         known_symbols = {**kwargs, **variable_results}
-        logger.info(f"Known symbols: {known_symbols}")
         issue_data = {
             "title": Template(issue_results.title).safe_substitute(known_symbols),
             "severity": issue_results.severity,

--- a/libraries/RW/CLI/stdout_parser.py
+++ b/libraries/RW/CLI/stdout_parser.py
@@ -291,7 +291,7 @@ def parse_cli_output_by_line(
                     issue_count += 1
                 if title and len(first_issue.keys()) == 0:
                     known_symbols = {**kwargs, **capture_groups}
-                    issue_data = {
+                    first_issue = {
                         "title": Template(title).safe_substitute(known_symbols),
                         "severity": severity,
                         "expected": Template(expected).safe_substitute(known_symbols),

--- a/libraries/RW/CLI/stdout_parser.py
+++ b/libraries/RW/CLI/stdout_parser.py
@@ -4,6 +4,7 @@ CLI Generic keyword library for running and parsing CLI stdout
 Scope: Global
 """
 import re, logging
+from string import Template
 from RW import platform
 from RW.Core import Core
 
@@ -290,13 +291,13 @@ def parse_cli_output_by_line(
                     issue_count += 1
                 if title and len(first_issue.keys()) == 0:
                     known_symbols = {**kwargs, **capture_groups}
-                    first_issue = {
-                        "title": f"{title}".format_map(known_symbols),
+                    issue_data = {
+                        "title": Template(title).safe_substitute(known_symbols),
                         "severity": severity,
-                        "expected": f"{expected}".format_map(known_symbols),
-                        "actual": f"{actual}".format_map(known_symbols),
-                        "reproduce_hint": f"{reproduce_hint}".format_map(known_symbols),
-                        "details": f"{details}".format_map(known_symbols),
+                        "expected": Template(expected).safe_substitute(known_symbols),
+                        "actual": Template(actual).safe_substitute(known_symbols),
+                        "reproduce_hint": Template(reproduce_hint).safe_substitute(known_symbols),
+                        "details": Template(details).safe_substitute(known_symbols),
                     }
             else:
                 logger.info(f"Prefix {prefix} not found in capture groups: {capture_groups.keys()}")


### PR DESCRIPTION
- updates formatting in parsers to use template and `$var` syntax to avoid recursive json formatting, resulting in keyerrors 