### PR TITLE
reformat authors and reduce max issue length to stop api model error

### DIFF
--- a/codebundles/aws-cloudwatch-overused-ec2/runbook.robot
+++ b/codebundles/aws-cloudwatch-overused-ec2/runbook.robot
@@ -1,6 +1,6 @@
 *** Settings ***
 Documentation       Queries AWS CloudWatch for a list of EC2 instances with a high amount of resource utilization, raising issues when overutilized instances are found.
-Metadata            Author    Jonathan Funk
+Metadata            Author    jon-funk
 Metadata            Display Name    AWS CloudWatch Overutlized EC2 Inspection
 Metadata            Supports    AWS,CloudWatch
 

--- a/codebundles/cli-test/runbook.robot
+++ b/codebundles/cli-test/runbook.robot
@@ -1,5 +1,5 @@
 *** Settings ***
-Metadata          Author    Jonathan Funk
+Metadata          Author    jon-funk
 Documentation     This taskset smoketests the CLI codebundle setup and run process
 Suite Setup       Suite Initialization
 Library           BuiltIn

--- a/codebundles/cmd-test/runbook.robot
+++ b/codebundles/cmd-test/runbook.robot
@@ -1,5 +1,5 @@
 *** Settings ***
-Metadata          Author    Jonathan Funk
+Metadata          Author    jon-funk
 Documentation     This taskset smoketests the CLI codebundle setup and run process by running a bare command
 Suite Setup       Suite Initialization
 Library           BuiltIn

--- a/codebundles/curl-gmp-nginx-ingress-inspection/runbook.robot
+++ b/codebundles/curl-gmp-nginx-ingress-inspection/runbook.robot
@@ -1,7 +1,7 @@
 *** Settings ***
 Documentation       Collects Nginx ingress host controller metrics from GMP on GCP and inspects the results for ingress with a HTTP error code rate greater than zero
 ...                 over a configurable duration and raises issues based on the number of ingress with error codes.
-Metadata            Author    Jonathan Funk
+Metadata            Author    jon-funk
 Metadata            Display Name    GKE Nginx Ingress Host Triage
 Metadata            Supports    GCP,GMP,Ingress,Nginx,Metrics
 

--- a/codebundles/gcloud-log-inspection/runbook.robot
+++ b/codebundles/gcloud-log-inspection/runbook.robot
@@ -1,5 +1,5 @@
 *** Settings ***
-Metadata          Author    Jonathan Funk
+Metadata          Author    jon-funk
 Metadata          Display Name    GCP Gcloud Log Inspection
 Metadata          Supports    GCP,Gcloud,Google Monitoring
 Documentation     Fetches logs from a GCP using a configurable query and raises an issue with details on the most common issues.

--- a/codebundles/k8s-artifactory-health/runbook.robot
+++ b/codebundles/k8s-artifactory-health/runbook.robot
@@ -1,5 +1,5 @@
 *** Settings ***
-Metadata          Author    Jonathan Funk
+Metadata          Author    jon-funk
 Metadata          Display Name    Kubernetes Artifactory Triage
 Metadata          Supports    Kubernetes,AKS,EKS,GKE,OpenShift,Artifactory
 Documentation     Performs a triage on the Open Source version of Artifactory in a Kubernetes cluster.

--- a/codebundles/k8s-certmanager-healthcheck/runbook.robot
+++ b/codebundles/k8s-certmanager-healthcheck/runbook.robot
@@ -1,6 +1,6 @@
 *** Settings ***
 Documentation       This taskset checks that your cert manager certificates are renewing as expected, raising issues when they are past due in the configured namespace
-Metadata            Author    Jonathan Funk
+Metadata            Author    jon-funk
 Metadata            Display Name    Kubernetes CertManager Healthcheck
 Metadata            Supports    Kubernetes,AKS,EKS,GKE,OpenShift,CertManager
 

--- a/codebundles/k8s-certmanager-healthcheck/sli.robot
+++ b/codebundles/k8s-certmanager-healthcheck/sli.robot
@@ -1,5 +1,5 @@
 *** Settings ***
-Metadata          Author    Jonathan Funk
+Metadata          Author    jon-funk
 Documentation     Check the health of pods deployed by cert-manager.
 Metadata          Display Name    Kubernetes CertManager Healthcheck
 Metadata          Supports    Kubernetes,AKS,EKS,GKE,OpenShift

--- a/codebundles/k8s-daemonset-healthcheck/runbook.robot
+++ b/codebundles/k8s-daemonset-healthcheck/runbook.robot
@@ -1,6 +1,6 @@
 *** Settings ***
 Documentation       Triages issues related to a Daemonset and its available replicas.
-Metadata            Author    Jonathan Funk
+Metadata            Author    jon-funk
 Metadata            Display Name    Kubernetes Daemonset Triage
 Metadata            Supports    Kubernetes,AKS,EKS,GKE,OpenShift
 

--- a/codebundles/k8s-deployment-healthcheck/runbook.robot
+++ b/codebundles/k8s-deployment-healthcheck/runbook.robot
@@ -1,6 +1,6 @@
 *** Settings ***
 Documentation       Triages issues related to a deployment and its replicas.
-Metadata            Author    Jonathan Funk
+Metadata            Author    jon-funk
 Metadata            Display Name    Kubernetes Deployment Triage
 Metadata            Supports    Kubernetes,AKS,EKS,GKE,OpenShift
 

