### PR TITLE
template updates and container script additions

### DIFF
--- a/codebundles/curl-http-ok/.runwhen/generation-rules/http-ok-tls-aks-public-loadbalancer-ext-dns-tls.yaml
+++ b/codebundles/curl-http-ok/.runwhen/generation-rules/http-ok-tls-aks-public-loadbalancer-ext-dns-tls.yaml
@@ -21,7 +21,7 @@ spec:
               mode: substring
       slxs:
         - baseName: http-ok-tls-aks
-          qualifiers: [resource]
+          qualifiers: ["resource", "namespace", "cluster"]
           baseTemplateName: http-ok-tls-aks-public-loadbalancer-ext-dns-tls
           levelOfDetail: basic
           outputItems:

--- a/codebundles/curl-http-ok/.runwhen/generation-rules/http-ok-tls.yaml
+++ b/codebundles/curl-http-ok/.runwhen/generation-rules/http-ok-tls.yaml
@@ -17,7 +17,7 @@ spec:
               mode: substring
       slxs:
         - baseName: http-ok-tls-test
-          qualifiers: [resource]
+          qualifiers: ["resource", "namespace", "cluster"]
           baseTemplateName: http-ok-tls
           levelOfDetail: basic
           outputItems:

--- a/codebundles/curl-http-ok/.runwhen/generation-rules/http-ok.yaml
+++ b/codebundles/curl-http-ok/.runwhen/generation-rules/http-ok.yaml
@@ -17,7 +17,7 @@ spec:
             path: spec/tls/hosts
       slxs:
         - baseName: http-ok
-          qualifiers: [resource]
+          qualifiers: ["resource", "namespace", "cluster"]
           baseTemplateName: http-ok
           levelOfDetail: basic
           outputItems:

--- a/codebundles/curl-http-ok/.runwhen/templates/http-ok-slx.yaml
+++ b/codebundles/curl-http-ok/.runwhen/templates/http-ok-slx.yaml
@@ -19,3 +19,5 @@ spec:
   additionalContext:  
     namespace: "{{match_resource.resource.metadata.namespace}}"
     labelMap: "{{match_resource.resource.metadata.labels}}" 
+    cluster: "{{ cluster.name }}"
+    context: "{{ cluster.context }}"

--- a/codebundles/curl-http-ok/.runwhen/templates/http-ok-tls-aks-public-loadbalancer-ext-dns-tls-slx.yaml
+++ b/codebundles/curl-http-ok/.runwhen/templates/http-ok-tls-aks-public-loadbalancer-ext-dns-tls-slx.yaml
@@ -19,3 +19,5 @@ spec:
   additionalContext:  
     namespace: "{{match_resource.resource.metadata.namespace}}"
     labelMap: "{{match_resource.resource.metadata.labels}}" 
+    cluster: "{{ cluster.name }}"
+    context: "{{ cluster.context }}"

--- a/codebundles/curl-http-ok/.runwhen/templates/http-ok-tls-slx.yaml
+++ b/codebundles/curl-http-ok/.runwhen/templates/http-ok-tls-slx.yaml
@@ -19,3 +19,5 @@ spec:
   additionalContext:  
     namespace: "{{match_resource.resource.metadata.namespace}}"
     labelMap: "{{match_resource.resource.metadata.labels}}"  
+    cluster: "{{ cluster.name }}"
+    context: "{{ cluster.context }}"

--- a/codebundles/gcloud-node-preempt/.runwhen/generation-rules/gcloud-node-preempt.yaml
+++ b/codebundles/gcloud-node-preempt/.runwhen/generation-rules/gcloud-node-preempt.yaml
@@ -21,7 +21,7 @@ spec:
               mode: exact
       slxs:
         - baseName: node-preempt
-          qualifiers: [resource]
+          qualifiers: ["resource", "cluster"]
           baseTemplateName: gcloud-node-preempt
           levelOfDetail: detailed
           outputItems:

