### PR TITLE
Implement Error Bingo mapping for nextsteps generation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,5 @@ RUN chown 1000:0 -R $WORKDIR
 RUN chown 1000:0 -R /app/codecollection
 
 # Set the user to $USER
+ENV USER "python"
 USER python

--- a/codebundles/cmd-test/getdeploys.sh
+++ b/codebundles/cmd-test/getdeploys.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+myns=$NAMESPACE
+myctxt=$CONTEXT
+kubectl get deployments -n "$myns" --context $myctxt -ojson | jq -r '.items[].metadata.name'

--- a/codebundles/cmd-test/runbook.robot
+++ b/codebundles/cmd-test/runbook.robot
@@ -7,6 +7,7 @@ Library             RW.Core
 Library             RW.platform
 Library             OperatingSystem
 Library             RW.CLI
+Library             RW.NextSteps
 
 Suite Setup         Suite Initialization
 
@@ -24,7 +25,7 @@ Run CLI Command
     RW.Core.Add Pre To Report    Command Stderr:\n${rsp.stderr}
 
 Run Bash File
-    [Documentation]    Runs a bash file to
+    [Documentation]    Runs a bash file to verify script passthrough works
     [Tags]    file    script
     ${rsp}=    RW.CLI.Run Bash File
     ...    bash_file=getdeploys.sh
@@ -32,6 +33,11 @@ Run Bash File
     ...    env=${env}
     RW.Core.Add Pre To Report    Command Stdout:\n${rsp.stdout}
     RW.Core.Add Pre To Report    Command Stderr:\n${rsp.stderr}
+
+Log Suggestion
+    [Documentation]    Generate a next step suggestion, format it, and log it
+    ${next_step}=    RW.NextSteps.Suggest    Bind Mount
+    RW.Core.Add Pre To Report    ${next_step}
 
 
 *** Keywords ***

--- a/codebundles/cmd-test/runbook.robot
+++ b/codebundles/cmd-test/runbook.robot
@@ -1,16 +1,43 @@
 *** Settings ***
-Metadata          Author    jon-funk
-Documentation     This taskset smoketests the CLI codebundle setup and run process by running a bare command
-Suite Setup       Suite Initialization
-Library           BuiltIn
-Library           RW.Core
-Library           RW.platform
-Library           OperatingSystem
-Library           RW.CLI
+Documentation       This taskset smoketests the CLI codebundle setup and run process by running a bare command
+Metadata            Author    jon-funk
+
+Library             BuiltIn
+Library             RW.Core
+Library             RW.platform
+Library             OperatingSystem
+Library             RW.CLI
+
+Suite Setup         Suite Initialization
+
+
+*** Tasks ***
+Run CLI Command
+    [Documentation]    Runs a bare CLI command and captures the stderr and stdout for the report
+    [Tags]    stdout    test    output    pods
+    ${rsp}=    RW.CLI.Run Cli
+    ...    cmd=${CLI_COMMAND}
+    ...    target_service=${kubectl}
+    ...    env={"KUBECONFIG":"./${kubeconfig.key}"}
+    ...    secret_file__kubeconfig=${kubeconfig}
+    RW.Core.Add Pre To Report    Command Stdout:\n${rsp.stdout}
+    RW.Core.Add Pre To Report    Command Stderr:\n${rsp.stderr}
+
+Run Bash File
+    [Documentation]    Runs a bash file to
+    [Tags]    file    script
+    ${rsp}=    RW.CLI.Run Bash File
+    ...    bash_file=getdeploys.sh
+    ...    secret_file__kubeconfig=${kubeconfig}
+    ...    env=${env}
+    RW.Core.Add Pre To Report    Command Stdout:\n${rsp.stdout}
+    RW.Core.Add Pre To Report    Command Stderr:\n${rsp.stderr}
+
 
 *** Keywords ***
 Suite Initialization
-    ${kubeconfig}=    RW.Core.Import Secret    kubeconfig
+    ${kubeconfig}=    RW.Core.Import Secret
+    ...    kubeconfig
     ...    type=string
     ...    description=The kubernetes kubeconfig yaml containing connection configuration used to connect to cluster(s).
     ...    pattern=\w*
@@ -19,6 +46,18 @@ Suite Initialization
     ...    description=The location service used to interpret shell commands.
     ...    default=kubectl-service.shared
     ...    example=kubectl-service.shared