--- a/codebundles/k8s-imagerollover-check/runbook.robot
+++ b/codebundles/k8s-imagerollover-check/runbook.robot
@@ -1,6 +1,6 @@
 *** Settings ***
 Documentation       This taskset collects info on the age of images in a Kubernetes workspace.
-Metadata            Author    Jonathan Funk
+Metadata            Author    jon-funk
 Metadata            Display Name    Kubernetes Image Rollover Check
 Metadata            Supports    Kubernetes,AKS,EKS,GKE,OpenShift,Redis
 Library             BuiltIn

--- a/codebundles/k8s-jenkins-healthcheck/runbook.robot
+++ b/codebundles/k8s-jenkins-healthcheck/runbook.robot
@@ -1,7 +1,7 @@
 *** Settings ***
 Documentation       This taskset collects information about perstistent volumes and persistent volume claims to 
 ...    validate health or help troubleshoot potential issues.
-Metadata            Author    Jonathan Funk
+Metadata            Author    jon-funk
 Metadata            Display Name    Kubernetes Jenkins Healthcheck
 Metadata            Supports    Kubernetes,AKS,EKS,GKE,OpenShift,Jenkins
 Library             BuiltIn

--- a/codebundles/k8s-namespace-healthcheck/runbook.robot
+++ b/codebundles/k8s-namespace-healthcheck/runbook.robot
@@ -1,6 +1,6 @@
 *** Settings ***
 Documentation       This taskset runs general troubleshooting checks against all applicable objects in a namespace, checks error events, and searches pod logs for error entries.
-Metadata            Author    Jonathan Funk
+Metadata            Author    jon-funk
 Metadata            Display Name    Kubernetes Namespace Troubleshoot
 Metadata            Supports    Kubernetes,AKS,EKS,GKE,OpenShift
 

--- a/codebundles/k8s-podresources-health/runbook.robot
+++ b/codebundles/k8s-podresources-health/runbook.robot
@@ -1,6 +1,6 @@
 *** Settings ***
 Documentation       Inspects the resources provisioned for a given set of pods, selected by their labels and raises issues if no resources were specified.
-Metadata            Author    Jonathan Funk
+Metadata            Author    jon-funk
 Metadata            Display Name    Kubernetes Pod Resources Scan
 Metadata            Supports    Kubernetes,AKS,EKS,GKE,OpenShift
 

--- a/codebundles/k8s-redis-healthcheck/runbook.robot
+++ b/codebundles/k8s-redis-healthcheck/runbook.robot
@@ -1,6 +1,6 @@
 *** Settings ***
 Documentation       This taskset collects information on your redis workload in your Kubernetes cluster and 
-Metadata            Author    Jonathan Funk
+Metadata            Author    jon-funk
 Metadata            Display Name    Kubernetes Redis Healthcheck
 Metadata            Supports    Kubernetes,AKS,EKS,GKE,OpenShift,Redis
 Library             BuiltIn

--- a/codebundles/k8s-statefulset-healthcheck/runbook.robot
+++ b/codebundles/k8s-statefulset-healthcheck/runbook.robot
@@ -1,6 +1,6 @@
 *** Settings ***
 Documentation       Triages issues related to a StatefulSet and its replicas.
-Metadata            Author    Jonathan Funk
+Metadata            Author    jon-funk
 Metadata            Display Name    Kubernetes StatefulSet Triage
 Metadata            Supports    Kubernetes,AKS,EKS,GKE,OpenShift
 

--- a/codebundles/k8s-vault-healthcheck/runbook.robot
+++ b/codebundles/k8s-vault-healthcheck/runbook.robot
@@ -1,6 +1,6 @@
 *** Settings ***
 Documentation       A suite of tasks that can be used to triage potential issues in your vault namespace.
-Metadata            Author    Jonathan Funk
+Metadata            Author    jon-funk
 Metadata            Display Name    Kubernetes Vault Triage
 Metadata            Supports    AKS,EKS,GKE,Kubernetes,Vault
 

--- a/libraries/RW/CLI/json_parser.py
+++ b/libraries/RW/CLI/json_parser.py
@@ -8,7 +8,7 @@ from . import cli_utils
 logger = logging.getLogger(__name__)
 ROBOT_LIBRARY_SCOPE = "GLOBAL"
 
-MAX_ISSUE_STRING_LENGTH: int = 2048
+MAX_ISSUE_STRING_LENGTH: int = 1920
 
 RECOGNIZED_JSON_PARSE_QUERIES = [
     "raise_issue_if_eq",

--- a/libraries/RW/CLI/stdout_parser.py
+++ b/libraries/RW/CLI/stdout_parser.py
@@ -15,7 +15,7 @@ ROBOT_LIBRARY_SCOPE = "GLOBAL"
 
 logger = logging.getLogger(__name__)
 
-MAX_ISSUE_STRING_LENGTH: int = 2048
+MAX_ISSUE_STRING_LENGTH: int = 1920
 
 RECOGNIZED_STDOUT_PARSE_QUERIES = [
     "raise_issue_if_eq",


### PR DESCRIPTION
- update author name to github handle format
- slightly reduces issue string max length as it turns out the API model has a max length of 2000, this was causing exceptions in the BOW index