--- a/codebundles/gcloud-node-preempt/.runwhen/templates/gcloud-node-preempt-slx.yaml
+++ b/codebundles/gcloud-node-preempt/.runwhen/templates/gcloud-node-preempt-slx.yaml
@@ -16,3 +16,6 @@ spec:
   owners:
   - {{workspace.owner_email}}
   statement: Nodes in an active preempt event should trigger RunWhen workflows.    
+  additionalContext:  
+    cluster: "{{ cluster.name }}"
+    context: "{{ cluster.context }}"

--- a/codebundles/k8s-argocd-application-health/.runwhen/generation-rules/k8s-argocd-application-health.yaml
+++ b/codebundles/k8s-argocd-application-health/.runwhen/generation-rules/k8s-argocd-application-health.yaml
@@ -11,7 +11,7 @@ spec:
           mode: substring
       slxs:
         - baseName: argocd-app
-          qualifiers: [resource]
+          qualifiers: ["resource", "namespace", "cluster"]
           baseTemplateName: k8s-argocd-application-health
           levelOfDetail: detailed
           outputItems:

--- a/codebundles/k8s-argocd-application-health/.runwhen/templates/k8s-argocd-application-health-slx.yaml
+++ b/codebundles/k8s-argocd-application-health/.runwhen/templates/k8s-argocd-application-health-slx.yaml
@@ -19,3 +19,5 @@ spec:
   additionalContext:  
     namespace: "{{match_resource.resource.metadata.namespace}}"
     labelMap: "{{match_resource.resource.metadata.labels}}" 
+    cluster: "{{ cluster.name }}"
+    context: "{{ cluster.context }}"

--- a/codebundles/k8s-argocd-helm-health/.runwhen/generation-rules/k8s-argocd-helm-health.yaml
+++ b/codebundles/k8s-argocd-helm-health/.runwhen/generation-rules/k8s-argocd-helm-health.yaml
@@ -11,7 +11,7 @@ spec:
           mode: substring
       slxs:
         - baseName: argocd-helm
-          qualifiers: [resource]
+          qualifiers: ["resource", "namespace", "cluster"]
           baseTemplateName: k8s-argocd-helm-health
           levelOfDetail: detailed
           outputItems:

--- a/codebundles/k8s-argocd-helm-health/.runwhen/templates/k8s-argocd-helm-health-slx.yaml
+++ b/codebundles/k8s-argocd-helm-health/.runwhen/templates/k8s-argocd-helm-health-slx.yaml
@@ -19,3 +19,5 @@ spec:
   additionalContext:  
     namespace: "{{match_resource.resource.metadata.namespace}}"
     labelMap: "{{match_resource.resource.metadata.labels}}" 
+    cluster: "{{ cluster.name }}"
+    context: "{{ cluster.context }}"

--- a/codebundles/k8s-artifactory-health/.runwhen/generation-rules/k8s-artifactory.yaml
+++ b/codebundles/k8s-artifactory-health/.runwhen/generation-rules/k8s-artifactory.yaml
@@ -12,7 +12,7 @@ spec:
       slxs:
         - baseName: arti-health
           levelOfDetail: basic
-          qualifiers: [namespace]
+          qualifiers: ["resource", "namespace", "cluster"]
           baseTemplateName: k8s-artifactory-healthcheck
           outputItems:
             - type: slx

--- a/codebundles/k8s-artifactory-health/.runwhen/templates/k8s-artifactory-healthcheck-slx.yaml
+++ b/codebundles/k8s-artifactory-health/.runwhen/templates/k8s-artifactory-healthcheck-slx.yaml
@@ -19,3 +19,5 @@ spec:
   additionalContext:  
     namespace: "{{match_resource.resource.metadata.namespace}}"
     labelMap: "{{match_resource.resource.metadata.labels}}" 
+    cluster: "{{ cluster.name }}"
+    context: "{{ cluster.context }}"

--- a/codebundles/k8s-daemonset-healthcheck/.runwhen/generation-rules/k8s-daemonset-health.yaml
+++ b/codebundles/k8s-daemonset-healthcheck/.runwhen/generation-rules/k8s-daemonset-health.yaml
@@ -12,7 +12,7 @@ spec:
       slxs:
         - baseName: ds-health
           levelOfDetail: detailed
