### PR TITLE
Initial e2e CI for codebundles

### DIFF
--- a/.github/scripts/e2e.py
+++ b/.github/scripts/e2e.py
@@ -1,0 +1,247 @@
+import requests, argparse, subprocess, os, logging, time
+from collections import OrderedDict
+
+
+logger = logging.getLogger(__name__)
+
+SYMBOL_PASS = "\u2705"
+SYMBOL_FAIL = "\u274C"
+api_token = None
+session = None
+SESSION_TAGS = ["testing"]
+POLL_DURATION = 60
+
+
+def get_codebundles_in_last_commit() -> set[str]:
+    command = "git show --name-only | grep codebundles | grep .robot || true"
+    process = subprocess.Popen(command, stdout=subprocess.PIPE, shell=True)
+    output, _ = process.communicate()
+    stdout_string = output.decode("utf-8").strip()
+    codebundles: set[str] = set([line.split("/")[1] for line in stdout_string.split("\n")])
+    return codebundles
+
+
+def get_workspace_codebundles(base_url, workspace_name) -> set[str]:
+    codebundle_names: set[str] = []
+    workspace_entities: list[dict] = []
+    cb_stats_rsp = session.get(f"{base_url}/workspaces/{workspace_name}/codebundle-stats")
+    if not cb_stats_rsp.status_code == 200:
+        raise AssertionError(f"Received non-200 response: {cb_stats_rsp}")
+    cb_stats = cb_stats_rsp.json()
+    workspace_entities = cb_stats["taskSets"]  # + cb_stats["slis"]
+    codebundle_names = set([wse["codeBundleName"] for wse in workspace_entities])
+    return codebundle_names
+
+
+def create_session(user, token, base_url) -> None:
+    global api_token
+    global session
+    token_url = f"{base_url}/token/"
+    rsp = requests.post(
+        token_url,
+        json={"username": user, "password": token},
+        headers={"Accept": "application/json"},
+    )
+    if not rsp.status_code == 200:
+        raise AssertionError(f"Received non-200 response: {rsp.json()}")
+    api_token = rsp.json()["access"]
+    session = requests.Session()
+    session.headers.update(
+        {
+            "Authorization": f"Bearer {api_token}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+    )
+
+
+def run_codebundles_in_workspace(base_url, workspace_name, session_name, cb_list: set[str]) -> {}:
+    tasks_running = {}
+    slxs_rsp = session.get(f"{base_url}/workspaces/{workspace_name}/slxs")
+    runsessions_rsp = session.get(f"{base_url}/workspaces/{workspace_name}/runsessions")
+    slxs: list = []
+    slxs = [slx["name"] for slx in slxs_rsp.json()["results"]]
+    tasksets: list = []
+    for slx in slxs:
+        shortname = slx.split("--")[1]
+        taskset_rsp = session.get(f"{base_url}/workspaces/{workspace_name}/slxs/{shortname}/runbook")
+        if taskset_rsp.status_code == 200 and taskset_rsp.json():
+            taskset_data = taskset_rsp.json()
+            cb_name = None
+            if "spec" in taskset_data and "codeBundle" in taskset_data["spec"]:
+                cb_name = taskset_data["spec"]["codeBundle"]["pathToRobot"].split("/")[1]
+            if cb_name and cb_name in cb_list:
+                tasks_running[slx] = taskset_data
+    # prep for runsession request
+    rrs = [{"slxName": slx, "taskTitles": ["*"]} for slx in tasks_running.keys()]
+    runsession_json = {
+        "runRequests": rrs,
+        "generateName": session_name,
+        "tags": ["testing"],
+        # "alias": {"key": "src", "value": "testing"},  # uncomment to dedupe with alias
+    }
+    # print(f"rs post: {runsession_json}")
+    rs_rsp = session.post(f"{base_url}/workspaces/{workspace_name}/runsessions", json=runsession_json)
+    if not (rs_rsp.status_code == 200 or rs_rsp.status_code == 201):
+        raise AssertionError(
+            f"Received non-200/201 response during runsession post: {rs_rsp.status_code} {rs_rsp.json()}"
+        )
+    tasks_running["runsession_data"] = rs_rsp.json()
+    return tasks_running
+
+
+def poll_runsessions_complete(task_data, base_url, workspace_name) -> bool:
+    # get the name of the runsession we just created to house tasks
+    session_display_name = None
+    aliases = task_data["runsession_data"]["aliases"]
+    for alias in aliases:
+        if alias["key"] == "displayName":
+            session_display_name = alias["value"]
+    # now get all live runsessions and find ours
+    ci_runsession = None
+    runsessions_rsp = session.get(f"{base_url}/workspaces/{workspace_name}/runsessions")
+    if runsessions_rsp.status_code != 200:
+        raise AssertionError(f"Received non-200 response during runsession get: {rs_rsp.status_code} {rs_rsp.json()}")
+    for rsr in runsessions_rsp.json()["results"]:
+        aliases = rsr["aliases"]
+        for alias in aliases:
+            if alias["key"] == "displayName" and alias["value"] == session_display_name:
+                ci_runsession = rsr
+    if not ci_runsession or not session_display_name:
+        print(f"No CI runsession or display name found: {ci_runsession}, {session_display_name}")
+        return False
+    for rr in ci_runsession["runRequests"]:
+        short_name = rr["slxShortName"]
+        # somehow ran an empty SLX
+        if not rr["passedTitles"] and not rr["failedTitles"] and not rr["skippedTitles"] and rr["responseTime"]:
+            continue
+        # not finished
+        if rr["responseTime"] is None:
+            print(f"Runrequest from {short_name} under {session_display_name} is not finished, waiting...")
+            return False
+        # completed runrequest
+        # if rr["responseTime"] is not None:
+        # if we make it past all rr short circuit returns then assume we iterated over results and it completed
+    return True
+
+
+def get_runsession_ci_results(task_data, base_url, workspace_name) -> dict:
+    results: dict = {}
+    # get the name of the runsession we just created to house tasks
+    session_display_name = None
+    aliases = task_data["runsession_data"]["aliases"]
+    for alias in aliases:
+        if alias["key"] == "displayName":
+            session_display_name = alias["value"]
+    # now get all live runsessions and find ours
+    ci_runsession = None
+    runsessions_rsp = session.get(f"{base_url}/workspaces/{workspace_name}/runsessions")
+    if runsessions_rsp.status_code != 200:
+        raise AssertionError(f"Received non-200 response during runsession get: {rs_rsp.status_code} {rs_rsp.json()}")
+    for rsr in runsessions_rsp.json()["results"]:
+        aliases = rsr["aliases"]
+        for alias in aliases:
+            if alias["key"] == "displayName" and alias["value"] == session_display_name:
+                ci_runsession = rsr
+    if not ci_runsession or not session_display_name:
+        return results
+    for rr in ci_runsession["runRequests"]:
+        # somehow ran an empty SLX
+        if not rr["passedTitles"] and not rr["failedTitles"] and not rr["skippedTitles"] and rr["responseTime"]:
+            continue
+        # not finished
+        if rr["responseTime"] is None:
+            return False
+        # completed runrequest
+        if rr["responseTime"] is not None:
+            memos = rr["memo"]
+            for memo in memos:
+                if "fail" in memo and "pass" in memo:
+                    results[rr["slxShortName"]] = {}
+                    results[rr["slxShortName"]]["pass"] = memo["pass"]
+                    results[rr["slxShortName"]]["fail"] = memo["fail"]
+    return results
+
+
+def decorate_results(base_url, workspace_name, results: dict) -> dict:
+    # print(results)
+    for slx in results.keys():
+        taskset_rsp = session.get(f"{base_url}/workspaces/{workspace_name}/slxs/{slx}/runbook")
+        if taskset_rsp.status_code != 200:
+            raise AssertionError(
+                f"Received non-200 response during runsession get: {taskset_rsp.status_code} {taskset_rsp.json()}"
+            )
+        taskset_data = taskset_rsp.json()
+        results[slx]["codebundle"] = None
+        if "spec" in taskset_data and "codeBundle" in taskset_data["spec"]:
+            cb_name = taskset_data["spec"]["codeBundle"]["pathToRobot"].split("/")[1]
+            results[slx]["codebundle"] = cb_name
+    return results
+
+
+def process_results(workspace_name, results) -> None:
+    exit_failure = False
+    print(f"CI Result in workspace {workspace_name}:")
+    for slx, test_results in results.items():
+        passes = test_results["pass"]
+        fails = test_results["fail"]
+        cb_name = test_results["codebundle"]
+        has_fails = fails > 0
+        if has_fails:
+            exit_failure
+        print(
+            f'{f"{cb_name} results in SLX {slx}":<128} ...    Passed: {passes}, Failed: {fails} {SYMBOL_FAIL if has_fails else SYMBOL_PASS}'
+        )
+    if exit_failure:
+        exit(1)
+    exit(0)
+
+
+if __name__ == "__main__":
+    USER: str = os.environ.get("API_USER")
+    TOKEN: str = os.environ.get("API_TOKEN")
+    if not USER or not TOKEN:
+        print("API User not provided - please set API_USER and API_TOKEN environment variables")
+    parser = argparse.ArgumentParser(
+        description="The workspace used for E2E testing. A session will be created and used to run recently changed codebundles."
+    )
+    required_named = parser.add_argument_group("required named arguments")
+    required_named.add_argument(
+        "--e2e_workspace", help="The workspace used to create a testing session and search for runnable codebundles."
+    )
+    required_named.add_argument("--papi_url", help="The url of the public API used to make requests against.")
+    parser.add_argument(
+        "--session_name", default="ci-session", help="The name of the runsession to organize results under."
+    )
+    args = parser.parse_args(["-h"])
+    print(f"Current Arguments: {args}")
+    # TODO: runall config
+    # TODO: trace python deps and run dependent codebundles
+    create_session(USER, TOKEN, args.papi_url)
+    changed_codebundles: list[str] = []
+    changed_codebundles = get_codebundles_in_last_commit()
+    print("Found the following codebundles to test:")
+    print("\n".join(changed_codebundles))
+    print("...")
+    codebundles_in_ws: list[str] = []
+    codebundles_in_ws = get_workspace_codebundles(args.papi_url, args.e2e_workspace)
+    print(f"Found the following taskset codebundles in the {args.e2e_workspace} workspace:")
+    print("\n".join(codebundles_in_ws))
+    print("...")
+    codebundles_to_run: set[str] = set([cb for cb in changed_codebundles if cb in codebundles_in_ws])
+    # codebundles_to_run = set(["k8s-redis-healthcheck"])
+    print("Queueing following codebundles for testing:")
+    print("\n".join(codebundles_to_run))
+    print("...")
+    task_data = run_codebundles_in_workspace(args.papi_url, args.e2e_workspace, args.session_name, codebundles_to_run)
+    print("Beginning polling for results")
+    while not poll_runsessions_complete(task_data, args.papi_url, args.e2e_workspace):
+        print("...")
+        time.sleep(POLL_DURATION)
+    print("CI Runsession finished - collecting results...")
+    print("...")
+    ci_results = get_runsession_ci_results(task_data, args.papi_url, args.e2e_workspace)
+    # decorate results with codebundles
+    ci_results = decorate_results(args.papi_url, args.e2e_workspace, ci_results)
+    # display the results and exit the script appropriately so that CI can determine the overall status
+    process_results(args.e2e_workspace, ci_results)

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,37 @@
+name: Run E2E Tests
+on:
+  workflow_dispatch:
+    inputs:
+      runall:
+        type: choice
+        description: Test all codebundles found in workspace, regardless of changes?
+        options: 
+          - no
+          - yes
+  push: 
+    branches: 
+      - main
+    paths: 
+      - "codebundles/**.robot"
+# TODO: add traced python dependency support
+
+jobs:
+  update-readme:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with: 
+          ref: ${{ github.event.pull_request.base.ref }}
+      - name: Run E2E Tests
+        env:
+          API_USER: ${{ secrets.API_USER }}
+          API_TOKEN: ${{ secrets.API_TOKEN }}
+          API_URL: https://backend-services.dev.project-468.com/api/v3
+          WORKSPACE: ob-1-small
+        run: |
+          if [ "${{ github.event.inputs.runall }}" = "yes" ]; then
+            python e2e.py --e2e_workspace=$WORKSPACE --papi_url=$API_URL --runall
+          else
+            python e2e.py --e2e_workspace=$WORKSPACE --papi_url=$API_URL
+          fi
+          

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,6 +22,9 @@ jobs:
       - uses: actions/checkout@v3
         with: 
           ref: ${{ github.event.pull_request.base.ref }}
+      - name: install deps
+        run: |
+          pip install requests
       - name: Run E2E Tests
         env:
           API_USER: ${{ secrets.API_USER }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -34,8 +34,8 @@ jobs:
           WORKSPACE: ob-1-small
         run: |
           if [ "${{ github.event.inputs.runall }}" = "yes" ]; then
-            python e2e.py --e2e_workspace=$WORKSPACE --papi_url=$API_URL --runall
+            cd .github/scripts/ && python e2e.py --e2e_workspace=$WORKSPACE --papi_url=$API_URL --runall
           else
-            python e2e.py --e2e_workspace=$WORKSPACE --papi_url=$API_URL
+            cd .github/scripts/ && python e2e.py --e2e_workspace=$WORKSPACE --papi_url=$API_URL
           fi
           

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -16,8 +16,9 @@ on:
 # TODO: add traced python dependency support
 
 jobs:
-  update-readme:
+  run-e2e:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3
         with: 

--- a/codebundles/k8s-redis-healthcheck/runbook.robot
+++ b/codebundles/k8s-redis-healthcheck/runbook.robot
@@ -1,8 +1,9 @@
 *** Settings ***
-Documentation       This taskset collects information on your redis workload in your Kubernetes cluster and 
+Documentation       This taskset collects information on your redis workload in your Kubernetes cluster and raises issues when health checks fail.
 Metadata            Author    jon-funk
 Metadata            Display Name    Kubernetes Redis Healthcheck
 Metadata            Supports    Kubernetes,AKS,EKS,GKE,OpenShift,Redis
+
 Library             BuiltIn
 Library             RW.Core
 Library             RW.CLI
@@ -12,6 +13,58 @@ Library             DateTime
 Library             Collections
 
 Suite Setup         Suite Initialization
+
+
+*** Tasks ***
+Ping Redis Workload
+    [Documentation]    Verifies that a PING can be peformed against the redis workload.
+    [Tags]    redis    cli    ping    pong    alive    probe    ready
+    ${rsp}=    RW.CLI.Run Cli
+    ...    cmd=${KUBERNETES_DISTRIBUTION_BINARY} exec deployment/${DEPLOYMENT_NAME} --context=${CONTEXT} -n ${NAMESPACE} -- redis-cli PING
+    ...    render_in_commandlist=true
+    ...    env=${env}
+    ...    secret_file__kubeconfig=${kubeconfig}
+    RW.CLI.Parse Cli Output By Line
+    ...    rsp=${rsp}
+    ...    set_severity_level=2
+    ...    set_issue_expected=The Redis workload returned a PONG in response to PING
+    ...    set_issue_actual=The Redis workload was unable to properly repond to the PING request
+    ...    set_issue_title=Redis PING Failed In Namespace ${NAMESPACE} For Redis Deployment ${DEPLOYMENT_NAME}
+    ...    set_issue_details=Found $_line in namespace ${NAMESPACE}\nCheck if the redis workload is healthy and available. Attempt to run a 'redis-cli PING' directly on the workload and verify the response which should be PONG.
+    ...    _line__raise_issue_if_ncontains=PONG
+    RW.Core.Add Pre To Report    Redis Response:\n${rsp.stdout}
+    ${history}=    RW.CLI.Pop Shell History
+    RW.Core.Add Pre To Report    Commands Used: ${history}
+
+Verify Redis Read Write Operation
+    [Documentation]    Attempts to perform a write and read operation on the redis workload, checking that a key can be set, incremented, and read from.
+    [Tags]    redis    cli    increment    health    check    read    write
+    ${set_op}=    RW.CLI.Run Cli
+    ...    cmd=${KUBERNETES_DISTRIBUTION_BINARY} exec deployment/${DEPLOYMENT_NAME} --context=${CONTEXT} -n ${NAMESPACE} -- redis-cli SET ${REDIS_HEALTHCHECK_KEY} 0
+    ...    render_in_commandlist=true
+    ...    env=${env}
+    ...    secret_file__kubeconfig=${kubeconfig}
+    ${incr_op}=    RW.CLI.Run Cli
+    ...    cmd=${KUBERNETES_DISTRIBUTION_BINARY} exec deployment/${DEPLOYMENT_NAME} --context=${CONTEXT} -n ${NAMESPACE} -- redis-cli INCR ${REDIS_HEALTHCHECK_KEY}
+    ...    render_in_commandlist=true
+    ...    env=${env}
+    ...    secret_file__kubeconfig=${kubeconfig}
+    ${get_op}=    RW.CLI.Run Cli
+    ...    cmd=${KUBERNETES_DISTRIBUTION_BINARY} exec deployment/${DEPLOYMENT_NAME} --context=${CONTEXT} -n ${NAMESPACE} -- redis-cli GET ${REDIS_HEALTHCHECK_KEY}
+    ...    render_in_commandlist=true
+    ...    env=${env}
+    ...    secret_file__kubeconfig=${kubeconfig}
+    RW.CLI.Parse Cli Output By Line
+    ...    rsp=${get_op}
+    ...    set_severity_level=1
+    ...    set_issue_expected=The redis workload successfully incremented the healthcheck key.
+    ...    set_issue_actual=The redis workload failed to increment the key as expected.
+    ...    set_issue_title=Redis Read Write Operation Failure In Namespace ${NAMESPACE} For Redis Deployment ${DEPLOYMENT_NAME}
+    ...    set_issue_details=Found $_line in namespace ${NAMESPACE}\nCheck the PVC that the redis workload depends on and verify it's healthy. Try use 'redis-cli INCR ${REDIS_HEALTHCHECK_KEY}' yourself on the workload.
+    ...    _line__raise_issue_if_neq=1
+    RW.Core.Add Pre To Report    Redis Response For Key ${REDIS_HEALTHCHECK_KEY}:${get_op.stdout}
+    ${history}=    RW.CLI.Pop Shell History
+    RW.Core.Add Pre To Report    Commands Used: ${history}
 
 
 *** Keywords ***
@@ -39,7 +92,7 @@ Suite Initialization
     ...    example=my-main-cluster
     ${NAMESPACE}=    RW.Core.Import User Variable    NAMESPACE
     ...    type=string
-    ...    description=The name of the namespace to search.   
+    ...    description=The name of the namespace to search.
     ...    pattern=\w*
     ...    example=otel-demo
     ...    default=
@@ -62,54 +115,3 @@ Suite Initialization
     Set Suite Variable    ${DEPLOYMENT_NAME}    ${DEPLOYMENT_NAME}
     Set Suite Variable    ${REDIS_HEALTHCHECK_KEY}    ${REDIS_HEALTHCHECK_KEY}
     Set Suite Variable    ${env}    {"KUBECONFIG":"./${kubeconfig.key}"}
-
-*** Tasks ***
-Ping Redis Workload
-    [Documentation]    Verifies that a PING can be peformed against the redis workload.
-    [Tags]    Redis    CLI    Ping    Pong    Alive    Probe    Ready
-    ${rsp}=    RW.CLI.Run Cli
-    ...    cmd=${KUBERNETES_DISTRIBUTION_BINARY} exec deployment/${DEPLOYMENT_NAME} --context=${CONTEXT} -n ${NAMESPACE} -- redis-cli PING
-    ...    render_in_commandlist=true
-    ...    env=${env}
-    ...    secret_file__kubeconfig=${kubeconfig}
-    RW.CLI.Parse Cli Output By Line
-    ...    rsp=${rsp}
-    ...    set_severity_level=2
-    ...    set_issue_expected=The Redis workload returned a PONG in response to PING
-    ...    set_issue_actual=The Redis workload was unable to properly repond to the PING request
-    ...    set_issue_title=Redis PING Failed In Namespace ${NAMESPACE} For Redis Deployment ${DEPLOYMENT_NAME}
-    ...    set_issue_details=Found $_line in namespace ${NAMESPACE}\nCheck if the redis workload is healthy and available. Attempt to run a 'redis-cli PING' directly on the workload and verify the response which should be PONG.
-    ...    _line__raise_issue_if_ncontains=PONG
-    RW.Core.Add Pre To Report    Redis Response:\n${rsp.stdout}
-    ${history}=    RW.CLI.Pop Shell History
-    RW.Core.Add Pre To Report    Commands Used: ${history}
-
-Verify Redis Read Write Operation
-    [Documentation]    Attempts to perform a write and read operation on the redis workload, checking that a key can be set, incremented, and read from.
-    [Tags]    Redis    CLI    Increment    Health    Check    Read    Write
-    ${set_op}=    RW.CLI.Run Cli
-    ...    cmd=${KUBERNETES_DISTRIBUTION_BINARY} exec deployment/${DEPLOYMENT_NAME} --context=${CONTEXT} -n ${NAMESPACE} -- redis-cli SET ${REDIS_HEALTHCHECK_KEY} 0
-    ...    render_in_commandlist=true
-    ...    env=${env}
-    ...    secret_file__kubeconfig=${kubeconfig}
-    ${incr_op}=    RW.CLI.Run Cli
-    ...    cmd=${KUBERNETES_DISTRIBUTION_BINARY} exec deployment/${DEPLOYMENT_NAME} --context=${CONTEXT} -n ${NAMESPACE} -- redis-cli INCR ${REDIS_HEALTHCHECK_KEY}
-    ...    render_in_commandlist=true
-    ...    env=${env}
-    ...    secret_file__kubeconfig=${kubeconfig}
-    ${get_op}=    RW.CLI.Run Cli
-    ...    cmd=${KUBERNETES_DISTRIBUTION_BINARY} exec deployment/${DEPLOYMENT_NAME} --context=${CONTEXT} -n ${NAMESPACE} -- redis-cli GET ${REDIS_HEALTHCHECK_KEY}
-    ...    render_in_commandlist=true
-    ...    env=${env}
-    ...    secret_file__kubeconfig=${kubeconfig}
-    RW.CLI.Parse Cli Output By Line
-    ...    rsp=${get_op}
-    ...    set_severity_level=1
-    ...    set_issue_expected=The redis workload successfully incremented the healthcheck key.
-    ...    set_issue_actual=The redis workload failed to increment the key as expected.
-    ...    set_issue_title=Redis Read Write Operation Failure In Namespace ${NAMESPACE} For Redis Deployment ${DEPLOYMENT_NAME}
-    ...    set_issue_details=Found $_line in namespace ${NAMESPACE}\nCheck the PVC that the redis workload depends on and verify it's healthy. Try use 'redis-cli INCR ${REDIS_HEALTHCHECK_KEY}' yourself on the workload.
-    ...    _line__raise_issue_if_neq=1
-    RW.Core.Add Pre To Report    Redis Response For Key ${REDIS_HEALTHCHECK_KEY}:${get_op.stdout}
-    ${history}=    RW.CLI.Pop Shell History
-    RW.Core.Add Pre To Report    Commands Used: ${history}

--- a/codebundles/k8s-vault-healthcheck/runbook.robot
+++ b/codebundles/k8s-vault-healthcheck/runbook.robot
@@ -33,7 +33,7 @@ Fetch Vault CSI Driver Logs
 
 Get Vault CSI Driver Warning Events
     [Documentation]    Fetches warning-type events related to the vault CSI driver.
-    [Tags]    events    workloads    errors    warnings    get    vault    csi    driver
+    [Tags]    events    errors    warnings    get    vault    csi    driver
     ${events}=    RW.CLI.Run Cli
     ...    cmd=${KUBERNETES_DISTRIBUTION_BINARY} get events --field-selector type=Warning --context ${CONTEXT} -n ${NAMESPACE} | grep -i "vault-csi-provider" || true
     ...    env=${env}


### PR DESCRIPTION
- adds script to test applicable recently changed codebundles in a target workspace. They are chosen to run if: they were changed in the PR, and they are used in the target workspace
- Contains a runall option, with a passthrough config via workflow dispatch for manual call via the github UI
- A codebundle is considered a pass/succeed if it runs fully without throwing any exceptions
- polls results every 60 seconds until all tasksets finish, times out after 10m

Sample output:

![cb-ci](https://github.com/runwhen-contrib/rw-cli-codecollection/assets/28266570/a746f849-e6e5-441f-9fd3-805192b81854)


TODO:
- dynamic ephemeral workspaces
- tracing python dependencies so that python keyword changes initiate tests for dependent codebundles
- QA on issue submission (difficult but an endgoal for a mature pipeline far in the future)

The above are 'nice-to-haves' as I feel this initial pass should get us most of the way there.
