### PR TITLE
add escape characters to text output of ss replica

### DIFF
--- a/codebundles/k8s-statefulset-healthcheck/runbook.robot
+++ b/codebundles/k8s-statefulset-healthcheck/runbook.robot
@@ -68,7 +68,7 @@ Check StatefulSet Replicas
     ...    stuck
     ...    pods
     RW.CLI.Run Cli
-    ...    cmd=${KUBERNETES_DISTRIBUTION_BINARY} get statefulset -n ${NAMESPACE} -o json --context ${CONTEXT} | jq -r '.items[] | select(.status.availableReplicas < .status.replicas) | "---\nStatefulSet Name: " + (.metadata.name|tostring) + "\nDesired Replicas: " + (.status.replicas|tostring) + "\nAvailable Replicas: " + (.status.availableReplicas|tostring)'
+    ...    cmd=${KUBERNETES_DISTRIBUTION_BINARY} get statefulset -n ${NAMESPACE} -o json --context ${CONTEXT} | jq -r '.items[] | select(.status.availableReplicas < .status.replicas) | "---\\nStatefulSet Name: " + (.metadata.name|tostring) + "\\nDesired Replicas: " + (.status.replicas|tostring) + "\\nAvailable Replicas: " + (.status.availableReplicas|tostring)'
     ...    target_service=${kubectl}
     ...    env=${env}
     ...    secret_file__kubeconfig=${kubeconfig}


### PR DESCRIPTION
Add's some escape characters to the \n output; in the current form this breaks the command rendering in runwhen-local docs