-          qualifiers: [resource]
+          qualifiers: ["resource", "namespace", "cluster"]
           baseTemplateName: k8s-daemonset-health
           outputItems:
             - type: slx

--- a/codebundles/k8s-daemonset-healthcheck/.runwhen/templates/k8s-daemonset-health-slx.yaml
+++ b/codebundles/k8s-daemonset-healthcheck/.runwhen/templates/k8s-daemonset-health-slx.yaml
@@ -18,4 +18,6 @@ spec:
   statement: Statefulset {{match_resource.resource.metadata.name}} should be in a healthy state. 
   additionalContext:  
     namespace: "{{match_resource.resource.metadata.namespace}}"
-    labelMap: "{{match_resource.resource.metadata.labels}}"  
+    labelMap: "{{match_resource.resource.metadata.labels}}"
+    cluster: "{{ cluster.name }}"
+    context: "{{ cluster.context }}"

--- a/codebundles/k8s-deployment-healthcheck/.runwhen/generation-rules/k8s-deployment-health.yaml
+++ b/codebundles/k8s-deployment-healthcheck/.runwhen/generation-rules/k8s-deployment-health.yaml
@@ -12,7 +12,7 @@ spec:
       slxs:
         - baseName: depl-health
           levelOfDetail: detailed
-          qualifiers: [resource]
+          qualifiers: ["resource", "namespace", "cluster"]
           baseTemplateName: k8s-deployment-health
           outputItems:
             - type: slx

--- a/codebundles/k8s-deployment-healthcheck/.runwhen/templates/k8s-deployment-health-slx.yaml
+++ b/codebundles/k8s-deployment-healthcheck/.runwhen/templates/k8s-deployment-health-slx.yaml
@@ -19,4 +19,5 @@ spec:
   additionalContext:  
     namespace: "{{match_resource.resource.metadata.namespace}}"
     labelMap: "{{match_resource.resource.metadata.labels}}"
-    cluster: "{{ cluster }}"
+    cluster: "{{ cluster.name }}"
+    context: "{{ cluster.context }}"

--- a/codebundles/k8s-deployment-healthcheck/.runwhen/templates/k8s-deployment-health-slx.yaml
+++ b/codebundles/k8s-deployment-healthcheck/.runwhen/templates/k8s-deployment-health-slx.yaml
@@ -18,4 +18,5 @@ spec:
   statement: Pods for {{match_resource.resource.metadata.name}} deployments should be in a ready state. There should be Zero unready pods. 
   additionalContext:  
     namespace: "{{match_resource.resource.metadata.namespace}}"
-    labelMap: "{{match_resource.resource.metadata.labels}}" 
+    labelMap: "{{match_resource.resource.metadata.labels}}"
+    cluster: "{{ cluster }}"

--- a/codebundles/k8s-fluxcd-helm-health/.runwhen/generation-rules/k8s-flux-helm-health.yaml
+++ b/codebundles/k8s-fluxcd-helm-health/.runwhen/generation-rules/k8s-flux-helm-health.yaml
@@ -13,7 +13,7 @@ spec:
               mode: substring
       slxs:
         - baseName: flux-helm
-          qualifiers: [resource]
+          qualifiers: ["resource", "namespace", "cluster"]
           baseTemplateName: k8s-flux-helm-health
           levelOfDetail: detailed
           outputItems:

--- a/codebundles/k8s-fluxcd-helm-health/.runwhen/templates/k8s-flux-helm-health-slx.yaml
+++ b/codebundles/k8s-fluxcd-helm-health/.runwhen/templates/k8s-flux-helm-health-slx.yaml
@@ -18,4 +18,6 @@ spec:
   statement: Helm releases for {{namespace.name}} should be reconciled in a good state. 
   additionalContext:  
     namespace: "{{match_resource.resource.metadata.namespace}}"
