### PR TITLE
Add cloudwatch EC2 util check

### DIFF
--- a/codebundles/aws-cloudwatch-overused-ec2/README.md
+++ b/codebundles/aws-cloudwatch-overused-ec2/README.md
@@ -1,0 +1,26 @@
+# AWS CloudWatch EC2 Instance Utilization Check
+This taskset can be used to check a fleet of EC2 instance and return the list of instances which are classified as overutilized.
+
+## Tasks
+`Check For Overutilized Ec2 Instances`
+
+## Configuration
+
+The TaskSet requires initialization to import necessary secrets, services, and user variables. The following variables should be set:
+
+- `aws_access_key_id`: the service account's access key ID, used during the `aws sts` call.
+- `aws_secret_access_key`: The service account's secret access key, used during the `aws sts` call.
+- `aws_role_arn`: The full aws role ARN that will be assumed.
+- `aws_assume_role_name`: The name of the role to assume as part of the `aws sts` assume role call.
+- `AWS_DEFAULT_REGION`: The AWS region to perform API requests in and for resources.
+- `AWS_SERVICE`: The remote aws service to use for requests.
+- `UTILIZATION_THRESHOLD`: used to determine the threshold at which point a EC2 instance is considered over-utilized.
+
+
+## Notes
+
+This codebundle assumes a traditional service account authentication using the assume role functionality of `aws sts`, and therefore a role with the correct access will be required so that it can be assumed by the service account for a temporary token.
+
+## TODO
+- [ ] Add documentation
+- [ ] Expand utilization checks

--- a/codebundles/aws-cloudwatch-overused-ec2/runbook.robot
+++ b/codebundles/aws-cloudwatch-overused-ec2/runbook.robot
@@ -13,7 +13,7 @@ Suite Setup         Suite Initialization
 *** Tasks ***
 Check For Overutilized Ec2 Instances
     [Documentation]    Fetches CloudWatch metrics for a list of EC2 instances and raises issues if they're over-utilized based on a configurable threshold.
-    [Tags]    logs    query    gcloud    gcp    errors    common
+    [Tags]    cloudwatch    metrics    ec2    utilization
     ${now}=    RW.CLI.String To Datetime    0h
     ${past_time}=    RW.CLI.String To Datetime    3h
     ${util_metrics}=    RW.CLI.Run Cli