+    ${NAMESPACE}=    RW.Core.Import User Variable    NAMESPACE
+    ...    type=string
+    ...    description=The name of the Kubernetes namespace to scope actions and searching to.
+    ...    pattern=\w*
+    ...    example=my-namespace
+    ...    default=online-boutique
+    ${CONTEXT}=    RW.Core.Import User Variable    CONTEXT
+    ...    type=string
+    ...    description=Which Kubernetes context to operate within.
+    ...    pattern=\w*
+    ...    example=my-main-cluster
+    ...    default=sandbox-cluster-1
     ${CLI_COMMAND}=    RW.Core.Import User Variable    CLI_COMMAND
     ...    type=string
     ...    description=The CLI command to run.
@@ -30,22 +69,14 @@ Suite Initialization
     ...    enum=[YES,NO]
     ...    example=YES
     ...    default=YES
+    Set Suite Variable    ${CONTEXT}    ${CONTEXT}
+    Set Suite Variable    ${NAMESPACE}    ${NAMESPACE}
     Set Suite Variable    ${CLI_COMMAND}    ${CLI_COMMAND}
     Set Suite Variable    ${kubeconfig}    ${kubeconfig}
-    Set Suite Variable    ${env}    {"KUBECONFIG":"./${kubeconfig.key}"}
+    Set Suite Variable
+    ...    ${env}
+    ...    {"KUBECONFIG":"./${kubeconfig.key}", "CONTEXT":"${CONTEXT}", "NAMESPACE":"${NAMESPACE}"}
     IF    "${RUN_LOCAL}" == "YES"
         ${kubectl}=    Evaluate    None
     END
     Set Suite Variable    ${kubectl}    ${kubectl}
-
-*** Tasks ***
-Run CLI Command
-    [Documentation]    Runs a bare CLI command and captures the stderr and stdout for the report
-    [Tags]    Stdout    Test    Output    Pods
-    ${rsp}=    RW.CLI.Run Cli
-    ...    cmd=${CLI_COMMAND}
-    ...    target_service=${kubectl}
-    ...    env=${env}
-    ...    secret_file__kubeconfig=${kubeconfig}
-    RW.Core.Add Pre To Report    Command Stdout:\n${rsp.stdout}
-    RW.Core.Add Pre To Report    Command Stderr:\n${rsp.stderr}

--- a/codebundles/cmd-test/runbook.robot
+++ b/codebundles/cmd-test/runbook.robot
@@ -36,8 +36,14 @@ Run Bash File
 
 Log Suggestion
     [Documentation]    Generate a next step suggestion, format it, and log it
-    ${next_step}=    RW.NextSteps.Suggest    Bind Mount
-    RW.Core.Add Pre To Report    ${next_step}
+    ${next_steps}=    RW.NextSteps.Suggest    Bind Mount
+    ${next_steps}=    RW.NextSteps.Format    ${next_steps}
+    ...    pvc_name=cartservicestorage
+    RW.Core.Add Pre To Report    ${next_steps}
+    ${next_steps}=    RW.NextSteps.Suggest    Useless Error Message
+    ${next_steps}=    RW.NextSteps.Format    ${next_steps}
+    ...    blah=foo
+    RW.Core.Add Pre To Report    ${next_steps}
 
 
 *** Keywords ***

--- a/codebundles/cmd-test/runbook.robot
+++ b/codebundles/cmd-test/runbook.robot
@@ -40,9 +40,28 @@ Log Suggestion
     ${next_steps}=    RW.NextSteps.Format    ${next_steps}
     ...    pvc_name=cartservicestorage
     RW.Core.Add Pre To Report    ${next_steps}
+
     ${next_steps}=    RW.NextSteps.Suggest    Useless Error Message
     ${next_steps}=    RW.NextSteps.Format    ${next_steps}
     ...    blah=foo
+    RW.Core.Add Pre To Report    ${next_steps}
+
+    ${next_steps}=    RW.NextSteps.Suggest    HTTP 500 errors found in logs
+    # pretend to fetch ingress name
+    ${db_name}=    RW.CLI.Run Cli
+    ...    cmd=echo "online-boutique"
+    ${next_steps}=    RW.NextSteps.Format    ${next_steps}
+    ...    ingress_name=online-boutique
+    RW.Core.Add Pre To Report    ${next_steps}
+
+    # simulate a connection err pulled from API logs
+    ${next_steps}=    RW.NextSteps.Suggest    OperationalError: FATAL: connection limit exceeded for non-superusers
+    # simulate fetch object name from k8s api
+    ${db_name}=    RW.CLI.Run Cli
+    ...    cmd=echo "mypostgresdb"
+    # inject db name into next steps
+    ${next_steps}=    RW.NextSteps.Format    ${next_steps}
+    ...    postgres_name=${db_name.stdout}
     RW.Core.Add Pre To Report    ${next_steps}
 
 