-    labelMap: "{{match_resource.resource.metadata.labels}}" 
+    labelMap: "{{match_resource.resource.metadata.labels}}"
+    cluster: "{{ cluster.name }}"
+    context: "{{ cluster.context }}"

--- a/codebundles/k8s-fluxcd-kustomization-health/.runwhen/generation-rules/k8s-flux-kustomization-health.yaml
+++ b/codebundles/k8s-fluxcd-kustomization-health/.runwhen/generation-rules/k8s-flux-kustomization-health.yaml
@@ -13,7 +13,7 @@ spec:
               mode: substring
       slxs:
         - baseName: flux-kstmz
-          qualifiers: [resource]
+          qualifiers: ["resource", "namespace", "cluster"]
           baseTemplateName: k8s-flux-kustomize-health
           levelOfDetail: detailed
           outputItems:

--- a/codebundles/k8s-fluxcd-kustomization-health/.runwhen/templates/k8s-flux-kustomize-health-slx.yaml
+++ b/codebundles/k8s-fluxcd-kustomization-health/.runwhen/templates/k8s-flux-kustomize-health-slx.yaml
@@ -19,3 +19,5 @@ spec:
   additionalContext:  
     namespace: "{{match_resource.resource.metadata.namespace}}"
     labelMap: "{{match_resource.resource.metadata.labels}}" 
+    cluster: "{{ cluster.name }}"
+    context: "{{ cluster.context }}"

--- a/codebundles/k8s-image-check/.runwhen/generation-rules/k8s-image-health.yaml
+++ b/codebundles/k8s-image-check/.runwhen/generation-rules/k8s-image-health.yaml
@@ -12,7 +12,7 @@ spec:
       slxs:
         - baseName: image-check
           levelOfDetail: detailed
-          qualifiers: [namespace]
+          qualifiers: ["resource", "namespace", "cluster"]
           baseTemplateName: k8s-image-check
           outputItems:
             - type: slx

--- a/codebundles/k8s-image-check/.runwhen/templates/k8s-image-check-slx.yaml
+++ b/codebundles/k8s-image-check/.runwhen/templates/k8s-image-check-slx.yaml
@@ -19,3 +19,5 @@ spec:
   additionalContext:  
     namespace: "{{match_resource.resource.metadata.namespace}}"
     labelMap: "{{match_resource.resource.metadata.labels}}"  
+    cluster: "{{ cluster.name }}"
+    context: "{{ cluster.context }}"

--- a/codebundles/k8s-ingress-healthcheck/.runwhen/generation-rules/k8s-ingress-health .yaml
+++ b/codebundles/k8s-ingress-healthcheck/.runwhen/generation-rules/k8s-ingress-health .yaml
@@ -13,7 +13,7 @@ spec:
               mode: substring
       slxs:
         - baseName: ingress-health
-          qualifiers: [resource]
+          qualifiers: ["resource", "namespace", "cluster"]
           baseTemplateName: k8s-ingress-healthcheck
           levelOfDetail: basic
           outputItems:

--- a/codebundles/k8s-ingress-healthcheck/.runwhen/templates/k8s-ingress-healthcheck-slx.yaml
+++ b/codebundles/k8s-ingress-healthcheck/.runwhen/templates/k8s-ingress-healthcheck-slx.yaml
@@ -19,3 +19,5 @@ spec:
   additionalContext:  
     namespace: "{{match_resource.resource.metadata.namespace}}"
     labelMap: "{{match_resource.resource.metadata.labels}}"  
+    cluster: "{{ cluster.name }}"
+    context: "{{ cluster.context }}"

--- a/codebundles/k8s-jenkins-healthcheck/.runwhen/generation-rules/k8s-jenkins-healthcheck.yaml
+++ b/codebundles/k8s-jenkins-healthcheck/.runwhen/generation-rules/k8s-jenkins-healthcheck.yaml
@@ -12,7 +12,7 @@ spec:
       slxs:
         - baseName: jenkins-health
           levelOfDetail: detailed
-          qualifiers: [resource]
+          qualifiers: ["resource", "namespace", "cluster"]
           baseTemplateName: k8s-jenkins-health
           outputItems:
             - type: slx