--- a/codebundles/aws-cloudwatch-overused-ec2/runbook.robot
+++ b/codebundles/aws-cloudwatch-overused-ec2/runbook.robot
@@ -1,0 +1,90 @@
+*** Settings ***
+Documentation       Queries AWS CloudWatch for a list of EC2 instances with a high amount of resource utilization, raising issues when overutilized instances are found.
+Metadata            Author    Jonathan Funk
+Metadata            Display Name    AWS CloudWatch Overutlized EC2 Inspection
+Metadata            Supports    AWS,CloudWatch
+
+Library             RW.Core
+Library             RW.CLI
+
+Suite Setup         Suite Initialization
+
+
+*** Tasks ***
+Check For Overutilized Ec2 Instances
+    [Documentation]    Fetches CloudWatch metrics for a list of EC2 instances and raises issues if they're over-utilized based on a configurable threshold.
+    [Tags]    logs    query    gcloud    gcp    errors    common
+    ${now}=    RW.CLI.String To Datetime    0h
+    ${past_time}=    RW.CLI.String To Datetime    3h
+    ${util_metrics}=    RW.CLI.Run Cli
+    ...    cmd=${AWS_ASSUME_ROLE_CMD} aws cloudwatch get-metric-data --start-time ${past_time} --end-time ${now} --metric-data-queries '[{"Id":"runWhenMetric","Expression":"SELECT MAX(CPUUtilization) FROM \\"AWS/EC2\\" GROUP BY InstanceId","Period":60,"ReturnData":true}]' | jq -r '.MetricDataResults[] | select(.Values|max > ${UTILIZATION_THRESHOLD}) | "Instance:" + .Label + "Max Detected Utilization:" + (.Values|max|tostring)'
+    ...    target_service=${AWS_SERVICE}
+    ...    secret__aws_access_key_id=${aws_access_key_id}
+    ...    secret__aws_secret_access_key=${aws_secret_access_key}
+    ...    secret__aws_role_arn=${aws_role_arn}
+    ...    secret__aws_assume_role_name=${aws_assume_role_name}
+    RW.CLI.Parse Cli Output By Line
+    ...    rsp=${util_metrics}
+    ...    set_severity_level=4
+    ...    set_issue_expected=EC2 instance is not overutilized.
+    ...    set_issue_actual=EC2 instances detected past ${UTILIZATION_THRESHOLD} utilization threshold.
+    ...    set_issue_title=EC2 Instances Over Utilized
+    ...    set_issue_details=The following EC2 instances have been detected as over-utilized: \n\n"$_stdout"
+    ...    _line__raise_issue_if_contains=Instance
+    RW.Core.Add Pre To Report
+    ...    The following EC2 instances in ${AWS_DEFAULT_REGION} are classified as over-utilized according to the threshold: ${UTILIZATION_THRESHOLD}:\n\n
+    RW.Core.Add Pre To Report    ${util_metrics.stdout}
+    ${history}=    RW.CLI.Pop Shell History
+    RW.Core.Add Pre To Report    Commands Used: ${history}
+
+
+*** Keywords ***
+Suite Initialization
+    ${AWS_SERVICE}=    RW.Core.Import Service    aws
+    ...    type=string
+    ...    description=The selected RunWhen Service to use for accessing services within a network.
+    ...    pattern=\w*
+    ...    example=aws-service.shared
+    ...    default=aws-service.shared
+    ${aws_access_key_id}=    RW.Core.Import Secret    aws_access_key_id
+    ...    type=string
+    ...    description=The AWS access key ID to use for connecting to AWS APIs.
+    ...    pattern=\w*
+    ...    example=SUPERSECRETKEYID
+    ${aws_secret_access_key}=    RW.Core.Import Secret    aws_secret_access_key
+    ...    type=string
+    ...    description=The AWS access key to use for connecting to AWS APIs.
+    ...    pattern=\w*
+    ...    example=SUPERSECRETKEY
+    ${aws_role_arn}=    RW.Core.Import Secret    aws_role_arn
+    ...    type=string
+    ...    description=The AWS role ARN to use for connecting to AWS APIs.
+    ...    pattern=\w*
+    ...    example=arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME
+    ${aws_assume_role_name}=    RW.Core.Import Secret    aws_assume_role_name
+    ...    type=string
+    ...    description=The AWS role ARN to use for connecting to AWS APIs.
+    ...    pattern=\w*
+    ...    example=runwhen-sa
+    ${AWS_DEFAULT_REGION}=    RW.Core.Import User Variable    AWS_DEFAULT_REGION
+    ...    type=string
+    ...    description=The AWS region to scope API requests to.
+    ...    pattern=\w*
+    ...    example=us-west-1
+    ...    default=us-west-1
+    ${UTILIZATION_THRESHOLD}=    RW.Core.Import User Variable    UTILIZATION_THRESHOLD
+    ...    type=string
+    ...    description=The threshold at which an instance is determined as overutilized.
+    ...    pattern=\w*
+    ...    example=0.8
+    ...    default=0.8
+    Set Suite Variable    ${aws_access_key_id}    ${aws_access_key_id}
+    Set Suite Variable    ${aws_secret_access_key}    ${aws_secret_access_key}
+    Set Suite Variable    ${aws_role_arn}    ${aws_role_arn}
+    Set Suite Variable    ${aws_assume_role_name}    ${aws_assume_role_name}
+    Set Suite Variable    ${AWS_DEFAULT_REGION}    ${AWS_DEFAULT_REGION}
+    Set Suite Variable    ${AWS_SERVICE}    ${AWS_SERVICE}
+    Set Suite Variable    ${UTILIZATION_THRESHOLD}    ${UTILIZATION_THRESHOLD}
+    Set Suite Variable
+    ...    ${AWS_ASSUME_ROLE_CMD}
+    ...    role_json=$(AWS_ACCESS_KEY_ID=$${aws_access_key_id.key} AWS_SECRET_ACCESS_KEY=$${aws_secret_access_key.key} AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION} aws sts assume-role --role-arn $${aws_role_arn.key} --role-session-name ${aws_assume_role_name.key}) && AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION} AWS_ACCESS_KEY_ID=$(echo $role_json | jq -r '.Credentials.AccessKeyId') AWS_SECRET_ACCESS_KEY=$(echo $role_json | jq -r '.Credentials.SecretAccessKey') AWS_SESSION_TOKEN=$(echo $role_json | jq -r '.Credentials.SessionToken')

--- a/libraries/RW/CLI/cli_utils.py
+++ b/libraries/RW/CLI/cli_utils.py
@@ -44,10 +44,10 @@ def verify_rsp(
         raise ValueError(f"rsp {rsp} has unexpected shell return code {rsp.returncode}")
 
 
-def _string_to_datetime(duration_str: str):
-    now = RobotDateTime.get_current_date(result_format="%Y-%m-%dT%H:%M:%SZ")
+def _string_to_datetime(duration_str: str, date_format_str="%Y-%m-%dT%H:%M:%SZ"):
+    now = RobotDateTime.get_current_date(result_format=date_format_str)
     time = RobotDateTime.convert_time(duration_str)
-    past_date = RobotDateTime.subtract_time_from_date(now, time)
+    past_date = RobotDateTime.subtract_time_from_date(now, time, result_format=date_format_str)
     return past_date
 
 


### PR DESCRIPTION
- adds a codebundle for raising issues for over-utilized EC2 instances using cloudwatch metrics

Note: putting together the EKS equivalent right now but I thought it'd be good to PR this so you can see the pattern/give feedback @stewartshea 