### PR TITLE
Add task additions to k8s deploy taskset

### DIFF
--- a/codebundles/k8s-deployment-healthcheck/README.md
+++ b/codebundles/k8s-deployment-healthcheck/README.md
@@ -3,10 +3,11 @@
 This codebundle provides a suite of tasks aimed at triaging issues related to a deployment and its replicas in Kubernetes clusters.
 
 ## Tasks
-`Get Deployment Log Details For Report`
+`Check Deployment Log For Issues`
 `Troubleshoot Deployment Warning Events`
 `Get Deployment Workload Details For Report`
 `Troubleshoot Deployment Replicas`
+`Check For Deployment Event Anomalies`
 
 ## Configuration
 The TaskSet requires initialization to import necessary secrets, services, and user variables. The following variables should be set:


### PR DESCRIPTION
- adds anomaly event task to taskset so it's more likely to be run at a smaller scope by assistants
- tweaks log fetch to raise issues when log results are found matching a error pattern (has include+exclude behaviour)