--- a/codebundles/k8s-jenkins-healthcheck/.runwhen/templates/k8s-jenkins-health-slx.yaml
+++ b/codebundles/k8s-jenkins-healthcheck/.runwhen/templates/k8s-jenkins-health-slx.yaml
@@ -19,3 +19,5 @@ spec:
   additionalContext:  
     namespace: "{{match_resource.resource.metadata.namespace}}"
     labelMap: "{{match_resource.resource.metadata.labels}}"   
+    cluster: "{{ cluster.name }}"
+    context: "{{ cluster.context }}"

--- a/codebundles/k8s-namespace-healthcheck/.runwhen/generation-rules/k8s-namespace-healthcheck.yaml
+++ b/codebundles/k8s-namespace-healthcheck/.runwhen/generation-rules/k8s-namespace-healthcheck.yaml
@@ -12,7 +12,7 @@ spec:
       slxs:
         - baseName: ns-health
           levelOfDetail: detailed
-          qualifiers: [namespace]
+          qualifiers: ["namespace", "cluster"]
           baseTemplateName: k8s-namespace-healthcheck
           outputItems:
             - type: slx

--- a/codebundles/k8s-namespace-healthcheck/.runwhen/templates/k8s-namespace-healthcheck-slx.yaml
+++ b/codebundles/k8s-namespace-healthcheck/.runwhen/templates/k8s-namespace-healthcheck-slx.yaml
@@ -18,4 +18,6 @@ spec:
   statement: Overall health for {{namespace.name}} should be 1, 99% of the time. 
   additionalContext:  
     namespace: "{{match_resource.resource.metadata.namespace}}"
-    labelMap: "{{match_resource.resource.metadata.labels}}" 
+    labelMap: "{{match_resource.resource.metadata.labels}}"
+    cluster: "{{ cluster.name }}"
+    context: "{{ cluster.context }}"

--- a/codebundles/k8s-podresources-health/.runwhen/generation-rules/k8s-pod-resources.yaml
+++ b/codebundles/k8s-podresources-health/.runwhen/generation-rules/k8s-pod-resources.yaml
@@ -12,7 +12,7 @@ spec:
     slxs:
     - baseName: pod-resources
       levelOfDetail: detailed
-      qualifiers: [namespace]
+      qualifiers: ["namespace", "cluster"]
       baseTemplateName: k8s-pod-resources
       outputItems:
         - type: slx

--- a/codebundles/k8s-podresources-health/.runwhen/templates/k8s-pod-resources-slx.yaml
+++ b/codebundles/k8s-podresources-health/.runwhen/templates/k8s-pod-resources-slx.yaml
@@ -19,3 +19,5 @@ spec:
   additionalContext:  
     namespace: "{{match_resource.resource.metadata.namespace}}"
     labelMap: "{{match_resource.resource.metadata.labels}}" 
+    cluster: "{{ cluster.name }}"
+    context: "{{ cluster.context }}"

--- a/codebundles/k8s-pvc-healthcheck/.runwhen/generation-rules/k8s-pvc-healthcheck.yaml
+++ b/codebundles/k8s-pvc-healthcheck/.runwhen/generation-rules/k8s-pvc-healthcheck.yaml
@@ -13,7 +13,7 @@ spec:
     slxs:
     - baseName: pvc-health
       levelOfDetail: detailed
-      qualifiers: [namespace]
+      qualifiers: ["namespace", "cluster"]
       baseTemplateName: k8s-pvc-healthcheck
       outputItems:
         - type: slx

--- a/codebundles/k8s-pvc-healthcheck/.runwhen/templates/k8s-pvc-healthcheck-slx.yaml
+++ b/codebundles/k8s-pvc-healthcheck/.runwhen/templates/k8s-pvc-healthcheck-slx.yaml
@@ -18,4 +18,6 @@ spec:
   statement: PVC's should be bound and healthy. 
   additionalContext:  
     namespace: "{{match_resource.resource.metadata.namespace}}"
