### PR TITLE
Add nginx ingress inspection taskset

### DIFF
--- a/codebundles/curl-gmp-ingress-inspection/README.md
+++ b/codebundles/curl-gmp-ingress-inspection/README.md
@@ -1,0 +1,26 @@
+# GCP GMP Nginx Ingress Inspection
+
+Runs a task which performs inspects the HTTP error code metrics related to your nginx ingress controller in your GKE kubernetes cluster and raises issues based on the number of ingress with errors.
+
+## Tasks
+`Fetch Nginx Ingress Metrics From GMP And Perform Inspection On Results`
+
+## Configuration
+
+The TaskSet requires initialization to import necessary secrets, services, and user variables. The following variables should be set:
+
+- `PROMQL_STATEMENT`: The promql statement to run to fetch nginx ingress metrics. Defaults to `rate(nginx_ingress_controller_requests{status=~${ERROR_CODES}}[${TIME_SLICE}]) > 0` which allows it to be injected with other configuration values.
+- `TIME_SLICE`: What duration to calculate the rate over. Defaults to 60 minutes.
+- `ERROR_CODES`: Which HTTP codes to consider as errors. defaults to 500, 501, and 502.
+- `GCLOUD_SERVICE`: The remote gcloud service to use for requests.
+- `gcp_credentials_json`: The json credentials secrets file used to authenticate with the GCP project. Should be a service account.
+- `GCP_PROJECT_ID`: The unique project ID identifier string.
+
+## Notes
+
+The `gcp_credentials_json` service account will need view and list permissions on the GCP logging API.
+
+## TODO
+- [ ] Add documentation
+- [ ] Add examples for non-gke ingress objects for other cloud projects
+- [ ] Add IAM settings examples

