### PR TITLE
create gh discussions for codebundles

### DIFF
--- a/.github/queries/addDiscussionComment.graphql
+++ b/.github/queries/addDiscussionComment.graphql
@@ -1,0 +1,7 @@
+mutation AddDiscussionComment($discussion_id: ID!) {
+  addDiscussionComment(input: { discussionId: $discussion_id, body: "Possibly outdated or obsolete. Please review." }) {
+    comment {
+      id
+    }
+  }
+}

--- a/.github/queries/createDiscussion.graphql
+++ b/.github/queries/createDiscussion.graphql
@@ -1,5 +1,5 @@
-mutation CreateDiscussion($repo_id: ID!, $codebundle: String!) {
-  createDiscussion(input: { repositoryId: $repo_id, title: $codebundle }) {
+mutation CreateDiscussion($repo_id: ID!, $codebundle: String!, $discussion_body: String!) {
+  createDiscussion(input: { repositoryId: $repo_id, title: $codebundle, body: $discussion_body, categoryId: "category_id" }) {
     discussion {
       id
     }

--- a/.github/queries/createDiscussion.graphql
+++ b/.github/queries/createDiscussion.graphql
@@ -1,0 +1,7 @@
+mutation CreateDiscussion($repo_id: ID!, $codebundle: String!) {
+  createDiscussion(input: { repositoryId: $repo_id, title: $codebundle }) {
+    discussion {
+      id
+    }
+  }
+}

--- a/.github/queries/createDiscussion.graphql
+++ b/.github/queries/createDiscussion.graphql
@@ -1,5 +1,5 @@
-mutation CreateDiscussion($repo_id: ID!, $codebundle: String!, $discussion_body: String!) {
-  createDiscussion(input: { repositoryId: $repo_id, title: $codebundle, body: $discussion_body, categoryId: "category_id" }) {
+mutation CreateDiscussion($repo_id: ID!, $codebundle: String!, $discussion_body: String!, category_id: ID!) {
+  createDiscussion(input: { repositoryId: $repo_id, title: $codebundle, body: $discussion_body, categoryId: $category_id }) {
     discussion {
       id
     }

--- a/.github/queries/createDiscussion.graphql
+++ b/.github/queries/createDiscussion.graphql
@@ -1,4 +1,4 @@
-mutation CreateDiscussion($repo_id: ID!, $codebundle: String!, $discussion_body: String!, category_id: ID!) {
+mutation CreateDiscussion($repo_id: ID!, $codebundle: String!, $discussion_body: String!, $category_id: ID!) {
   createDiscussion(input: { repositoryId: $repo_id, title: $codebundle, body: $discussion_body, categoryId: $category_id }) {
     discussion {
       id

--- a/.github/queries/deleteDiscussion.graphql
+++ b/.github/queries/deleteDiscussion.graphql
@@ -1,0 +1,5 @@
+mutation DeleteDiscussion($discussion_id: ID!) {
+  deleteDiscussion(input: { discussionId: $discussion_id }) {
+    clientMutationId
+  }
+}

--- a/.github/queries/deleteDiscussion.graphql
+++ b/.github/queries/deleteDiscussion.graphql
@@ -1,5 +1,5 @@
 mutation DeleteDiscussion($discussion_id: ID!) {
-  deleteDiscussion(input: { discussionId: $discussion_id }) {
+  deleteDiscussion(input: { id: $discussion_id }) {
     clientMutationId
   }
 }

--- a/.github/queries/getComments.graphql
+++ b/.github/queries/getComments.graphql
@@ -1,0 +1,13 @@
+query GetComments($discussion_id: ID!) {
+  node(id: $discussion_id) {
+    ... on Discussion {
+      comments(first: 100) {
+        edges {
+          node {
+            body
+          }
+        }
+      }
+    }
+  }
+}

--- a/.github/queries/getDiscussion.graphql
+++ b/.github/queries/getDiscussion.graphql
@@ -1,0 +1,12 @@
+query GetDiscussion($discussion_id: ID!) {
+  discussion:node(id: $discussion_id) {
+    ... on Discussion {
+      repository {
+        id
+      }
+      category {
+        id
+      }
+    }
+  }
+}

--- a/.github/queries/searchDiscussions.graphql
+++ b/.github/queries/searchDiscussions.graphql
@@ -1,0 +1,16 @@
+query SearchDiscussions($searchQuery: String!) {
+  search(query: $searchQuery, type: REPOSITORY, first: 100) {
+    edges {
+      node {
+        ... on Repository {
+          discussions(first: 100) {
+            nodes {
+              id
+              title
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/.github/workflows/update-discussion.yml
+++ b/.github/workflows/update-discussion.yml
@@ -36,12 +36,9 @@ jobs:
           echo $discussion_nodes
 
           # Loop through the discussion nodes
-          for discussion_node in $discussion_nodes; do
+          echo "$discussion_nodes" | while IFS= read -r discussion_node; do
             echo "$discussion_node"
-            echo "start loop"
-            echo "$discussion_node" | jq -r '.title'
             codebundle=$(echo "$discussion_node" | jq -r '.title')
-            echo "$discussion_node" | jq -r '.id'
             discussion_id=$(echo "$discussion_node" | jq -r '.id')
 
             if [[ "$codebundles" =~ (^|[[:space:]])"$codebundle"($|[[:space:]]) ]]; then

--- a/.github/workflows/update-discussion.yml
+++ b/.github/workflows/update-discussion.yml
@@ -26,7 +26,7 @@ jobs:
           # Temp for cleanup of messes
           delete=true
           delete_discusssion_query=$(cat .github/queries/deleteDiscussion.graphql | tr -d '\n' | sed 's/"/\\\"/g')
-          
+          codebundles=test
           
           # Perform the searchDiscussions query
           search_response=$(curl -s -H "Authorization: Bearer $GH_TOKEN" -H "Content-Type: application/json" -X POST -d "{\"query\": \"$search_discussions_query\", \"variables\": {\"searchQuery\": \"org:runwhen-contrib\"}}" https://api.github.com/graphql)
@@ -61,11 +61,12 @@ jobs:
               if ! $found ; then
                 echo "No matching discussion found for $codebundle"
                 echo "Creating new discussion for $codebundle"
-                discussion_body=$codebundle
+                discussion_title=$codebundle
                 #Troubleshooting Commands Category
                 category_id="DIC_kwDOJo2Id84CXeeV"
                 # The repository_id that we need to use  
                 repo_id="R_kgDOJo2Idw"              
+                discussion_body="🌟Welcome to the community discussion for the troubleshooting commands defined in: $codebundle \n\n-> This discussion is intended to help grow the community\n-> Together, lets enhance the usefulness of the troubleshooting commands\n-> 🙌 Your participation is crucial! Share your valuable comments and questions here, and don't forget to give a thumbs up if you find the commands helpful and utilize them in your work."
                 curl -s -H "Authorization: Bearer $GH_TOKEN" -H "Content-Type: application/json" -X POST -d "{\"query\": \"$create_discussion_query\", \"variables\": {\"repo_id\": \"$repo_id\", \"codebundle\": \"$codebundle\",\"discussion_body\": \"$discussion_body\", \"category_id\": \"$category_id\"}}" https://api.github.com/graphql 
               fi
             fi

--- a/.github/workflows/update-discussion.yml
+++ b/.github/workflows/update-discussion.yml
@@ -53,7 +53,7 @@ jobs:
 
                 # if [[ -z $notes ]]; then
                 #   echo "Adding note to discussion for $codebundle"
-                #   curl -s -H "Authorization: Bearer $GH_TOKEN" -H "Content-Type: application/json" -X POST -d "{\"query\": \"$add_comment_query\", \"variables\": {\"discussion_id\": \"$discussion_id\"}}" https://api.github.com/graphql > /dev/null
+                #   curl -s -H "Authorization: Bearer $GH_TOKEN" -H "Content-Type: application/json" -X POST -d "{\"query\": \"$add_comment_query\", \"variables\": {\"discussion_id\": \"$discussion_id\"}}" https://api.github.com/graphql 
                 # fi
 
                 break
@@ -63,7 +63,7 @@ jobs:
             if ! $found; then
               echo "No matching discussion found for $codebundle"
               echo "Creating new discussion for $codebundle"
-              curl -s -H "Authorization: Bearer $GH_TOKEN" -H "Content-Type: application/json" -X POST -d "{\"query\": \"$create_discussion_query\", \"variables\": {\"repo_id\": \"$repo_id\", \"codebundle\": \"$codebundle\"}}" https://api.github.com/graphql > /dev/null
+              curl -s -H "Authorization: Bearer $GH_TOKEN" -H "Content-Type: application/json" -X POST -d "{\"query\": \"$create_discussion_query\", \"variables\": {\"repo_id\": \"$repo_id\", \"codebundle\": \"$codebundle\"}}" https://api.github.com/graphql 
             fi
           done
 

--- a/.github/workflows/update-discussion.yml
+++ b/.github/workflows/update-discussion.yml
@@ -36,7 +36,7 @@ jobs:
           echo $discussion_nodes
 
           # Loop through the discussion nodes
-          echo "$discussion_nodes" | while IFS= read -r discussion_node; do
+          jq -c '.[]' $discussion_nodes | while read discussion_node; do
             echo "$discussion_node"
             codebundle=$(echo "$discussion_node" | jq -r '.title')
             discussion_id=$(echo "$discussion_node" | jq -r '.id')

--- a/.github/workflows/update-discussion.yml
+++ b/.github/workflows/update-discussion.yml
@@ -43,7 +43,7 @@ jobs:
           done
 
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.PAT }}
 
   check-discussions-on-commit:
     if: github.ref != 'refs/heads/main'
@@ -83,4 +83,4 @@ jobs:
           done
 
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.PAT }}

--- a/.github/workflows/update-discussion.yml
+++ b/.github/workflows/update-discussion.yml
@@ -1,0 +1,47 @@
+name: Check CodeBundle Discussions
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '**'
+  push:
+    branches-ignore:
+      - main
+
+jobs:
+  check-discussions:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for CodeBundles
+        id: find_codebundles
+        run: |
+          codebundles=$(find codebundles -type d -depth 1 -exec basename {} \;)
+          echo "::set-output name=codebundles::$codebundles"
+
+      - name: Search Discussions
+        id: search_discussions
+        run: |
+          codebundles=(${{ steps.find_codebundles.outputs.codebundles }})
+
+          for codebundle in "${codebundles[@]}"; do
+            discussion=$(gh api -X GET "/orgs/runwhen-contrib/discussions" --jq "[.[] | select(.title == \"$codebundle\")]")
+            if [[ -z $discussion ]]; then
+              echo "Creating new discussion for $codebundle"
+              gh api -X POST "/repos/runwhen-contrib/.github/discussions" -H "Accept: application/vnd.github.echo-preview+json" -d "{\"title\": \"$codebundle\"}"
+            elif [[ $(jq length <<< "$discussion") -gt 1 ]]; then
+              echo "Multiple discussions found for $codebundle. Skipping note addition."
+            else
+              echo "Discussion found for $codebundle"
+              discussion_id=$(jq -r '.[0].id' <<< "$discussion")
+              notes=$(gh api -X GET "/orgs/runwhen-contrib/discussions/$discussion_id/comments" --jq "[.[] | select(.body | contains(\"Possibly outdated or obsolete\"))]")
+
+              if [[ -z $notes ]]; then
+                echo "Adding note to discussion for $codebundle"
+                gh api -X POST "/orgs/runwhen-contrib/discussions/$discussion_id/comments" -H "Accept: application/vnd.github.echo-preview+json" -d "{\"body\": \"Possibly outdated or obsolete. Please review.\"}"
+              fi
+            fi
+          done
+
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-discussion.yml
+++ b/.github/workflows/update-discussion.yml
@@ -8,6 +8,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+        with:
+          ref: ${{ github.ref }}
 
       - name: Check if codebundle discussion exists
         id: find_and_create_codebundle_discussions

--- a/.github/workflows/update-discussion.yml
+++ b/.github/workflows/update-discussion.yml
@@ -57,16 +57,17 @@ jobs:
                 break
               fi
             done
-
-            if ! $found; then
-              echo "No matching discussion found for $codebundle"
-              echo "Creating new discussion for $codebundle"
-              discussion_body=$codebundle
-              #Troubleshooting Commands Category
-              category_id="DIC_kwDOJo2Id84CXeeV"
-              # The repository_id that we need to use  
-              repo_id="R_kgDOJo2Idw"              
-              curl -s -H "Authorization: Bearer $GH_TOKEN" -H "Content-Type: application/json" -X POST -d "{\"query\": \"$create_discussion_query\", \"variables\": {\"repo_id\": \"$repo_id\", \"codebundle\": \"$codebundle\",\"discussion_body\": \"$discussion_body\", \"category_id\": \"$category_id\"}}" https://api.github.com/graphql 
+            if [[ "$delete" != "true" ]]; then
+              if ! $found ; then
+                echo "No matching discussion found for $codebundle"
+                echo "Creating new discussion for $codebundle"
+                discussion_body=$codebundle
+                #Troubleshooting Commands Category
+                category_id="DIC_kwDOJo2Id84CXeeV"
+                # The repository_id that we need to use  
+                repo_id="R_kgDOJo2Idw"              
+                curl -s -H "Authorization: Bearer $GH_TOKEN" -H "Content-Type: application/json" -X POST -d "{\"query\": \"$create_discussion_query\", \"variables\": {\"repo_id\": \"$repo_id\", \"codebundle\": \"$codebundle\",\"discussion_body\": \"$discussion_body\", \"category_id\": \"$category_id\"}}" https://api.github.com/graphql 
+              fi
             fi
           done
 

--- a/.github/workflows/update-discussion.yml
+++ b/.github/workflows/update-discussion.yml
@@ -37,6 +37,7 @@ jobs:
 
           # Loop through the discussion nodes
           for discussion_node in $discussion_nodes; do
+            echo "$discussion_node"
             echo "start loop"
             echo "$discussion_node" | jq -r '.title'
             codebundle=$(echo "$discussion_node" | jq -r '.title')

--- a/.github/workflows/update-discussion.yml
+++ b/.github/workflows/update-discussion.yml
@@ -65,7 +65,9 @@ jobs:
               echo "No matching discussion found for $codebundle"
               echo "Creating new discussion for $codebundle"
               discussion_body=$codebundle
-              curl -s -H "Authorization: Bearer $GH_TOKEN" -H "Content-Type: application/json" -X POST -d "{\"query\": \"$create_discussion_query\", \"variables\": {\"repo_id\": \"org:runwhen-contrib\", \"codebundle\": \"$codebundle\",\"discussion_body\": \"$discussion_body\"}}" https://api.github.com/graphql 
+              category_id="DIC_kwDOJo2Id84CXeeV"  #Troubleshooting Commands Category
+              repo_id="R_kgDOJo2Idw"              # The repository_id that we need to use
+              curl -s -H "Authorization: Bearer $GH_TOKEN" -H "Content-Type: application/json" -X POST -d "{\"query\": \"$create_discussion_query\", \"variables\": {\"repo_id\": \"$repo_id\", \"codebundle\": \"$codebundle\",\"discussion_body\": \"$discussion_body\"}}" https://api.github.com/graphql 
             fi
           done
 

--- a/.github/workflows/update-discussion.yml
+++ b/.github/workflows/update-discussion.yml
@@ -9,17 +9,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Check for CodeBundles
-        id: find_codebundles
+      - name: Check if codebundle discussion exists
+        id: find_and_create_codebundle_discussions
         run: |
-          codebundles=$(find codebundles -type d -exec basename {} \; | grep -v "codebundles")
-          echo "codebundles=$codebundles" >> $GITHUB_ENV
-          echo $codebundles
+          codebundles=$(find codebundles -type d -exec basename {} \; | grep -v "codebundles")          
 
-      - name: Search Discussions
-        id: search_discussions
-        run: |
-          codebundles=$CODEBUNDLES
           echo "Found codebundles: $codebundles"
           echo "Searching discussions..."
 
@@ -58,4 +52,3 @@ jobs:
 
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CODEBUNDLES: ${{ steps.find_codebundles.outputs.codebundles }}

--- a/.github/workflows/update-discussion.yml
+++ b/.github/workflows/update-discussion.yml
@@ -1,12 +1,8 @@
 name: Check CodeBundle Discussions
 on:
-  push:
-    branches-ignore:
-      - main
   workflow_dispatch:
 jobs:
   check-discussions-on-main:
-    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -29,46 +25,6 @@ jobs:
             if [[ -z $discussion ]]; then
               echo "Creating new discussion for $codebundle"
               gh api -X POST "/repos/runwhen-contrib/.github/discussions" -H "Accept: application/vnd.github.echo-preview+json" -d "{\"title\": \"$codebundle\"}"
-            elif [[ $(jq length <<< "$discussion") -gt 1 ]]; then
-              echo "Multiple discussions found for $codebundle. Skipping note addition."
-            else
-              echo "Discussion found for $codebundle"
-              discussion_id=$(jq -r '.[0].id' <<< "$discussion")
-              notes=$(gh api -X GET "/orgs/runwhen-contrib/discussions/$discussion_id/comments" --jq "[.[] | select(.body | contains(\"Possibly outdated or obsolete\"))]")
-
-              if [[ -z $notes ]]; then
-                echo "Adding note to discussion for $codebundle"
-                gh api -X POST "/orgs/runwhen-contrib/discussions/$discussion_id/comments" -H "Accept: application/vnd.github.echo-preview+json" -H "Content-Type: application/json" -d "{\"body\": \"Possibly outdated or obsolete. Please review.\"}"
-              fi
-            fi
-          done
-
-        env:
-          GH_TOKEN: ${{ secrets.PAT }}
-
-  check-discussions-on-commit:
-    if: github.ref != 'refs/heads/main'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
-      - name: Check for CodeBundles
-        id: find_codebundles
-        run: |
-          codebundles=$(find . -type d -name 'codebundles*' -exec basename {} \;)
-          echo "::set-output name=codebundles::$codebundles"
-
-      - name: Search Discussions
-        id: search_discussions
-        run: |
-          codebundles=(${{ steps.find_codebundles.outputs.codebundles }})
-
-          for codebundle in "${codebundles[@]}"; do
-            discussion=$(gh api -X GET "/orgs/runwhen-contrib/discussions" --jq "[.[] | select(.title == \"$codebundle\")]")
-            if [[ -z $discussion ]]; then
-              echo "Creating new discussion for $codebundle"
-              gh api -X POST "/repos/runwhen-contrib/.github/discussions" -H "Accept: application/vnd.github.echo-preview+json" -H "Content-Type: application/json" -d "{\"title\": \"$codebundle\"}"
             elif [[ $(jq length <<< "$discussion") -gt 1 ]]; then
               echo "Multiple discussions found for $codebundle. Skipping note addition."
             else

--- a/.github/workflows/update-discussion.yml
+++ b/.github/workflows/update-discussion.yml
@@ -24,7 +24,7 @@ jobs:
           get_comments_query=$(cat .github/queries/getComments.graphql | tr -d '\n' | sed 's/"/\\\"/g')
           
           # Temp for cleanup of messes
-          delete=true
+          delete=false
           delete_discusssion_query=$(cat .github/queries/deleteDiscussion.graphql | tr -d '\n' | sed 's/"/\\\"/g')
           codebundles=test
           

--- a/.github/workflows/update-discussion.yml
+++ b/.github/workflows/update-discussion.yml
@@ -24,13 +24,15 @@ jobs:
           cat .github/queries/searchDiscussions.graphql
           # Read the queries from separate files
           search_discussions_query=$(cat .github/queries/searchDiscussions.graphql | tr -d '\n' | sed 's/"/\\\"/g')
+          echo $search_discussions_query
           create_discussion_query=$(cat .github/queries/createDiscussion.graphql | tr -d '\n' | sed 's/"/\\\"/g')
           add_comment_query=$(cat .github/queries/addDiscussionComment.graphql | tr -d '\n' | sed 's/"/\\\"/g')
           get_comments_query=$(cat .github/queries/getComments.graphql | tr -d '\n' | sed 's/"/\\\"/g')
-
+          echo "done var fetch"
           # Perform the searchDiscussions query
           search_response=$(curl -s -H "Authorization: Bearer $GH_TOKEN" -H "Content-Type: application/json" -X POST -d "{\"query\": \"$search_discussions_query\", \"variables\": $search_discussions_variables}" https://api.github.com/graphql)
           discussion_nodes=$(echo "$search_response" | jq -r '.data.search.edges[].node.discussions.nodes[] | select(.title != null) | { id, title }')
+          echo "done curls"
 
           # Loop through the discussion nodes
           for discussion_node in $discussion_nodes; do

--- a/.github/workflows/update-discussion.yml
+++ b/.github/workflows/update-discussion.yml
@@ -30,9 +30,10 @@ jobs:
           get_comments_query=$(cat .github/queries/getComments.graphql | tr -d '\n' | sed 's/"/\\\"/g')
           echo "done var fetch"
           # Perform the searchDiscussions query
-          search_response=$(curl -s -H "Authorization: Bearer $GH_TOKEN" -H "Content-Type: application/json" -X POST -d "{\"query\": \"$search_discussions_query\", \"variables\": $search_discussions_variables}" https://api.github.com/graphql)
+          search_response=$(curl -s -H "Authorization: Bearer $GH_TOKEN" -H "Content-Type: application/json" -X POST -d "{\"query\": \"$search_discussions_query\", \"variables\": {\"searchQuery\": \"org:runwhen-contrib\"}}" https://api.github.com/graphql)
+          echo $search_response
           discussion_nodes=$(echo "$search_response" | jq -r '.data.search.edges[].node.discussions.nodes[] | select(.title != null) | { id, title }')
-          echo "done curls"
+          echo $discussion_nodes
 
           # Loop through the discussion nodes
           for discussion_node in $discussion_nodes; do

--- a/.github/workflows/update-discussion.yml
+++ b/.github/workflows/update-discussion.yml
@@ -21,6 +21,7 @@ jobs:
           pwd
           ls -lha
           tree .github
+          cat .github/queries/searchDiscussions.graphql
           # Read the queries from separate files
           search_discussions_query=$(cat .github/queries/searchDiscussions.graphql | tr -d '\n' | sed 's/"/\\\"/g')
           create_discussion_query=$(cat .github/queries/createDiscussion.graphql | tr -d '\n' | sed 's/"/\\\"/g')

--- a/.github/workflows/update-discussion.yml
+++ b/.github/workflows/update-discussion.yml
@@ -1,5 +1,5 @@
 name: Check CodeBundle Discussions
-on: 
+on:
   push:
     branches-ignore:
       - main
@@ -9,10 +9,13 @@ jobs:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
       - name: Check for CodeBundles
         id: find_codebundles
         run: |
-          codebundles=$(find codebundles -type d -depth 1 -exec basename {} \;)
+          codebundles=$(find . -type d -name 'codebundles*' -exec basename {} \;)
           echo "::set-output name=codebundles::$codebundles"
 
       - name: Search Discussions
@@ -46,10 +49,13 @@ jobs:
     if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
       - name: Check for CodeBundles
         id: find_codebundles
         run: |
-          codebundles=$(find codebundles -type d -depth 1 -exec basename {} \;)
+          codebundles=$(find . -type d -name 'codebundles*' -exec basename {} \;)
           echo "::set-output name=codebundles::$codebundles"
 
       - name: Search Discussions
@@ -62,5 +68,4 @@ jobs:
             if [[ -z $discussion ]]; then
               echo "Creating new discussion for $codebundle"
               gh api -X POST "/repos/runwhen-contrib/.github/discussions" -H "Accept: application/vnd.github.echo-preview+json" -d "{\"title\": \"$codebundle\"}"
-            elif [[ $(jq length <<< "$discussion") -gt 1 ]]; then
-              echo "Multiple discussions found for $codebundle. Skipping note addition."
+            elif [[ $(jq length <<< "$discussion

--- a/.github/workflows/update-discussion.yml
+++ b/.github/workflows/update-discussion.yml
@@ -37,7 +37,7 @@ jobs:
 
               if [[ -z $notes ]]; then
                 echo "Adding note to discussion for $codebundle"
-                gh api -X POST "/orgs/runwhen-contrib/discussions/$discussion_id/comments" -H "Accept: application/vnd.github.echo-preview+json" -d "{\"body\": \"Possibly outdated or obsolete. Please review.\"}"
+                gh api -X POST "/orgs/runwhen-contrib/discussions/$discussion_id/comments" -H "Accept: application/vnd.github.echo-preview+json" -H "Content-Type: application/json" -d "{\"body\": \"Possibly outdated or obsolete. Please review.\"}"
               fi
             fi
           done
@@ -67,5 +67,20 @@ jobs:
             discussion=$(gh api -X GET "/orgs/runwhen-contrib/discussions" --jq "[.[] | select(.title == \"$codebundle\")]")
             if [[ -z $discussion ]]; then
               echo "Creating new discussion for $codebundle"
-              gh api -X POST "/repos/runwhen-contrib/.github/discussions" -H "Accept: application/vnd.github.echo-preview+json" -d "{\"title\": \"$codebundle\"}"
-            elif [[ $(jq length <<< "$discussion
+              gh api -X POST "/repos/runwhen-contrib/.github/discussions" -H "Accept: application/vnd.github.echo-preview+json" -H "Content-Type: application/json" -d "{\"title\": \"$codebundle\"}"
+            elif [[ $(jq length <<< "$discussion") -gt 1 ]]; then
+              echo "Multiple discussions found for $codebundle. Skipping note addition."
+            else
+              echo "Discussion found for $codebundle"
+              discussion_id=$(jq -r '.[0].id' <<< "$discussion")
+              notes=$(gh api -X GET "/orgs/runwhen-contrib/discussions/$discussion_id/comments" --jq "[.[] | select(.body | contains(\"Possibly outdated or obsolete\"))]")
+
+              if [[ -z $notes ]]; then
+                echo "Adding note to discussion for $codebundle"
+                gh api -X POST "/orgs/runwhen-contrib/discussions/$discussion_id/comments" -H "Accept: application/vnd.github.echo-preview+json" -H "Content-Type: application/json" -d "{\"body\": \"Possibly outdated or obsolete. Please review.\"}"
+              fi
+            fi
+          done
+
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-discussion.yml
+++ b/.github/workflows/update-discussion.yml
@@ -24,7 +24,7 @@ jobs:
           get_comments_query=$(cat .github/queries/getComments.graphql | tr -d '\n' | sed 's/"/\\\"/g')
           
           # Temp for cleanup of messes
-          delete=false
+          delete=true
           delete_discusssion_query=$(cat .github/queries/deleteDiscussion.graphql | tr -d '\n' | sed 's/"/\\\"/g')
           codebundles=test
           
@@ -66,7 +66,7 @@ jobs:
                 category_id="DIC_kwDOJo2Id84CXeeV"
                 # The repository_id that we need to use  
                 repo_id="R_kgDOJo2Idw"              
-                discussion_body="🌟Welcome to the community discussion for the troubleshooting commands defined in: [$codebundle](https://github.com/rw-cli-codecollection/tree/main/codebundles/$codebundle) \n\n🌱This discussion is intended to help grow the community\n 🛠️Together, lets enhance the usefulness of the troubleshooting commands\n\n 🙌 Your participation is crucial! Share your valuable comments and questions here, and don't forget to give a thumbs up if you find the commands helpful and utilize them in your work."
+                discussion_body="🌟Welcome to the community discussion for the troubleshooting commands defined in: [$codebundle](https://github.com/runwhen-contrib/rw-cli-codecollection/tree/main/codebundles/$codebundle) \n\n🌱This discussion is intended to help grow the community\n🛠️Together, lets enhance the usefulness of the troubleshooting commands\n\n🙌 Your participation is crucial! Share your valuable comments and questions here, and don't forget to give a thumbs up if you find the commands helpful and utilize them in your work."
                 curl -s -H "Authorization: Bearer $GH_TOKEN" -H "Content-Type: application/json" -X POST -d "{\"query\": \"$create_discussion_query\", \"variables\": {\"repo_id\": \"$repo_id\", \"codebundle\": \"$codebundle\",\"discussion_body\": \"$discussion_body\", \"category_id\": \"$category_id\"}}" https://api.github.com/graphql 
               fi
             fi

--- a/.github/workflows/update-discussion.yml
+++ b/.github/workflows/update-discussion.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches-ignore:
       - main
-
+  workflow_dispatch:
 jobs:
   check-discussions-on-main:
     if: github.ref == 'refs/heads/main'

--- a/.github/workflows/update-discussion.yml
+++ b/.github/workflows/update-discussion.yml
@@ -32,7 +32,7 @@ jobs:
           # Perform the searchDiscussions query
           search_response=$(curl -s -H "Authorization: Bearer $GH_TOKEN" -H "Content-Type: application/json" -X POST -d "{\"query\": \"$search_discussions_query\", \"variables\": {\"searchQuery\": \"org:runwhen-contrib\"}}" https://api.github.com/graphql)
           echo $search_response
-          discussion_nodes=$(echo "$search_response" | jq -r '.data.search.edges[].node.discussions.nodes[] | select(.title != null) | { id, title }')
+          discussion_nodes=$(echo "$search_response" | jq -r '[.data.search.edges[].node.discussions.nodes[] | select(.title != null) | { id, title }] | { items: . }')
           echo $discussion_nodes
 
           # Loop through the discussion nodes

--- a/.github/workflows/update-discussion.yml
+++ b/.github/workflows/update-discussion.yml
@@ -42,7 +42,7 @@ jobs:
                 found=true
                 echo "Discussion found for $codebundle with ID: $discussion_id"
                 if [[ "$delete" == "true" ]]; then
-                  url -s -H "Authorization: Bearer $GH_TOKEN" -H "Content-Type: application/json" -X POST -d "{\"query\": \"$delete_discusssion_query\", \"variables\": {\"discussion_id\": \"$discussion_id\" }}" https://api.github.com/graphql 
+                  curl -s -H "Authorization: Bearer $GH_TOKEN" -H "Content-Type: application/json" -X POST -d "{\"query\": \"$delete_discusssion_query\", \"variables\": {\"discussion_id\": \"$discussion_id\" }}" https://api.github.com/graphql 
                 fi
 
                 # # Fetch comments for the discussion

--- a/.github/workflows/update-discussion.yml
+++ b/.github/workflows/update-discussion.yml
@@ -9,10 +9,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
+
       - name: Check for CodeBundles
         id: find_codebundles
         run: |
-          codebundles=$(find . -type d -name 'codebundles*' -exec basename {} \;)
+          codebundles=$(find codebundles -type d -exec basename {} \; | grep -v "codebundles")
           echo "::set-output name=codebundles::$codebundles"
           echo $codebundles
 
@@ -20,25 +21,40 @@ jobs:
         id: search_discussions
         run: |
           codebundles=(${{ steps.find_codebundles.outputs.codebundles }})
-          echo $codebundles
-          for codebundle in "${codebundles[@]}"; do
-            discussion=$(gh api -X GET "/orgs/runwhen-contrib/discussions" --jq "[.[] | select(.title == \"$codebundle\")]")
-            if [[ -z $discussion ]]; then
-              echo "Creating new discussion for $codebundle"
-              gh api -X POST "/repos/runwhen-contrib/.github/discussions" -H "Accept: application/vnd.github.echo-preview+json" -d "{\"title\": \"$codebundle\"}"
-            elif [[ $(jq length <<< "$discussion") -gt 1 ]]; then
-              echo "Multiple discussions found for $codebundle. Skipping note addition."
-            else
-              echo "Discussion found for $codebundle"
-              discussion_id=$(jq -r '.[0].id' <<< "$discussion")
-              notes=$(gh api -X GET "/orgs/runwhen-contrib/discussions/$discussion_id/comments" --jq "[.[] | select(.body | contains(\"Possibly outdated or obsolete\"))]")
+          echo "Found codebundles: ${{ join(steps.find_codebundles.outputs.codebundles, ',') }}"
+          echo "Searching discussions..."
 
-              if [[ -z $notes ]]; then
-                echo "Adding note to discussion for $codebundle"
-                gh api -X POST "/orgs/runwhen-contrib/discussions/$discussion_id/comments" -H "Accept: application/vnd.github.echo-preview+json" -H "Content-Type: application/json" -d "{\"body\": \"Possibly outdated or obsolete. Please review.\"}"
-              fi
+          # Read the queries from separate files
+          search_discussions_query=$(cat .github/queries/searchDiscussions.graphql | tr -d '\n' | sed 's/"/\\\"/g')
+          create_discussion_query=$(cat .github/queries/createDiscussion.graphql | tr -d '\n' | sed 's/"/\\\"/g')
+          add_comment_query=$(cat .github/queries/addDiscussionComment.graphql | tr -d '\n' | sed 's/"/\\\"/g')
+          get_comments_query=$(cat .github/queries/graphql-queries/getComments.graphql | tr -d '\n' | sed 's/"/\\\"/g')
+
+          # Perform the searchDiscussions query
+          search_response=$(curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -H "Content-Type: application/json" -X POST -d "{\"query\": \"$search_discussions_query\", \"variables\": $search_discussions_variables}" https://api.github.com/graphql)
+          discussion_nodes=$(echo "$search_response" | jq -r '.data.search.edges[].node.discussions.nodes[] | select(.title != null) | { id, title }')
+
+          # Loop through the discussion nodes
+          for discussion_node in $discussion_nodes; do
+            codebundle=$(echo "$discussion_node" | jq -r '.title')
+            discussion_id=$(echo "$discussion_node" | jq -r '.id')
+
+            if [[ -z $discussion_id ]]; then
+              echo "Creating new discussion for $codebundle"
+              curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -H "Content-Type: application/json" -X POST -d "{\"query\": \"$create_discussion_query\", \"variables\": {\"repo_id\": \"$repo_id\", \"codebundle\": \"$codebundle\"}}" https://api.github.com/graphql > /dev/null
+            else
+              echo "Discussion found for $codebundle with ID: $discussion_id"
+
+              # # Fetch comments for the discussion
+              # comments_response=$(curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -H "Content-Type: application/json" -X POST -d "{\"query\": \"$get_comments_query\", \"variables\": {\"discussion_id\": \"$discussion_id\"}}" https://api.github.com/graphql)
+              # notes=$(echo "$comments_response" | jq -r '.data.node.comments.edges[].node.body')
+
+              # if [[ -z $notes ]]; then
+              #   echo "Adding note to discussion for $codebundle"
+              #   curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -H "Content-Type: application/json" -X POST -d "{\"query\": \"$add_comment_query\", \"variables\": {\"discussion_id\": \"$discussion_id\"}}" https://api.github.com/graphql > /dev/null
+              # fi
             fi
           done
 
         env:
-          GH_TOKEN: ${{ secrets.PAT }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-discussion.yml
+++ b/.github/workflows/update-discussion.yml
@@ -65,8 +65,10 @@ jobs:
               echo "No matching discussion found for $codebundle"
               echo "Creating new discussion for $codebundle"
               discussion_body=$codebundle
-              category_id="DIC_kwDOJo2Id84CXeeV"  #Troubleshooting Commands Category
-              repo_id="R_kgDOJo2Idw"              # The repository_id that we need to use
+              #Troubleshooting Commands Category
+              category_id="DIC_kwDOJo2Id84CXeeV"
+              # The repository_id that we need to use  
+              repo_id="R_kgDOJo2Idw"              
               curl -s -H "Authorization: Bearer $GH_TOKEN" -H "Content-Type: application/json" -X POST -d "{\"query\": \"$create_discussion_query\", \"variables\": {\"repo_id\": \"$repo_id\", \"codebundle\": \"$codebundle\",\"discussion_body\": \"$discussion_body\", \"category_id\": \"$category_id\"}}" https://api.github.com/graphql 
             fi
           done

--- a/.github/workflows/update-discussion.yml
+++ b/.github/workflows/update-discussion.yml
@@ -1,5 +1,5 @@
 name: Check CodeBundle Discussions
-on:  
+on:
   workflow_dispatch:
   push:
 jobs:
@@ -9,29 +9,28 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-
       - name: Check for CodeBundles
         id: find_codebundles
         run: |
           codebundles=$(find codebundles -type d -exec basename {} \; | grep -v "codebundles")
-          echo "::set-output name=codebundles::$codebundles"
+          echo "codebundles=$codebundles" >> $GITHUB_ENV
           echo $codebundles
 
       - name: Search Discussions
         id: search_discussions
         run: |
-          codebundles=(${{ steps.find_codebundles.outputs.codebundles }})
-          echo "Found codebundles: ${{ join(steps.find_codebundles.outputs.codebundles, ',') }}"
+          codebundles=$CODEBUNDLES
+          echo "Found codebundles: $codebundles"
           echo "Searching discussions..."
 
           # Read the queries from separate files
           search_discussions_query=$(cat .github/queries/searchDiscussions.graphql | tr -d '\n' | sed 's/"/\\\"/g')
           create_discussion_query=$(cat .github/queries/createDiscussion.graphql | tr -d '\n' | sed 's/"/\\\"/g')
           add_comment_query=$(cat .github/queries/addDiscussionComment.graphql | tr -d '\n' | sed 's/"/\\\"/g')
-          get_comments_query=$(cat .github/queries/graphql-queries/getComments.graphql | tr -d '\n' | sed 's/"/\\\"/g')
+          get_comments_query=$(cat .github/queries/getComments.graphql | tr -d '\n' | sed 's/"/\\\"/g')
 
           # Perform the searchDiscussions query
-          search_response=$(curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -H "Content-Type: application/json" -X POST -d "{\"query\": \"$search_discussions_query\", \"variables\": $search_discussions_variables}" https://api.github.com/graphql)
+          search_response=$(curl -s -H "Authorization: Bearer $GH_TOKEN" -H "Content-Type: application/json" -X POST -d "{\"query\": \"$search_discussions_query\", \"variables\": $search_discussions_variables}" https://api.github.com/graphql)
           discussion_nodes=$(echo "$search_response" | jq -r '.data.search.edges[].node.discussions.nodes[] | select(.title != null) | { id, title }')
 
           # Loop through the discussion nodes
@@ -39,22 +38,24 @@ jobs:
             codebundle=$(echo "$discussion_node" | jq -r '.title')
             discussion_id=$(echo "$discussion_node" | jq -r '.id')
 
-            if [[ -z $discussion_id ]]; then
-              echo "Creating new discussion for $codebundle"
-              curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -H "Content-Type: application/json" -X POST -d "{\"query\": \"$create_discussion_query\", \"variables\": {\"repo_id\": \"$repo_id\", \"codebundle\": \"$codebundle\"}}" https://api.github.com/graphql > /dev/null
-            else
+            if [[ "$codebundles" =~ (^|[[:space:]])"$codebundle"($|[[:space:]]) ]]; then
               echo "Discussion found for $codebundle with ID: $discussion_id"
 
               # # Fetch comments for the discussion
-              # comments_response=$(curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -H "Content-Type: application/json" -X POST -d "{\"query\": \"$get_comments_query\", \"variables\": {\"discussion_id\": \"$discussion_id\"}}" https://api.github.com/graphql)
+              # comments_response=$(curl -s -H "Authorization: Bearer $GH_TOKEN" -H "Content-Type: application/json" -X POST -d "{\"query\": \"$get_comments_query\", \"variables\": {\"discussion_id\": \"$discussion_id\"}}" https://api.github.com/graphql)
               # notes=$(echo "$comments_response" | jq -r '.data.node.comments.edges[].node.body')
 
               # if [[ -z $notes ]]; then
               #   echo "Adding note to discussion for $codebundle"
-              #   curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -H "Content-Type: application/json" -X POST -d "{\"query\": \"$add_comment_query\", \"variables\": {\"discussion_id\": \"$discussion_id\"}}" https://api.github.com/graphql > /dev/null
+              #   curl -s -H "Authorization: Bearer $GH_TOKEN" -H "Content-Type: application/json" -X POST -d "{\"query\": \"$add_comment_query\", \"variables\": {\"discussion_id\": \"$discussion_id\"}}" https://api.github.com/graphql > /dev/null
               # fi
+            else
+              echo "No matching discussion found for $codebundle"
+              echo "Creating new discussion for $codebundle"
+              curl -s -H "Authorization: Bearer $GH_TOKEN" -H "Content-Type: application/json" -X POST -d "{\"query\": \"$create_discussion_query\", \"variables\": {\"repo_id\": \"$repo_id\", \"codebundle\": \"$codebundle\"}}" https://api.github.com/graphql > /dev/null
             fi
           done
 
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CODEBUNDLES: ${{ steps.find_codebundles.outputs.codebundles }}

--- a/.github/workflows/update-discussion.yml
+++ b/.github/workflows/update-discussion.yml
@@ -20,6 +20,7 @@ jobs:
           echo "Searching discussions..."
           pwd
           ls -lha
+          tree .github
           # Read the queries from separate files
           search_discussions_query=$(cat .github/queries/searchDiscussions.graphql | tr -d '\n' | sed 's/"/\\\"/g')
           create_discussion_query=$(cat .github/queries/createDiscussion.graphql | tr -d '\n' | sed 's/"/\\\"/g')

--- a/.github/workflows/update-discussion.yml
+++ b/.github/workflows/update-discussion.yml
@@ -56,4 +56,4 @@ jobs:
           done
 
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.PAT }}

--- a/.github/workflows/update-discussion.yml
+++ b/.github/workflows/update-discussion.yml
@@ -37,7 +37,10 @@ jobs:
 
           # Loop through the discussion nodes
           for discussion_node in $discussion_nodes; do
+            echo "start loop"
+            echo "$discussion_node" | jq -r '.title'
             codebundle=$(echo "$discussion_node" | jq -r '.title')
+            echo "$discussion_node" | jq -r '.id'
             discussion_id=$(echo "$discussion_node" | jq -r '.id')
 
             if [[ "$codebundles" =~ (^|[[:space:]])"$codebundle"($|[[:space:]]) ]]; then

--- a/.github/workflows/update-discussion.yml
+++ b/.github/workflows/update-discussion.yml
@@ -24,7 +24,7 @@ jobs:
           get_comments_query=$(cat .github/queries/getComments.graphql | tr -d '\n' | sed 's/"/\\\"/g')
           
           # Temp for cleanup of messes
-          delete=false
+          delete=true
           delete_discusssion_query=$(cat .github/queries/deleteDiscussion.graphql | tr -d '\n' | sed 's/"/\\\"/g')
           codebundles=test
           

--- a/.github/workflows/update-discussion.yml
+++ b/.github/workflows/update-discussion.yml
@@ -1,9 +1,15 @@
 name: Check CodeBundle Discussions
 on:
   push:
+    branches:
+      - main
+  push:
+    branches-ignore:
+      - main
 
 jobs:
-  check-discussions:
+  check-discussions-on-main:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - name: Check for CodeBundles
@@ -38,3 +44,26 @@ jobs:
 
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  check-discussions-on-commit:
+    if: github.ref != 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for CodeBundles
+        id: find_codebundles
+        run: |
+          codebundles=$(find codebundles -type d -depth 1 -exec basename {} \;)
+          echo "::set-output name=codebundles::$codebundles"
+
+      - name: Search Discussions
+        id: search_discussions
+        run: |
+          codebundles=(${{ steps.find_codebundles.outputs.codebundles }})
+
+          for codebundle in "${codebundles[@]}"; do
+            discussion=$(gh api -X GET "/orgs/runwhen-contrib/discussions" --jq "[.[] | select(.title == \"$codebundle\")]")
+            if [[ -z $discussion ]]; then
+              echo "Creating new discussion for $codebundle"
+              gh api -X POST "/repos/runwhen-contrib/.github/discussions" -H "Accept: application/vnd.github.echo-preview+json" -d "{\"title\": \"$codebundle\"}"
+            elif [[ $(jq length <<< "$discussion") -gt 1 ]]; then
+              echo "Multiple discussions found for $codebundle. Skipping note addition."

--- a/.github/workflows/update-discussion.yml
+++ b/.github/workflows/update-discussion.yml
@@ -14,8 +14,9 @@ jobs:
       - name: Check if codebundle discussion exists
         id: find_and_create_codebundle_discussions
         run: |
-          codebundles=$(find codebundles -type d -exec basename {} \; | grep -v "codebundles")          
-
+          codebundles=$(find codebundles -type d -exec basename {} \; | grep -v "codebundles")   
+          # remove this after testing       
+          codebundles=test
           echo "Found codebundles: $codebundles"
           echo "Searching discussions..."
           pwd
@@ -63,7 +64,8 @@ jobs:
             if ! $found; then
               echo "No matching discussion found for $codebundle"
               echo "Creating new discussion for $codebundle"
-              curl -s -H "Authorization: Bearer $GH_TOKEN" -H "Content-Type: application/json" -X POST -d "{\"query\": \"$create_discussion_query\", \"variables\": {\"repo_id\": \"$repo_id\", \"codebundle\": \"$codebundle\"}}" https://api.github.com/graphql 
+              discussion_body=$codebundle
+              curl -s -H "Authorization: Bearer $GH_TOKEN" -H "Content-Type: application/json" -X POST -d "{\"query\": \"$create_discussion_query\", \"variables\": {\"repo_id\": \"org:runwhen-contrib\", \"codebundle\": \"$codebundle\",\"discussion_body\": \"$discussion_body\"}}" https://api.github.com/graphql 
             fi
           done
 

--- a/.github/workflows/update-discussion.yml
+++ b/.github/workflows/update-discussion.yml
@@ -16,7 +16,8 @@ jobs:
 
           echo "Found codebundles: $codebundles"
           echo "Searching discussions..."
-
+          pwd
+          ls -lha
           # Read the queries from separate files
           search_discussions_query=$(cat .github/queries/searchDiscussions.graphql | tr -d '\n' | sed 's/"/\\\"/g')
           create_discussion_query=$(cat .github/queries/createDiscussion.graphql | tr -d '\n' | sed 's/"/\\\"/g')

--- a/.github/workflows/update-discussion.yml
+++ b/.github/workflows/update-discussion.yml
@@ -36,7 +36,7 @@ jobs:
           echo $discussion_nodes
 
           # Loop through the discussion nodes
-          jq -c '.[]' $discussion_nodes | while read discussion_node; do
+          jq -c '.items[]' <<< "$discussion_nodes" | while read -r discussion_node; do
             echo "$discussion_node"
             codebundle=$(echo "$discussion_node" | jq -r '.title')
             discussion_id=$(echo "$discussion_node" | jq -r '.id')

--- a/.github/workflows/update-discussion.yml
+++ b/.github/workflows/update-discussion.yml
@@ -1,13 +1,6 @@
 name: Check CodeBundle Discussions
 on:
   push:
-    branches:
-      - main
-    paths-ignore:
-      - '**'
-  push:
-    branches-ignore:
-      - main
 
 jobs:
   check-discussions:

--- a/.github/workflows/update-discussion.yml
+++ b/.github/workflows/update-discussion.yml
@@ -17,6 +17,7 @@ jobs:
         run: |
           codebundles=$(find . -type d -name 'codebundles*' -exec basename {} \;)
           echo "::set-output name=codebundles::$codebundles"
+          echo $codebundles
 
       - name: Search Discussions
         id: search_discussions

--- a/.github/workflows/update-discussion.yml
+++ b/.github/workflows/update-discussion.yml
@@ -1,11 +1,4 @@
 name: Check CodeBundle Discussions
-on:
-  push:
-    branches:
-      - main
-  push:
-    branches-ignore:
-      - main
 
 jobs:
   check-discussions-on-main:

--- a/.github/workflows/update-discussion.yml
+++ b/.github/workflows/update-discussion.yml
@@ -15,32 +15,20 @@ jobs:
         id: find_and_create_codebundle_discussions
         run: |
           codebundles=$(find codebundles -type d -exec basename {} \; | grep -v "codebundles")   
-          # remove this after testing       
-          codebundles=test
           echo "Found codebundles: $codebundles"
           echo "Searching discussions..."
-          pwd
-          ls -lha
-          tree .github
-          cat .github/queries/searchDiscussions.graphql
           # Read the queries from separate files
           search_discussions_query=$(cat .github/queries/searchDiscussions.graphql | tr -d '\n' | sed 's/"/\\\"/g')
-          echo $search_discussions_query
           create_discussion_query=$(cat .github/queries/createDiscussion.graphql | tr -d '\n' | sed 's/"/\\\"/g')
           add_comment_query=$(cat .github/queries/addDiscussionComment.graphql | tr -d '\n' | sed 's/"/\\\"/g')
           get_comments_query=$(cat .github/queries/getComments.graphql | tr -d '\n' | sed 's/"/\\\"/g')
-          echo "done var fetch"
           # Perform the searchDiscussions query
           search_response=$(curl -s -H "Authorization: Bearer $GH_TOKEN" -H "Content-Type: application/json" -X POST -d "{\"query\": \"$search_discussions_query\", \"variables\": {\"searchQuery\": \"org:runwhen-contrib\"}}" https://api.github.com/graphql)
-          echo $search_response
           discussion_nodes=$(echo "$search_response" | jq -r '[.data.search.edges[].node.discussions.nodes[] | select(.title != null) | { id, title }] | { items: . }')
-          echo $discussion_nodes
 
           for codebundle in $codebundles; do
             found=false
-            echo $codebundle
             jq -c '.items[]' <<< "$discussion_nodes" | while read -r discussion_node; do
-              echo "$discussion_node"
               node_codebundle=$(echo "$discussion_node" | jq -r '.title')
               discussion_id=$(echo "$discussion_node" | jq -r '.id')
 

--- a/.github/workflows/update-discussion.yml
+++ b/.github/workflows/update-discussion.yml
@@ -23,7 +23,7 @@ jobs:
         id: search_discussions
         run: |
           codebundles=(${{ steps.find_codebundles.outputs.codebundles }})
-
+          echo $codebundles
           for codebundle in "${codebundles[@]}"; do
             discussion=$(gh api -X GET "/orgs/runwhen-contrib/discussions" --jq "[.[] | select(.title == \"$codebundle\")]")
             if [[ -z $discussion ]]; then

--- a/.github/workflows/update-discussion.yml
+++ b/.github/workflows/update-discussion.yml
@@ -66,7 +66,7 @@ jobs:
                 category_id="DIC_kwDOJo2Id84CXeeV"
                 # The repository_id that we need to use  
                 repo_id="R_kgDOJo2Idw"              
-                discussion_body="🌟Welcome to the community discussion for the troubleshooting commands defined in: $codebundle \n\n-> This discussion is intended to help grow the community\n-> Together, lets enhance the usefulness of the troubleshooting commands\n-> 🙌 Your participation is crucial! Share your valuable comments and questions here, and don't forget to give a thumbs up if you find the commands helpful and utilize them in your work."
+                discussion_body="🌟Welcome to the community discussion for the troubleshooting commands defined in: [$codebundle](https://github.com/rw-cli-codecollection/tree/main/codebundles/$codebundle) \n\n🌱This discussion is intended to help grow the community\n 🛠️Together, lets enhance the usefulness of the troubleshooting commands\n\n 🙌 Your participation is crucial! Share your valuable comments and questions here, and don't forget to give a thumbs up if you find the commands helpful and utilize them in your work."
                 curl -s -H "Authorization: Bearer $GH_TOKEN" -H "Content-Type: application/json" -X POST -d "{\"query\": \"$create_discussion_query\", \"variables\": {\"repo_id\": \"$repo_id\", \"codebundle\": \"$codebundle\",\"discussion_body\": \"$discussion_body\", \"category_id\": \"$category_id\"}}" https://api.github.com/graphql 
               fi
             fi

--- a/.github/workflows/update-discussion.yml
+++ b/.github/workflows/update-discussion.yml
@@ -35,24 +35,32 @@ jobs:
           discussion_nodes=$(echo "$search_response" | jq -r '[.data.search.edges[].node.discussions.nodes[] | select(.title != null) | { id, title }] | { items: . }')
           echo $discussion_nodes
 
-          # Loop through the discussion nodes
-          jq -c '.items[]' <<< "$discussion_nodes" | while read -r discussion_node; do
-            echo "$discussion_node"
-            codebundle=$(echo "$discussion_node" | jq -r '.title')
-            discussion_id=$(echo "$discussion_node" | jq -r '.id')
+          for codebundle in $codebundles; do
+            found=false
+            echo $codebundle
+            jq -c '.items[]' <<< "$discussion_nodes" | while read -r discussion_node; do
+              echo "$discussion_node"
+              node_codebundle=$(echo "$discussion_node" | jq -r '.title')
+              discussion_id=$(echo "$discussion_node" | jq -r '.id')
 
-            if [[ "$codebundles" =~ (^|[[:space:]])"$codebundle"($|[[:space:]]) ]]; then
-              echo "Discussion found for $codebundle with ID: $discussion_id"
+              if [[ "$codebundle" == "$node_codebundle" ]]; then
+                found=true
+                echo "Discussion found for $codebundle with ID: $discussion_id"
 
-              # # Fetch comments for the discussion
-              # comments_response=$(curl -s -H "Authorization: Bearer $GH_TOKEN" -H "Content-Type: application/json" -X POST -d "{\"query\": \"$get_comments_query\", \"variables\": {\"discussion_id\": \"$discussion_id\"}}" https://api.github.com/graphql)
-              # notes=$(echo "$comments_response" | jq -r '.data.node.comments.edges[].node.body')
+                # # Fetch comments for the discussion
+                # comments_response=$(curl -s -H "Authorization: Bearer $GH_TOKEN" -H "Content-Type: application/json" -X POST -d "{\"query\": \"$get_comments_query\", \"variables\": {\"discussion_id\": \"$discussion_id\"}}" https://api.github.com/graphql)
+                # notes=$(echo "$comments_response" | jq -r '.data.node.comments.edges[].node.body')
 
-              # if [[ -z $notes ]]; then
-              #   echo "Adding note to discussion for $codebundle"
-              #   curl -s -H "Authorization: Bearer $GH_TOKEN" -H "Content-Type: application/json" -X POST -d "{\"query\": \"$add_comment_query\", \"variables\": {\"discussion_id\": \"$discussion_id\"}}" https://api.github.com/graphql > /dev/null
-              # fi
-            else
+                # if [[ -z $notes ]]; then
+                #   echo "Adding note to discussion for $codebundle"
+                #   curl -s -H "Authorization: Bearer $GH_TOKEN" -H "Content-Type: application/json" -X POST -d "{\"query\": \"$add_comment_query\", \"variables\": {\"discussion_id\": \"$discussion_id\"}}" https://api.github.com/graphql > /dev/null
+                # fi
+
+                break
+              fi
+            done
+
+            if ! $found; then
               echo "No matching discussion found for $codebundle"
               echo "Creating new discussion for $codebundle"
               curl -s -H "Authorization: Bearer $GH_TOKEN" -H "Content-Type: application/json" -X POST -d "{\"query\": \"$create_discussion_query\", \"variables\": {\"repo_id\": \"$repo_id\", \"codebundle\": \"$codebundle\"}}" https://api.github.com/graphql > /dev/null

--- a/.github/workflows/update-discussion.yml
+++ b/.github/workflows/update-discussion.yml
@@ -22,6 +22,12 @@ jobs:
           create_discussion_query=$(cat .github/queries/createDiscussion.graphql | tr -d '\n' | sed 's/"/\\\"/g')
           add_comment_query=$(cat .github/queries/addDiscussionComment.graphql | tr -d '\n' | sed 's/"/\\\"/g')
           get_comments_query=$(cat .github/queries/getComments.graphql | tr -d '\n' | sed 's/"/\\\"/g')
+          
+          # Temp for cleanup of messes
+          delete=true
+          delete_discusssion_query=$(cat .github/queries/deleteDiscussion.graphql | tr -d '\n' | sed 's/"/\\\"/g')
+          
+          
           # Perform the searchDiscussions query
           search_response=$(curl -s -H "Authorization: Bearer $GH_TOKEN" -H "Content-Type: application/json" -X POST -d "{\"query\": \"$search_discussions_query\", \"variables\": {\"searchQuery\": \"org:runwhen-contrib\"}}" https://api.github.com/graphql)
           discussion_nodes=$(echo "$search_response" | jq -r '[.data.search.edges[].node.discussions.nodes[] | select(.title != null) | { id, title }] | { items: . }')
@@ -35,6 +41,9 @@ jobs:
               if [[ "$codebundle" == "$node_codebundle" ]]; then
                 found=true
                 echo "Discussion found for $codebundle with ID: $discussion_id"
+                if [[ "$delete" == "true" ]]; then
+                  url -s -H "Authorization: Bearer $GH_TOKEN" -H "Content-Type: application/json" -X POST -d "{\"query\": \"$delete_discusssion_query\", \"variables\": {\"discussion_id\": \"$discussion_id\" }}" https://api.github.com/graphql 
+                fi
 
                 # # Fetch comments for the discussion
                 # comments_response=$(curl -s -H "Authorization: Bearer $GH_TOKEN" -H "Content-Type: application/json" -X POST -d "{\"query\": \"$get_comments_query\", \"variables\": {\"discussion_id\": \"$discussion_id\"}}" https://api.github.com/graphql)

--- a/.github/workflows/update-discussion.yml
+++ b/.github/workflows/update-discussion.yml
@@ -1,6 +1,7 @@
 name: Check CodeBundle Discussions
-on:
+on:  
   workflow_dispatch:
+  push:
 jobs:
   check-discussions-on-main:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-discussion.yml
+++ b/.github/workflows/update-discussion.yml
@@ -1,7 +1,8 @@
 name: Check CodeBundle Discussions
-on:
-  workflow_dispatch:
+on: 
   push:
+    branches:
+      - master
 jobs:
   check-discussions-on-main:
     runs-on: ubuntu-latest
@@ -24,9 +25,9 @@ jobs:
           get_comments_query=$(cat .github/queries/getComments.graphql | tr -d '\n' | sed 's/"/\\\"/g')
           
           # Temp for cleanup of messes
-          delete=true
+          delete=false
           delete_discusssion_query=$(cat .github/queries/deleteDiscussion.graphql | tr -d '\n' | sed 's/"/\\\"/g')
-          codebundles=test
+          # codebundles=test
           
           # Perform the searchDiscussions query
           search_response=$(curl -s -H "Authorization: Bearer $GH_TOKEN" -H "Content-Type: application/json" -X POST -d "{\"query\": \"$search_discussions_query\", \"variables\": {\"searchQuery\": \"org:runwhen-contrib\"}}" https://api.github.com/graphql)
@@ -66,7 +67,7 @@ jobs:
                 category_id="DIC_kwDOJo2Id84CXeeV"
                 # The repository_id that we need to use  
                 repo_id="R_kgDOJo2Idw"              
-                discussion_body="🌟Welcome to the community discussion for the troubleshooting commands defined in: [$codebundle](https://github.com/runwhen-contrib/rw-cli-codecollection/tree/main/codebundles/$codebundle) \n\n🌱This discussion is intended to help grow the community\n🛠️Together, lets enhance the usefulness of the troubleshooting commands\n\n🙌 Your participation is crucial! Share your valuable comments and questions here, and don't forget to give a thumbs up if you find the commands helpful and utilize them in your work."
+                discussion_body="🌟Welcome to the community discussion for the troubleshooting commands defined in: [$codebundle](https://github.com/runwhen-contrib/rw-cli-codecollection/tree/main/codebundles/$codebundle) \n\n🌱This discussion is intended to help grow the community\n🛠️Together, lets enhance the usefulness of these troubleshooting commands\n🙌 Your participation is crucial! Share your valuable comments and questions here, and don't forget to give a thumbs up if you find the commands helpful and utilize them in your work."
                 curl -s -H "Authorization: Bearer $GH_TOKEN" -H "Content-Type: application/json" -X POST -d "{\"query\": \"$create_discussion_query\", \"variables\": {\"repo_id\": \"$repo_id\", \"codebundle\": \"$codebundle\",\"discussion_body\": \"$discussion_body\", \"category_id\": \"$category_id\"}}" https://api.github.com/graphql 
               fi
             fi

--- a/.github/workflows/update-discussion.yml
+++ b/.github/workflows/update-discussion.yml
@@ -67,7 +67,7 @@ jobs:
               discussion_body=$codebundle
               category_id="DIC_kwDOJo2Id84CXeeV"  #Troubleshooting Commands Category
               repo_id="R_kgDOJo2Idw"              # The repository_id that we need to use
-              curl -s -H "Authorization: Bearer $GH_TOKEN" -H "Content-Type: application/json" -X POST -d "{\"query\": \"$create_discussion_query\", \"variables\": {\"repo_id\": \"$repo_id\", \"codebundle\": \"$codebundle\",\"discussion_body\": \"$discussion_body\"}}" https://api.github.com/graphql 
+              curl -s -H "Authorization: Bearer $GH_TOKEN" -H "Content-Type: application/json" -X POST -d "{\"query\": \"$create_discussion_query\", \"variables\": {\"repo_id\": \"$repo_id\", \"codebundle\": \"$codebundle\",\"discussion_body\": \"$discussion_body\", \"category_id\": \"$category_id\"}}" https://api.github.com/graphql 
             fi
           done
 

--- a/.github/workflows/update-discussion.yml
+++ b/.github/workflows/update-discussion.yml
@@ -1,4 +1,8 @@
 name: Check CodeBundle Discussions
+on: 
+  push:
+    branches-ignore:
+      - main
 
 jobs:
   check-discussions-on-main:


### PR DESCRIPTION
This adds a workflow to create a github discussion for a new codebundle folder. 

Some of the code is not used yet, we might have future desire to expand the functionality, but for now this just checks if it exists, and if not, creates it. 

Beware of the #Temp for cleamup of messes header, it can be used to clean up a mess if we've created a lot of discussions incorrectly, but it's most likely not that helpful once we have a bunch of discussions with active comments. 