-    labelMap: "{{match_resource.resource.metadata.labels}}" 
+    labelMap: "{{match_resource.resource.metadata.labels}}"
+    cluster: "{{ cluster.name }}"
+    context: "{{ cluster.context }}"

--- a/codebundles/k8s-redis-healthcheck/.runwhen/generation-rules/k8s-redis-healthcheck.yaml
+++ b/codebundles/k8s-redis-healthcheck/.runwhen/generation-rules/k8s-redis-healthcheck.yaml
@@ -12,7 +12,7 @@ spec:
       slxs:
         - baseName: redis-health
           levelOfDetail: detailed
-          qualifiers: [resource]
+          qualifiers: ["resource", "namespace", "cluster"]
           baseTemplateName: k8s-redis-health
           outputItems:
             - type: slx

--- a/codebundles/k8s-redis-healthcheck/.runwhen/templates/k8s-redis-health-slx.yaml
+++ b/codebundles/k8s-redis-healthcheck/.runwhen/templates/k8s-redis-health-slx.yaml
@@ -19,3 +19,5 @@ spec:
   additionalContext:  
     namespace: "{{match_resource.resource.metadata.namespace}}"
     labelMap: "{{match_resource.resource.metadata.labels}}" 
+    cluster: "{{ cluster.name }}"
+    context: "{{ cluster.context }}"

--- a/codebundles/k8s-serviceaccount-check/.runwhen/generation-rules/k8s-serviceaccount-check.yaml
+++ b/codebundles/k8s-serviceaccount-check/.runwhen/generation-rules/k8s-serviceaccount-check.yaml
@@ -13,7 +13,7 @@ spec:
               mode: substring
       slxs:
         - baseName: sa-check
-          qualifiers: [namespace]
+          qualifiers: ["namespace", "cluster"]
           baseTemplateName: k8s-serviceaccount-check
           levelOfDetail: detailed
           outputItems:

--- a/codebundles/k8s-serviceaccount-check/.runwhen/templates/k8s-serviceaccount-check-slx.yaml
+++ b/codebundles/k8s-serviceaccount-check/.runwhen/templates/k8s-serviceaccount-check-slx.yaml
@@ -20,3 +20,5 @@ spec:
   additionalContext:  
     namespace: "{{match_resource.resource.metadata.name}}"
     labelMap: "{{match_resource.resource.metadata.labels}}"  
+    cluster: "{{ cluster.name }}"
+    context: "{{ cluster.context }}"

--- a/codebundles/k8s-statefulset-healthcheck/.runwhen/generation-rules/k8s-statefulset-health.yaml
+++ b/codebundles/k8s-statefulset-healthcheck/.runwhen/generation-rules/k8s-statefulset-health.yaml
@@ -12,7 +12,7 @@ spec:
       slxs:
         - baseName: ss-health
           levelOfDetail: detailed
-          qualifiers: [resource]
+          qualifiers: ["resource", "namespace", "cluster"]
           baseTemplateName: k8s-statefulset-health
           outputItems:
             - type: slx

--- a/codebundles/k8s-statefulset-healthcheck/.runwhen/templates/k8s-statefulset-health-slx.yaml
+++ b/codebundles/k8s-statefulset-healthcheck/.runwhen/templates/k8s-statefulset-health-slx.yaml
@@ -18,4 +18,6 @@ spec:
   statement: Statefulset {{match_resource.resource.metadata.name}} should be in a healthy state. 
   additionalContext:  
     namespace: "{{match_resource.resource.metadata.namespace}}"
-    labelMap: "{{match_resource.resource.metadata.labels}}"   
+    labelMap: "{{match_resource.resource.metadata.labels}}"
+    cluster: "{{ cluster.name }}"
+    context: "{{ cluster.context }}"


### PR DESCRIPTION
this includes a number of template and metadata updates for rule matching. 
It also includes some updates to the deployment logs script analysis - which still has some outstanding improvements but was functioning as of the last time I ran it. 

Of note, this PR is required to support new grouping and multi-cluster strategies that will be released in runwhen-local 0.3.6