--- a/codebundles/curl-gmp-ingress-inspection/runbook.robot
+++ b/codebundles/curl-gmp-ingress-inspection/runbook.robot
@@ -1,0 +1,88 @@
+*** Settings ***
+Documentation       Collects Nginx ingress controller metrics from GMP on GCP and inspects the results for ingress with a HTTP error code rate greater than zero
+...                 over a configurable duration and raises issues based on the number of ingress with error codes.
+Metadata            Author    Jonathan Funk
+Metadata            Display Name    GKE Nginx Ingress Controller Triage 
+Metadata            Supports    GCP,GMP,Ingress,Nginx,Metrics
+Library             BuiltIn
+Library             RW.Core
+Library             RW.CLI
+Library             RW.platform
+
+Suite Setup         Suite Initialization
+
+*** Keywords ***
+Suite Initialization
+    ${GCLOUD_SERVICE}=    RW.Core.Import Service    gcloud
+    ...    type=string
+    ...    description=The selected RunWhen Service to use for accessing services within a network.
+    ...    pattern=\w*
+    ...    example=gcloud-service.shared
+    ...    default=gcloud-service.shared
+    ${gcp_credentials_json}=    RW.Core.Import Secret    gcp_credentials_json
+    ...    type=string
+    ...    description=GCP service account json used to authenticate with GCP APIs.
+    ...    pattern=\w*
+    ...    example={"type": "service_account","project_id":"myproject-ID", ... super secret stuff ...}
+    ${GCP_PROJECT_ID}=    RW.Core.Import User Variable    GCP_PROJECT_ID
+    ...    type=string
+    ...    description=The GCP Project ID to scope the API to.
+    ...    pattern=\w*
+    ...    example=myproject-ID
+    ${TIME_SLICE}=    RW.Core.Import User Variable    TIME_SLICE
+    ...    type=string
+    ...    description=The amount of time to perform aggregations over.
+    ...    pattern=\w*
+    ...    example=60m
+    ...    default=60m
+    Set Suite Variable    ${TIME_SLICE}    ${TIME_SLICE}
+    ${ERROR_CODES}=    RW.Core.Import User Variable    ERROR_CODES
+    ...    type=string
+    ...    description=Which http status codes to look for and classify as errors. Note the single quotes, they are required.
+    ...    pattern=\w*
+    ...    example='500'
+    ...    default='500|501|502'
+    Set Suite Variable    ${ERROR_CODES}    ${ERROR_CODES}
+    RW.Core.Import User Variable    PROMQL_STATEMENT
+    ...    type=string
+    ...    description=The PromQL statement used to query metrics from the GCP OpsSuite PromQL API.
+    ...    pattern=\w*
+    ...    example=up
+    ...    default=rate(nginx_ingress_controller_requests{status=~${ERROR_CODES}}[${TIME_SLICE}]) > 0
+    Set Suite Variable    ${GCLOUD_SERVICE}    ${GCLOUD_SERVICE}
+    Set Suite Variable    ${gcp_credentials_json}    ${gcp_credentials_json}
+    Set Suite Variable    ${GCP_PROJECT_ID}    ${GCP_PROJECT_ID}
+    Set Suite Variable    ${PROMQL_STATEMENT}    ${PROMQL_STATEMENT}
+    Set Suite Variable    ${env}    {"CLOUDSDK_CORE_PROJECT":"${GCP_PROJECT_ID}","GOOGLE_APPLICATION_CREDENTIALS":"./${gcp_credentials_json.key}"}
+
+
+*** Tasks ***
+Fetch Nginx Ingress Metrics From GMP And Perform Inspection On Results
+    [Documentation]    Fetches metrics for the Nginx ingress controller from GMP and performs an inspection on the results.
+    ...     If there are currently any results with more than zero errors, their name will be surfaced for further troubleshooting.
+    [Tags]    cURL    HTTP    Ingress    Latency    Errors    Metrics    Controller    Nginx    GMP
+    ${gmp_rsp}=    RW.CLI.Run Cli
+    ...    cmd=gcloud auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS && curl -d "query=${PROMQL_STATEMENT}" -H "Authorization: Bearer $(gcloud auth print-access-token)" 'https://monitoring.googleapis.com/v1/projects/${GCP_PROJECT_ID}/location/global/prometheus/api/v1/query' | jq -r '.data.result[] | "Host:" + .metric.host + " Ingress:" + .metric.ingress + " Namespace:" + .metric.export_namespace + " Service:" + .metric.service'
+    ...    render_in_commandlist=true
+    ...    target_service=${GCLOUD_SERVICE}
+    ...    env=${env}
+    ...    secret_file__gcp_credentials_json=${gcp_credentials_json}
+    ${gmp_json}=    RW.CLI.Run Cli
+    ...    cmd=gcloud auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS && curl -d "query=${PROMQL_STATEMENT}" -H "Authorization: Bearer $(gcloud auth print-access-token)" 'https://monitoring.googleapis.com/v1/projects/${GCP_PROJECT_ID}/location/global/prometheus/api/v1/query'
+    ...    render_in_commandlist=true
+    ...    target_service=${GCLOUD_SERVICE}
+    ...    env=${env}
+    ...    secret_file__gcp_credentials_json=${gcp_credentials_json}
+    RW.CLI.Parse Cli Output By Line
+    ...    rsp=${gmp_rsp}
+    ...    set_severity_level=3
+    ...    set_issue_expected=The ingress in $_line should not have any HTTP responses with the following codes: ${ERROR_CODES}
+    ...    set_issue_actual=We found the following HTTP error codes: ${ERROR_CODES} associated with the ingress in $_line
+    ...    set_issue_title=Detected HTTP Error Codes Across Network
+    ...    set_issue_details=The returned stdout line: $_line indicates there's HTTP error codes associated with this ingress and service!
+    ...    _line__raise_issue_if_contains=Host
+    ${history}=    RW.CLI.Pop Shell History
+    RW.Core.Add Pre To Report    Commands Used: ${history}
+    RW.Core.Add Pre To Report    Ingress Info:\n${gmp_rsp.stdout}
+    RW.Core.Add Pre To Report    GMP Json Data:\n${gmp_json.stdout}
+    

--- a/libraries/RW/CLI/json_parser.py
+++ b/libraries/RW/CLI/json_parser.py
@@ -8,7 +8,7 @@ from . import cli_utils
 logger = logging.getLogger(__name__)
 ROBOT_LIBRARY_SCOPE = "GLOBAL"
 
-MAX_ISSUE_STRING_LENGTH: int = 255
+MAX_ISSUE_STRING_LENGTH: int = 512
 
 RECOGNIZED_JSON_PARSE_QUERIES = [
     "raise_issue_if_eq",

--- a/libraries/RW/CLI/stdout_parser.py
+++ b/libraries/RW/CLI/stdout_parser.py
@@ -15,7 +15,7 @@ ROBOT_LIBRARY_SCOPE = "GLOBAL"
 
 logger = logging.getLogger(__name__)
 
-MAX_ISSUE_STRING_LENGTH: int = 255
+MAX_ISSUE_STRING_LENGTH: int = 512
 
 RECOGNIZED_STDOUT_PARSE_QUERIES = [
     "raise_issue_if_eq",


### PR DESCRIPTION
- Adds a nginx ingress triage which lists the nginx ingress names, namespaces and associated services that returned the HTTP error codes detected in the metrics. Ideally personas can piggy back off the raised issue details to investigate those namespaces/services further
- Tweaks max issue string length to 512, I found it getting truncated too soon with the new templated variables in use