--- a/libraries/RW/NextSteps/Kubernetes/mapping.yaml
+++ b/libraries/RW/NextSteps/Kubernetes/mapping.yaml
@@ -1,4 +1,4 @@
-# Mapping of Kubernetes issues
+# Mapping of Kubernetes troubleshooting suggestions for next steps
 # structure adheres to following rules to keep things DRY:
 # 1. If you foresee a set of titles/objects used under many keys (errors), create anchors and reference them
 # 2. if the set of tasks for the key (error) is unlikely to be used elsewhere, simply hardcode them
@@ -12,7 +12,7 @@ PersistentVolumeTroubleshooting: &pvt
   - List Pods with Attached Volumes and Related PersistentVolume Details
   - Fetch the Storage Utilization for PVC Mounts
   - Check for RWO Persistent Volume Node Attachment Issues
-  - PersistentVolumeClaim:$workloadpvc
+  - PersistentVolumeClaim:$pvc_name
 # Aliases
 FailedMount: *pvt
 FailedAttachVolume: *pvt

--- a/libraries/RW/NextSteps/Kubernetes/mapping.yaml
+++ b/libraries/RW/NextSteps/Kubernetes/mapping.yaml
@@ -3,6 +3,16 @@
 # 1. If you foresee a set of titles/objects used under many keys (errors), create anchors and reference them
 # 2. if the set of tasks for the key (error) is unlikely to be used elsewhere, simply hardcode them
 # If an array index contains a ':' it will be formatted seperately as a object hint
+# EXAMPLE:
+#
+# ErrorMessageToSearchOn:
+#   - A suggested task title to run A
+#   - A suggested task title to run B
+#   - A suggested task title to run C
+#   - ObjectTypeAssociatedWithError:$name_variable_of_object_to_run_tasks_against
+# the $name_variable_of_object_to_run_tasks_against can be dynamically injected
+# with the object name to investigate using RW.NextSteps.Format
+# aliases are typically error messages you would associate with the troubleshooting steps
 
 # BEGIN PersistentVolumeTroubleshooting
 PersistentVolumeTroubleshooting: &pvt
@@ -18,3 +28,32 @@ FailedMount: *pvt
 FailedAttachVolume: *pvt
 FailedBinding: *pvt
 # END PersistentVolumeTroubleshooting
+
+# BEGIN PostgresTroubleshooting
+PostgresTroubleshooting: &psqlt
+  - Get Standard Postgres Resource Information
+  - Describe Postgres Custom Resources
+  - Get Postgres Pod Logs & Events
+  - Get Postgres Pod Resource Utilization
+  - Get Running Postgres Configuration
+  - Get Patroni Output
+  - Run DB Debug Queries
+  - StatefulSet:$postgres_name
+# Aliases
+OperationalError: *psqlt
+"OperationalError: FATAL:  connection limit exceeded": *psqlt
+"OperationalError: could not connect to server: Connection timed out": *psqlt
+"OperationalError: FATAL: sorry, too many clients already": *psqlt
+# END PostgresTroubleshooting
+
+# BEGIN IngressTroubleshooting
+IngressTroubleshooting: &ingresst
+  - Fetch Nginx Ingress Metrics From GMP And Perform Inspection On Results
+  - Find Ingress Owner and Service Health
+  - Ingress:$ingress_name
+# Aliases
+"HTTP Errors In Metrics": *ingresst
+"HTTP Errors In Logs": *ingresst
+"Application not receiving traffic": *ingresst
+"Network Errors": *ingresst
+# END IngressTroubleshooting

--- a/libraries/RW/NextSteps/Kubernetes/mapping.yaml
+++ b/libraries/RW/NextSteps/Kubernetes/mapping.yaml
@@ -1,0 +1,20 @@
+# Mapping of Kubernetes issues
+# structure adheres to following rules to keep things DRY:
+# 1. If you foresee a set of titles/objects used under many keys (errors), create anchors and reference them
+# 2. if the set of tasks for the key (error) is unlikely to be used elsewhere, simply hardcode them
+# If an array index contains a ':' it will be formatted seperately as a object hint
+
+# BEGIN PersistentVolumeTroubleshooting
+PersistentVolumeTroubleshooting: &pvt
+  - Fetch Events for Unhealthy Kubernetes PersistentVolumeClaims
+  - List PersistentVolumeClaims in Terminating State
+  - List PersistentVolumes in Terminating State
+  - List Pods with Attached Volumes and Related PersistentVolume Details
+  - Fetch the Storage Utilization for PVC Mounts
+  - Check for RWO Persistent Volume Node Attachment Issues
+  - PersistentVolumeClaim:$workloadpvc
+# Aliases
+FailedMount: *pvt
+FailedAttachVolume: *pvt
+FailedBinding: *pvt
+# END PersistentVolumeTroubleshooting

--- a/libraries/RW/NextSteps/Suggest.py
+++ b/libraries/RW/NextSteps/Suggest.py
@@ -40,7 +40,7 @@ def suggest(
     pretty_answer: bool = True,
     include_object_hints: bool = True,
     k_nearest: int = 1,
-    minimum_match_score: int = 50,
+    minimum_match_score: int = 60,
     **kwargs,
 ):
     mapping = _load_mapping(platform)
@@ -51,7 +51,7 @@ def suggest(
     next_steps_data = []
     for match_tuple in key_results:
         # tuple structure: ('FailedMount', 67)
-        # logger.info(f"Fuzzy Match: {match_tuple}")
+        logger.info(f"Fuzzy Match: {match_tuple}")
         if match_tuple[1] < minimum_match_score:
             continue
         map_key = match_tuple[0]

--- a/libraries/RW/NextSteps/Suggest.py
+++ b/libraries/RW/NextSteps/Suggest.py
@@ -1,0 +1,57 @@
+"""
+Utility library for suggesting next steps based on a static troubleshooting yaml database
+
+See https://github.com/seatgeek/thefuzz
+
+Scope: Global
+"""
+import logging, yaml
+from datetime import datetime
+from robot.libraries.BuiltIn import BuiltIn
+from thefuzz import process as fuzzprocessor
+
+from RW import platform
+from RW.Core import Core
+
+logger = logging.getLogger(__name__)
+
+ROBOT_LIBRARY_SCOPE = "GLOBAL"
+
+THIS_DIR: str = "/".join(__file__.split("/")[:-1])
+
+
+def _load_mapping(platform: str) -> dict:
+    data: dict = {}
+    with open(f"{THIS_DIR}/{platform}/mapping.yaml", "r") as fh:
+        data = yaml.safe_load(fh)
+    return data
+
+
+def format_suggestions(suggestions: list) -> str:
+    pass
+
+
+def suggest(
+    search_error: str,
+    platform: str = "Kubernetes",
+    pretty_answer: bool = True,
+    k_nearest: int = 1,
+    **kwargs,
+):
+    mapping = _load_mapping(platform)
+    results: list[str] = []
+    if not mapping:
+        return results
+    key_results = fuzzprocessor.extract(search_error, mapping.keys(), limit=k_nearest)
+    next_steps_data = []
+    for match_tuple in key_results:
+        map_key = match_tuple[0]
+        next_steps_data += mapping[map_key]
+    if pretty_answer:
+        titles: str = ""
+        object_hints: str = ""
+        for suggestion in suggestions:
+            if ":" in suggestion:
+                object_hints += f"\n{suggestion}"
+        results = ", ".join(results)
+    return results

--- a/libraries/RW/NextSteps/__init__.py
+++ b/libraries/RW/NextSteps/__init__.py
@@ -1,0 +1,1 @@
+from .Suggest import *

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ robotframework>=4.1.2
 jmespath>=1.0.1
 python-dateutil==2.8.2
 requests>=2.31.0
+thefuzz==0.20.0
+pyyaml==6.0.1


### PR DESCRIPTION
- Adds a troubleshooting lookup keyword that can "suggest" nextsteps based on a error bingo board, called `RW.NextSteps.Suggest`
- Adds `RW.NextSteps.Format` keyword to allow for quick injection of live object values/names into nextsteps message before issue submission to reduce robot bloat
- Board is based on a maintained static yaml mapping file, specific to each system/platform (eg: 1 for Kubernetes, 1 for ECS, 1 for Google Cloudrun, etc)
- Adds `RW.CLI.Run Bash File` keyword


See https://github.com/runwhen-contrib/rw-cli-codecollection/blob/err-bingo/codebundles/cmd-test/runbook.robot for samples