### PR TITLE
Add application and Azure troubleshooting codebundles

### DIFF
--- a/codebundles/azure-loadbalancer-triage/README.md
+++ b/codebundles/azure-loadbalancer-triage/README.md
@@ -18,6 +18,7 @@ The TaskSet requires initialization to import necessary secrets, services, and u
 
 ## TODO
 - [ ] Refine issues raised
-- [ ] Look at cross az/kubectl support and if keeping it in this codebundle makes sense
+- [ ] Array support for issues
+- [ ] Look at cross az/kubectl for better triage
 - [ ] Add additional documentation.
 

--- a/codebundles/azure-loadbalancer-triage/README.md
+++ b/codebundles/azure-loadbalancer-triage/README.md
@@ -3,19 +3,11 @@
 Queries the activity logs of internal loadbalancers (AKS ingress) objects in Azure and optionally inspects internal AKS ingress objects if available.
 
 ## Tasks
-`Health Check Azure Load Balancer`
-`Fetch Azure Ingress Object Health in Namespace``
+`Health Check Internal Azure Load Balancer`
 
 ## Configuration
 The TaskSet requires initialization to import necessary secrets, services, and user variables. The following variables should be set:
 
-- `kubeconfig`: The kubeconfig secret containing access info for the cluster.
-- `kubectl`: The location service used to interpret shell commands. Default value is `kubectl-service.shared`.
-- `KUBERNETES_DISTRIBUTION_BINARY`: Which binary to use for Kubernetes CLI commands. Default value is `kubectl`.
-- `CONTEXT`: The Kubernetes context to operate within.
-- `NAMESPACE`: The name of the namespace to search.
-- `LABELS`: The labels used for resource selection, particularly for fetching logs.
-- `SKIP_K8S`: Configuration to disable the kubernetes ingress check if the API is not publically available (skips by default).
 - `AZ_USERNAME`: Azure service account username secret used to authenticate.
 - `AZ_CLIENT_SECRET`: Azure service account client secret used to authenticate.
 - `AZ_TENANT`: Azure tenant ID used to authenticate to.

--- a/codebundles/azure-loadbalancer-triage/README.md
+++ b/codebundles/azure-loadbalancer-triage/README.md
@@ -1,0 +1,31 @@
+# Azure LoadBalancer Triage
+
+Queries the activity logs of internal loadbalancers (AKS ingress) objects in Azure and optionally inspects internal AKS ingress objects if available.
+
+## Tasks
+`Health Check Azure Load Balancer`
+`Fetch Azure Ingress Object Health in Namespace``
+
+## Configuration
+The TaskSet requires initialization to import necessary secrets, services, and user variables. The following variables should be set:
+
+- `kubeconfig`: The kubeconfig secret containing access info for the cluster.
+- `kubectl`: The location service used to interpret shell commands. Default value is `kubectl-service.shared`.
+- `KUBERNETES_DISTRIBUTION_BINARY`: Which binary to use for Kubernetes CLI commands. Default value is `kubectl`.
+- `CONTEXT`: The Kubernetes context to operate within.
+- `NAMESPACE`: The name of the namespace to search.
+- `LABELS`: The labels used for resource selection, particularly for fetching logs.
+- `SKIP_K8S`: Configuration to disable the kubernetes ingress check if the API is not publically available (skips by default).
+- `AZ_USERNAME`: Azure service account username secret used to authenticate.
+- `AZ_CLIENT_SECRET`: Azure service account client secret used to authenticate.
+- `AZ_TENANT`: Azure tenant ID used to authenticate to.
+- `AZ_HISTORY_RANGE`: The history range to inspect for incidents in the activity log, in hours. Defaults to 24 hours.
+
+## Requirements
+- A kubeconfig with appropriate RBAC permissions to perform the desired command.
+
+## TODO
+- [ ] Refine issues raised
+- [ ] Look at cross az/kubectl support and if keeping it in this codebundle makes sense
+- [ ] Add additional documentation.
+

--- a/codebundles/azure-loadbalancer-triage/runbook.robot
+++ b/codebundles/azure-loadbalancer-triage/runbook.robot
@@ -1,0 +1,128 @@
+*** Settings ***
+Documentation       Triages issues related to a Azure Loadbalancers, Kubernetes ingress objects and services.
+Metadata            Author    jon-funk
+Metadata            Display Name    Kubernetes Ingress Healthcheck
+Metadata            Supports    Kubernetes,AKS,Azure
+
+Library             BuiltIn
+Library             RW.Core
+Library             RW.CLI
+Library             RW.platform
+Library             OperatingSystem
+
+Suite Setup         Suite Initialization
+
+
+*** Tasks ***
+Health Check Azure Load Balancer
+    [Documentation]    Queries a Azure Loadbalancer's health probe to determine if it's in a healthy state.
+    [Tags]    load    balancer    azure
+    ${lb_id}=    RW.CLI.Run Cli
+    ...    cmd=az login --service-principal -u $${AZ_USERNAME.key} -p $${AZ_CLIENT_SECRET.key} --tenant $${AZ_TENANT.key} > /dev/null 2>&1 && az network lb list --query "[?name=='${AZ_LB_NAME}']" | jq -r '.[0].id'
+    ...    secret__az_username=${AZ_USERNAME}
+    ...    secret__az_client_secret=${AZ_CLIENT_SECRET}
+    ...    secret__az_tenant=${AZ_TENANT}
+    ${activity_logs}=    RW.CLI.Run Cli
+    ...    cmd=START_TIME=$(date -d "${AZ_HISTORY_RANGE} hours ago" '+%Y-%m-%dT%H:%M:%SZ') && END_TIME=$(date '+%Y-%m-%dT%H:%M:%SZ') && az login --service-principal -u $${AZ_USERNAME.key} -p $${AZ_CLIENT_SECRET.key} --tenant $${AZ_TENANT.key} > /dev/null 2>&1 && az monitor activity-log list --start-time $START_TIME --end-time $END_TIME --query "[?resourceType.value=='MICROSOFT.NETWORK/loadbalancers' && resourceId=='${lb_id.stdout}']" | jq -r '.[] | [(.eventTimestamp // "N/A"), (.status.localizedValue // "N/A"), (.subStatus.localizedValue // "N/A"), (.properties.details // "N/A")] | @tsv' | while IFS=$'\t' read -r timestamp status substatus details; do printf "%-30s | %-30s | %-60s | %s\n" "$timestamp" "$status" "$substatus" "$details"; done
+    ...    secret__az_username=${AZ_USERNAME}
+    ...    secret__az_client_secret=${AZ_CLIENT_SECRET}
+    ...    secret__az_tenant=${AZ_TENANT}
+    ${activity_logs_report}=    Set Variable    "Azure Load Balancer Health Report:"
+    IF    """${activity_logs.stdout}""" == ""
+        ${activity_logs_report}=    Set Variable
+        ...    "${activity_logs_report}\n\nNo activity log events could be pulled for this resource. If there are events, consider checking the configured time range."
+    ELSE
+        ${activity_logs_report}=    Set Variable    "${activity_logs_report}\n\n${activity_logs.stdout}"
+    END
+    RW.CLI.Parse Cli Output By Line
+    ...    rsp=${activity_logs}
+    ...    set_severity_level=2
+    ...    set_issue_expected=No activity logs indicating failures for the resource.
+    ...    set_issue_actual=Found activity logs indicating the resource has recently experienced an error.
+    ...    set_issue_title=Load Balancer Activity Log Indicates Recent Errors
+    ...    set_issue_details=Activity Log History\n\n${activity_logs.stdout}
+    ...    set_issue_next_steps=Run 'az aks get-credentials' and with the credentials/context provided, use `kubectl describe service -l service.beta.kubernetes.io/azure-load-balancer-internal=true' to get a list of services and inspect their selectors. If the selectors are correct, begin troubleshooting the resource the selectors point to.
+    ...    _line__raise_issue_if_contains=Error
+    ...    _line__raise_issue_if_contains=Critical
+    ...    _line__raise_issue_if_contains=In Progress
+    ${history}=    RW.CLI.Pop Shell History
+    RW.Core.Add Pre To Report    ${activity_logs_report}
+    RW.Core.Add Pre To Report    Commands Used: ${history}
+
+
+*** Keywords ***
+Suite Initialization
+    ${kubeconfig}=    RW.Core.Import Secret
+    ...    kubeconfig
+    ...    type=string
+    ...    description=The kubernetes kubeconfig yaml containing connection configuration used to connect to cluster(s).
+    ...    pattern=\w*
+    ...    example=For examples, start here https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/
+    ${kubectl}=    RW.Core.Import Service    kubectl
+    ...    description=The location service used to interpret shell commands.
+    ...    default=kubectl-service.shared
+    ...    example=kubectl-service.shared
+    ${NAMESPACE}=    RW.Core.Import User Variable    NAMESPACE
+    ...    type=string
+    ...    description=The name of the Kubernetes namespace to scope actions and searching to.
+    ...    pattern=\w*
+    ...    example=my-namespace
+    ${CONTEXT}=    RW.Core.Import User Variable    CONTEXT
+    ...    type=string
+    ...    description=Which Kubernetes context to operate within.
+    ...    pattern=\w*
+    ...    example=my-main-cluster
+    ${KUBERNETES_DISTRIBUTION_BINARY}=    RW.Core.Import User Variable    KUBERNETES_DISTRIBUTION_BINARY
+    ...    type=string
+    ...    description=Which binary to use for Kubernetes CLI commands.
+    ...    enum=[kubectl,oc]
+    ...    example=kubectl
+    ...    default=kubectl
+    ${SKIP_K8S}=    RW.Core.Import User Variable
+    ...    SKIP_K8S
+    ...    type=string
+    ...    description=Skip the Kubernetes Ingress Object health check. This may be desirable if the Kubernetes API of your cluster is not public.
+    ...    enum=[yes,no]
+    ...    example=yes
+    ...    default=yes
+    ${AZ_USERNAME}=    RW.Core.Import Secret
+    ...    AZ_USERNAME
+    ...    type=string
+    ...    description=The azure service principal user ID.
+    ...    pattern=\w*
+    ${AZ_CLIENT_SECRET}=    RW.Core.Import Secret
+    ...    AZ_CLIENT_SECRET
+    ...    type=string
+    ...    description=The service principal client secret used to authenticate with azure.
+    ...    pattern=\w*
+    ${AZ_TENANT}=    RW.Core.Import Secret
+    ...    AZ_TENANT
+    ...    type=string
+    ...    description=The azure tenant ID used by the service principal to authenticate with azure.
+    ...    pattern=\w*
+    ${AZ_HISTORY_RANGE}=    RW.Core.Import User Variable
+    ...    AZ_HISTORY_RANGE
+    ...    type=string
+    ...    description=The range of history to check for incidents in the activity log, in hours.
+    ...    pattern=\w*
+    ...    default=24
+    ...    example=24
+    ${AZ_LB_NAME}=    RW.Core.Import User Variable
+    ...    AZ_LB_NAME
+    ...    type=string
+    ...    description=The name of the Azure loadbalancer resource, used to map to activity log events.
+    ...    pattern=\w*
+    ...    example=kubernetes-internal
+    ...    example=kubernetes-internal
+    Set Suite Variable    ${kubeconfig}    ${kubeconfig}
+    Set Suite Variable    ${kubectl}    ${kubectl}
+    Set Suite Variable    ${KUBERNETES_DISTRIBUTION_BINARY}    ${KUBERNETES_DISTRIBUTION_BINARY}
+    Set Suite Variable    ${CONTEXT}    ${CONTEXT}
+    Set Suite Variable    ${NAMESPACE}    ${NAMESPACE}
+    Set Suite Variable    ${SKIP_K8S}    ${SKIP_K8S}
+    Set Suite Variable    ${AZ_USERNAME}    ${AZ_USERNAME}
+    Set Suite Variable    ${AZ_CLIENT_SECRET}    ${AZ_CLIENT_SECRET}
+    Set Suite Variable    ${AZ_TENANT}    ${AZ_TENANT}
+    Set Suite Variable    ${AZ_HISTORY_RANGE}    ${AZ_HISTORY_RANGE}
+    Set Suite Variable    ${AZ_LB_NAME}    ${AZ_LB_NAME}
+    Set Suite Variable    ${env}    {"KUBECONFIG":"./${kubeconfig.key}"}

--- a/codebundles/azure-monitor-event-triage/README.md
+++ b/codebundles/azure-monitor-event-triage/README.md
@@ -1,0 +1,23 @@
+# Azure Monitor Event Triage
+
+This codebundle queries for general activity log issues and raises them in a tabular report.
+
+## Tasks
+`Run Azure Monitor Activity Log Triage`
+
+## Configuration
+The TaskSet requires initialization to import necessary secrets, services, and user variables. The following variables should be set:
+
+- `AZ_USERNAME`: Azure service account username secret used to authenticate.
+- `AZ_CLIENT_SECRET`: Azure service account client secret used to authenticate.
+- `AZ_TENANT`: Azure tenant ID used to authenticate to.
+- `AZ_HISTORY_RANGE`: The history range to inspect for incidents in the activity log, in hours. Defaults to 24 hours.
+
+## Requirements
+- The azure service principal should have access to the azure monitor API.
+
+## TODO
+- [ ] Additional tasks
+- [ ] Refine next steps
+- [ ] Array support for issues
+- [ ] Add additional documentation.

--- a/codebundles/azure-monitor-event-triage/runbook.robot
+++ b/codebundles/azure-monitor-event-triage/runbook.robot
@@ -1,7 +1,7 @@
 *** Settings ***
-Documentation       Triages issues related to a Azure Loadbalancers and its activity logs.
+Documentation       Triages issues related to a Azure Loadbalancers, Kubernetes ingress objects and services.
 Metadata            Author    jon-funk
-Metadata            Display Name    Azure Internal LoadBalancer Triage
+Metadata            Display Name    Azure Monitor Event Triage
 Metadata            Supports    Kubernetes,AKS,Azure
 
 Library             BuiltIn
@@ -14,23 +14,18 @@ Suite Setup         Suite Initialization
 
 
 *** Tasks ***
-Health Check Internal Azure Load Balancer
+Run Azure Monitor Activity Log Triage
     [Documentation]    Queries a Azure Loadbalancer's health probe to determine if it's in a healthy state.
     [Tags]    load    balancer    azure
-    ${lb_id}=    RW.CLI.Run Cli
-    ...    cmd=az login --service-principal -u $${AZ_USERNAME.key} -p $${AZ_CLIENT_SECRET.key} --tenant $${AZ_TENANT.key} > /dev/null 2>&1 && az network lb list --query "[?name=='${AZ_LB_NAME}']" | jq -r '.[0].id'
-    ...    secret__az_username=${AZ_USERNAME}
-    ...    secret__az_client_secret=${AZ_CLIENT_SECRET}
-    ...    secret__az_tenant=${AZ_TENANT}
     ${activity_logs}=    RW.CLI.Run Cli
-    ...    cmd=START_TIME=$(date -d "${AZ_HISTORY_RANGE} hours ago" '+%Y-%m-%dT%H:%M:%SZ') && END_TIME=$(date '+%Y-%m-%dT%H:%M:%SZ') && az login --service-principal -u $${AZ_USERNAME.key} -p $${AZ_CLIENT_SECRET.key} --tenant $${AZ_TENANT.key} > /dev/null 2>&1 && az monitor activity-log list --start-time $START_TIME --end-time $END_TIME --query "[?resourceType.value=='MICROSOFT.NETWORK/loadbalancers' && resourceId=='${lb_id.stdout}']" | jq -r '.[] | [(.eventTimestamp // "N/A"), (.status.localizedValue // "N/A"), (.subStatus.localizedValue // "N/A"), (.properties.details // "N/A")] | @tsv' | while IFS=$'\t' read -r timestamp status substatus details; do printf "%-30s | %-30s | %-60s | %s\n" "$timestamp" "$status" "$substatus" "$details"; done
+    ...    cmd=START_TIME=$(date -d "${AZ_HISTORY_RANGE} hours ago" '+%Y-%m-%dT%H:%M:%SZ') && END_TIME=$(date '+%Y-%m-%dT%H:%M:%SZ') && az login --service-principal -u $${AZ_USERNAME.key} -p $${AZ_CLIENT_SECRET.key} --tenant $${AZ_TENANT.key} > /dev/null 2>&1 && az monitor activity-log list --start-time $START_TIME --end-time $END_TIME | jq -r '.[] | [(.eventTimestamp // "N/A"), (.status.localizedValue // "N/A"), (.subStatus.localizedValue // "N/A"), (.properties.details // "N/A")] | @tsv' | while IFS=$'\t' read -r timestamp status substatus details; do printf "%-30s | %-30s | %-60s | %s\n" "$timestamp" "$status" "$substatus" "$details"; done
     ...    secret__az_username=${AZ_USERNAME}
     ...    secret__az_client_secret=${AZ_CLIENT_SECRET}
     ...    secret__az_tenant=${AZ_TENANT}
-    ${activity_logs_report}=    Set Variable    "Azure Load Balancer Health Report:"
+    ${activity_logs_report}=    Set Variable    "Azure Monitor Activity Log Report:"
     IF    """${activity_logs.stdout}""" == ""
         ${activity_logs_report}=    Set Variable
-        ...    "${activity_logs_report}\n\nNo activity log events could be pulled for this resource. If there are events, consider checking the configured time range."
+        ...    "${activity_logs_report}\n\nNo activity log events could be pulled in the Azure Tenancy."
     ELSE
         ${activity_logs_report}=    Set Variable
         ...    "${activity_logs_report}\ntimestamp status substatus details\n${activity_logs.stdout}"
@@ -40,9 +35,9 @@ Health Check Internal Azure Load Balancer
     ...    set_severity_level=2
     ...    set_issue_expected=No activity logs indicating failures for the resource.
     ...    set_issue_actual=Found activity logs indicating the resource has recently experienced an error.
-    ...    set_issue_title=Load Balancer Activity Log Indicates Recent Errors
+    ...    set_issue_title=Azure Monitor Activity Log Indicates Recent Errors
     ...    set_issue_details=Activity Log History\n\n${activity_logs.stdout}
-    ...    set_issue_next_steps=Run 'az aks get-credentials' and with the credentials/context provided, use `kubectl describe service -l service.beta.kubernetes.io/azure-load-balancer-internal=true' to get a list of services and inspect their selectors. If the selectors are correct, begin troubleshooting the resource the selectors point to.
+    ...    set_issue_next_steps=Inspect the status, substatus, and details of the activity log report for more details.
     ...    _line__raise_issue_if_contains=Critical
     ${history}=    RW.CLI.Pop Shell History
     RW.Core.Add Pre To Report    ${activity_logs_report}
@@ -73,15 +68,7 @@ Suite Initialization
     ...    pattern=\w*
     ...    default=24
     ...    example=24
-    ${AZ_LB_NAME}=    RW.Core.Import User Variable
-    ...    AZ_LB_NAME
-    ...    type=string
-    ...    description=The name of the Azure loadbalancer resource, used to map to activity log events.
-    ...    pattern=\w*
-    ...    example=kubernetes-internal
-    ...    example=kubernetes-internal
     Set Suite Variable    ${AZ_USERNAME}    ${AZ_USERNAME}
     Set Suite Variable    ${AZ_CLIENT_SECRET}    ${AZ_CLIENT_SECRET}
     Set Suite Variable    ${AZ_TENANT}    ${AZ_TENANT}
     Set Suite Variable    ${AZ_HISTORY_RANGE}    ${AZ_HISTORY_RANGE}
-    Set Suite Variable    ${AZ_LB_NAME}    ${AZ_LB_NAME}

--- a/codebundles/azure-monitor-event-triage/sli.robot
+++ b/codebundles/azure-monitor-event-triage/sli.robot
@@ -1,0 +1,57 @@
+*** Settings ***
+Documentation       Measures the count of error activity log entries as a SLI metric for the Azure tenancy.
+Metadata            Author    jon-funk
+Metadata            Display Name    Azure Monitor Activity Log SLI
+Metadata            Supports    Kubernetes,AKS,Azure
+
+Library             BuiltIn
+Library             RW.Core
+Library             RW.CLI
+Library             RW.platform
+Library             OperatingSystem
+
+Suite Setup         Suite Initialization
+
+
+*** Tasks ***
+Run Azure Monitor Activity Log Triage
+    [Documentation]    Queries a Azure Loadbalancer's health probe to determine if it's in a healthy state.
+    [Tags]    load    balancer    azure
+    ${activity_logs_count}=    RW.CLI.Run Cli
+    ...    cmd=START_TIME=$(date -d "${AZ_HISTORY_RANGE} hours ago" '+%Y-%m-%dT%H:%M:%SZ') && END_TIME=$(date '+%Y-%m-%dT%H:%M:%SZ') && az login --service-principal -u $${AZ_USERNAME.key} -p $${AZ_CLIENT_SECRET.key} --tenant $${AZ_TENANT.key} > /dev/null 2>&1 && az monitor activity-log list --start-time $START_TIME --end-time $END_TIME --status Failed --status Error --status Critical --status "In Progress" | jq -r '. | length'
+    ...    secret__az_username=${AZ_USERNAME}
+    ...    secret__az_client_secret=${AZ_CLIENT_SECRET}
+    ...    secret__az_tenant=${AZ_TENANT}
+    ${history}=    RW.CLI.Pop Shell History
+    Log    Running: ${history} resulted in the following count: ${activity_logs_count}
+    RW.Core.Push Metric    ${activity_logs_count}
+
+
+*** Keywords ***
+Suite Initialization
+    ${AZ_USERNAME}=    RW.Core.Import Secret
+    ...    AZ_USERNAME
+    ...    type=string
+    ...    description=The azure service principal user ID.
+    ...    pattern=\w*
+    ${AZ_CLIENT_SECRET}=    RW.Core.Import Secret
+    ...    AZ_CLIENT_SECRET
+    ...    type=string
+    ...    description=The service principal client secret used to authenticate with azure.
+    ...    pattern=\w*
+    ${AZ_TENANT}=    RW.Core.Import Secret
+    ...    AZ_TENANT
+    ...    type=string
+    ...    description=The azure tenant ID used by the service principal to authenticate with azure.
+    ...    pattern=\w*
+    ${AZ_HISTORY_RANGE}=    RW.Core.Import User Variable
+    ...    AZ_HISTORY_RANGE
+    ...    type=string
+    ...    description=The range of history to check for incidents in the activity log, in hours.
+    ...    pattern=\w*
+    ...    default=24
+    ...    example=24
+    Set Suite Variable    ${AZ_USERNAME}    ${AZ_USERNAME}
+    Set Suite Variable    ${AZ_CLIENT_SECRET}    ${AZ_CLIENT_SECRET}
+    Set Suite Variable    ${AZ_TENANT}    ${AZ_TENANT}
+    Set Suite Variable    ${AZ_HISTORY_RANGE}    ${AZ_HISTORY_RANGE}

--- a/codebundles/k8s-app-troubleshoot/README.md
+++ b/codebundles/k8s-app-troubleshoot/README.md
@@ -1,0 +1,28 @@
+# Kubernetes Application Troubleshoot
+
+This codebundle attempts to identify issues created in application code changes recently. Currently focuses on environment misconfigurations.
+
+## Tasks
+`Get Resource Logs`
+`Scan For Misconfigured Environment`
+
+## Configuration
+The TaskSet requires initialization to import necessary secrets, services, and user variables. The following variables should be set:
+
+- `kubeconfig`: The kubeconfig secret containing access info for the cluster.
+- `kubectl`: The location service used to interpret shell commands. Default value is `kubectl-service.shared`.
+- `KUBERNETES_DISTRIBUTION_BINARY`: Which binary to use for Kubernetes CLI commands. Default value is `kubectl`.
+- `CONTEXT`: The Kubernetes context to operate within.
+- `NAMESPACE`: The name of the namespace to search. Leave it blank to search in all namespaces.
+- `LABELS`: The labaels used for resource selection, particularly for fetching logs.
+- `REPO_URI`: The URI for the git repo used to fetch source code, can be a GitHub URL.
+- `NUM_OF_COMMITS`: How many commits to search through into the past to identify potential problems.
+
+## Requirements
+- A kubeconfig with appropriate RBAC permissions to perform the desired command.
+
+## TODO
+- [ ] New keywords for code inspection
+- [ ] SPIKE for potential genAI integration
+- [ ] Add additional documentation.
+

--- a/codebundles/k8s-app-troubleshoot/env_check.sh
+++ b/codebundles/k8s-app-troubleshoot/env_check.sh
@@ -1,4 +1,12 @@
 #!/bin/bash
+# -----------------------------------------------------------------------------
+# Script Information and Metadata
+# -----------------------------------------------------------------------------
+# Author: @jon-funk
+# Description: This script checks a resource's logs for errors or potential problems 
+# related to environment variables and attempts to pinpoint them to recent code changes in the repo.
+# -----------------------------------------------------------------------------
+
 # Setup error handling
 set -Euo pipefail
 # Function to handle errors
@@ -23,10 +31,6 @@ if [ -z "$NAMESPACE" ] || [ -z "$CONTEXT" ] || [ -z "$LABELS" ] || [ -z "$REPO_U
     exit 1
 fi
 
-# clone code repo
-# search for ENV var in code
-# parse recent commits for matching files/lines
-# generate url to files
 APPLOGS=$(kubectl -n ${NAMESPACE} --context ${CONTEXT} logs deployment,statefulset -l ${LABELS} --all-containers --tail=50 --limit-bytes=256000 | grep -i env || true)
 APP_REPO_PATH=/tmp/app_repo
 git clone $REPO_URI $APP_REPO_PATH || true

--- a/codebundles/k8s-app-troubleshoot/env_check.sh
+++ b/codebundles/k8s-app-troubleshoot/env_check.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# Setup error handling
+set -Euo pipefail
+# Function to handle errors
+function handle_error() {
+    local line_number=$1
+    local function_name=$2
+    local error_code=$3
+    echo "Error occurred in function '$function_name' at line $line_number with error code $error_code"
+}
+# Trap error signals to error handler function
+trap 'handle_error $LINENO $FUNCNAME $?' ERR
+
+# Check if kubectl is available
+if ! command -v kubectl &> /dev/null; then
+    echo "kubectl command not found!"
+    exit 1
+fi
+
+# Check for namespace argument
+if [ -z "$NAMESPACE" ] || [ -z "$CONTEXT" ] || [ -z "$LABELS" ] || [ -z "$REPO_URI" ] || [ -z "$NUM_OF_COMMITS" ]; then
+    echo "Please set the NAMESPACE, LABELS, REPO_URI and CONTEXT environment variables"
+    exit 1
+fi
+
+# clone code repo
+# search for ENV var in code
+# parse recent commits for matching files/lines
+# generate url to files
+APPLOGS=$(kubectl -n ${NAMESPACE} --context ${CONTEXT} logs -l ${LABELS} --all-containers --tail=50 --limit-bytes=256000 | grep -i env || true)
+APP_REPO_PATH=/tmp/app_repo
+git clone $REPO_URI $APP_REPO_PATH || true
+cd $APP_REPO_PATH
+
+
+changes_to_investigate=""
+for word in $APPLOGS; do
+    checkpath=$(echo "$word" | tr ' ' '\n' | xargs -I{} grep -rin "{}" | grep -E "environment|env" | grep -oE "[A-Z_]{3,}" | sort | uniq || true)
+    changes_to_investigate+="${checkpath}\n"
+done;
+changes_to_investigate=$(echo -e $changes_to_investigate | sed 's/ /\n/g' | sort | uniq | sed 's/ /\n/g')
+# echo -e $changes_to_investigate
+
+GIT_URL=$(git remote get-url origin | sed -E 's/git@github.com:/https:\/\/github.com\//' | sed 's/.git$//')
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
+# Create git changes filter for final result
+MODIFIED_FILES=$(mktemp)
+for word in $changes_to_investigate; do
+    # Get a list of file paths in the last 10 commits containing the word
+    git diff HEAD~$NUM_OF_COMMITS HEAD --name-only -S "$word" >> "$MODIFIED_FILES"
+done
+MODIFIED_FILES=$(cat "$MODIFIED_FILES" | sort | uniq)
+# echo -e $MODIFIED_FILES | sed 's/ /\n/g'
+
+# Temporary file to store results
+TEMPFILE=$(mktemp)
+# Search for the words and generate GitHub links with line numbers
+for word in $changes_to_investigate; do
+    grep -rn "$word" . | while IFS=: read -r file line content; do
+        # Check if the file is in the list of modified files
+        if echo "$MODIFIED_FILES" | sed 's/ /\n/g' | grep -qF "$(basename $file)"; then
+            # Convert the file path to a GitHub link with line number
+            echo "$GIT_URL/blob/$BRANCH/$file#L$line" >> "$TEMPFILE"
+        fi
+    done
+done
+
+# Sort, make unique and print the results
+sort "$TEMPFILE" | uniq
+cat "$TEMPFILE"
+
+# Clean up the temporary file
+rm "$TEMPFILE"

--- a/codebundles/k8s-app-troubleshoot/runbook.robot
+++ b/codebundles/k8s-app-troubleshoot/runbook.robot
@@ -19,7 +19,7 @@ Get Resource Logs
     [Documentation]    Collects the last approximately 200 lines of logs from the resource before restarting it.
     [Tags]    resource    application    workload    logs    state
     ${logs}=    RW.CLI.Run Cli
-    ...    cmd=${KUBERNETES_DISTRIBUTION_BINARY} --context=${CONTEXT} -n ${NAMESPACE} logs daemonset,deployment,statefulset -l ${LABELS} --tail=200 --limit-bytes=256000
+    ...    cmd=${KUBERNETES_DISTRIBUTION_BINARY} --context=${CONTEXT} -n ${NAMESPACE} logs deployment,statefulset -l ${LABELS} --tail=200 --limit-bytes=256000
     ...    render_in_commandlist=true
     ...    env=${env}
     ...    secret_file__kubeconfig=${kubeconfig}

--- a/codebundles/k8s-app-troubleshoot/runbook.robot
+++ b/codebundles/k8s-app-troubleshoot/runbook.robot
@@ -1,0 +1,99 @@
+*** Settings ***
+Documentation       Triages issues related to a deployment and its replicas.
+Metadata            Author    jon-funk
+Metadata            Display Name    Kubernetes Application Troubleshoot
+Metadata            Supports    Kubernetes,AKS,EKS,GKE,OpenShift
+
+Library             BuiltIn
+Library             RW.Core
+Library             RW.CLI
+Library             RW.platform
+Library             RW.NextSteps
+Library             OperatingSystem
+
+Suite Setup         Suite Initialization
+
+
+*** Tasks ***
+Get Resource Logs
+    [Documentation]    Collects the last approximately 200 lines of logs from the resource before restarting it.
+    [Tags]    resource    application    workload    logs    state
+    ${logs}=    RW.CLI.Run Cli
+    ...    cmd=${KUBERNETES_DISTRIBUTION_BINARY} --context=${CONTEXT} -n ${NAMESPACE} logs daemonset,deployment,statefulset -l ${LABELS} --tail=200 --limit-bytes=256000
+    ...    render_in_commandlist=true
+    ...    env=${env}
+    ...    secret_file__kubeconfig=${kubeconfig}
+    RW.Core.Add Pre To Report    Resource Logs:\n\n${logs.stdout}
+    ${history}=    RW.CLI.Pop Shell History
+    RW.Core.Add Pre To Report    Commands Used: ${history}
+
+Scan For Misconfigured Environment
+    [Documentation]    Compares codebase to configured infra environment variables and attempts to report missing environment variables in the app
+    [Tags]    environment    variables    env    infra
+    ${script_run}=    RW.CLI.Run Bash File
+    ...    bash_file=env_check.sh
+    ...    include_in_history=False
+    ...    env=${env}
+    ...    secret_file__kubeconfig=${kubeconfig}
+    ${history}=    RW.CLI.Pop Shell History
+    RW.Core.Add Pre To Report    Stdout:\n\n${script_run.stdout}
+    RW.Core.Add Pre To Report    Commands Used: ${history}
+
+
+*** Keywords ***
+Suite Initialization
+    ${kubeconfig}=    RW.Core.Import Secret
+    ...    kubeconfig
+    ...    type=string
+    ...    description=The kubernetes kubeconfig yaml containing connection configuration used to connect to cluster(s).
+    ...    pattern=\w*
+    ...    example=For examples, start here https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/
+    ${kubectl}=    RW.Core.Import Service    kubectl
+    ...    description=The location service used to interpret shell commands.
+    ...    default=kubectl-service.shared
+    ...    example=kubectl-service.shared
+    ${NAMESPACE}=    RW.Core.Import User Variable    NAMESPACE
+    ...    type=string
+    ...    description=The name of the Kubernetes namespace to scope actions and searching to.
+    ...    pattern=\w*
+    ...    example=my-namespace
+    ...    default=sock-shop
+    ${CONTEXT}=    RW.Core.Import User Variable    CONTEXT
+    ...    type=string
+    ...    description=Which Kubernetes context to operate within.
+    ...    pattern=\w*
+    ...    example=sandbox-cluster-1
+    ...    default=sandbox-cluster-1
+    ${KUBERNETES_DISTRIBUTION_BINARY}=    RW.Core.Import User Variable    KUBERNETES_DISTRIBUTION_BINARY
+    ...    type=string
+    ...    description=Which binary to use for Kubernetes CLI commands.
+    ...    enum=[kubectl,oc]
+    ...    example=kubectl
+    ...    default=kubectl
+    ${REPO_URI}=    RW.Core.Import User Variable    REPO_URI
+    ...    type=string
+    ...    description=Repo URI for the source code to inspect.
+    ...    pattern=\w*
+    ...    example=https://github.com/runwhen-contrib/runwhen-local
+    ...    default=https://github.com/runwhen-contrib/runwhen-local
+    ${LABELS}=    RW.Core.Import User Variable    LABELS
+    ...    type=string
+    ...    description=The Kubernetes labels used to select the resource for logs.
+    ...    pattern=\w*
+    ${NUM_OF_COMMITS}=    RW.Core.Import User Variable
+    ...    NUM_OF_COMMITS
+    ...    type=string
+    ...    description=The number of commits to look through when troubleshooting. Adjust this based on your team's git usage and commit frequency.
+    ...    pattern=\w*
+    ...    example=3
+    ...    default=3
+    Set Suite Variable    ${kubeconfig}    ${kubeconfig}
+    Set Suite Variable    ${kubectl}    ${kubectl}
+    Set Suite Variable    ${KUBERNETES_DISTRIBUTION_BINARY}    ${KUBERNETES_DISTRIBUTION_BINARY}
+    Set Suite Variable    ${CONTEXT}    ${CONTEXT}
+    Set Suite Variable    ${REPO_URI}    ${REPO_URI}
+    Set Suite Variable    ${LABELS}    ${LABELS}
+    Set Suite Variable    ${NAMESPACE}    ${NAMESPACE}
+    Set Suite Variable
+    ...    ${env}
+    ...    {"NUM_OF_COMMITS":"${NUM_OF_COMMITS}", "REPO_URI":"${REPO_URI}", "LABELS":"${LABELS}", "KUBECONFIG":"./${kubeconfig.key}", "KUBERNETES_DISTRIBUTION_BINARY":"${KUBERNETES_DISTRIBUTION_BINARY}", "CONTEXT":"${CONTEXT}", "NAMESPACE":"${NAMESPACE}"}

--- a/codebundles/k8s-restart-resource/README.md
+++ b/codebundles/k8s-restart-resource/README.md
@@ -1,0 +1,29 @@
+# Kubernetes Restart Resource
+
+Restarts a kubernetes resource in an attempt to get it out of a bad state. This would typically be used in conjunction with other
+tasksets after collecting some information about the resource and what state it is in. This taskset supports Deployments,Daemonsets and StatefulSets.
+It applies a `rollout restart` to the resource to respect rollout strategies and avoid downtime provided the resource is highly-available.
+
+## Tasks
+`Get Current Resource State`
+`Get Resource Logs`
+`Restart Resource`
+
+## Configuration
+
+The TaskSet requires initialization to import necessary secrets, services, and user variables. The following variables should be set:
+
+- `kubeconfig`: The kubeconfig secret containing access info for the cluster.
+- `kubectl`: The location service used to interpret shell commands. Default value is `kubectl-service.shared`.
+- `KUBERNETES_DISTRIBUTION_BINARY`: Which binary to use for Kubernetes CLI commands. Default value is `kubectl`.
+- `CONTEXT`: The Kubernetes context to operate within.
+- `NAMESPACE`: The name of the namespace to search.
+- `LABELS`: The set of kubernetes labels used in the selector for the resource. Ensure this is specific enough to get the exact resource you want to restart.
+
+## Notes
+
+Please note that these checks require Kubernetes RBAC exec permissions for the service account used.
+
+## TODO
+- [ ] Add documentation
+- [ ] Refine raised issues

--- a/codebundles/k8s-restart-resource/runbook.robot
+++ b/codebundles/k8s-restart-resource/runbook.robot
@@ -1,0 +1,100 @@
+*** Settings ***
+Documentation       This taskset restarts a resource with a given set of labels, typically used with other tasksets.
+Metadata            Author    jon-funk
+Metadata            Display Name    Kubernetes Restart resource
+Metadata            Supports    Kubernetes,AKS,EKS,GKE,OpenShift
+
+Library             BuiltIn
+Library             RW.Core
+Library             RW.CLI
+Library             RW.platform
+Library             OperatingSystem
+Library             DateTime
+Library             Collections
+
+Suite Setup         Suite Initialization
+
+
+*** Tasks ***
+Get Current Resource State
+    [Documentation]    Gets the current state of the resource before applying the restart for report review.
+    [Tags]    resource    application    restart    state    yaml
+    ${resource}=    RW.CLI.Run Cli
+    ...    cmd=${KUBERNETES_DISTRIBUTION_BINARY} --context=${CONTEXT} -n ${NAMESPACE} get daemonset,deployment,statefulset -l ${LABELS} -oyaml
+    ...    render_in_commandlist=true
+    ...    env=${env}
+    ...    secret_file__kubeconfig=${kubeconfig}
+    RW.Core.Add Pre To Report    Current Resource State:\n\n${resource.stdout}
+    ${history}=    RW.CLI.Pop Shell History
+    RW.Core.Add Pre To Report    Commands Used: ${history}
+
+Get Resource Logs
+    [Documentation]    Collects the last approximately 200 lines of logs from the resource before restarting it.
+    [Tags]    resource    application    workload    logs    state
+    ${logs}=    RW.CLI.Run Cli
+    ...    cmd=${KUBERNETES_DISTRIBUTION_BINARY} --context=${CONTEXT} -n ${NAMESPACE} logs daemonset,deployment,statefulset -l ${LABELS} --tail=200 --limit-bytes=256000
+    ...    render_in_commandlist=true
+    ...    env=${env}
+    ...    secret_file__kubeconfig=${kubeconfig}
+    RW.Core.Add Pre To Report    Resource Logs:\n\n${logs.stdout}
+    ${history}=    RW.CLI.Pop Shell History
+    RW.Core.Add Pre To Report    Commands Used: ${history}
+
+Restart Resource
+    [Documentation]    Restarts the labeled resource in an attempt to get it out of a bad state.
+    [Tags]    resource    application    restart    pod    kill    rollout    revision
+    ${resource_name}=    RW.CLI.Run Cli
+    ...    cmd=${KUBERNETES_DISTRIBUTION_BINARY} --context=${CONTEXT} -n ${NAMESPACE} get daemonset,deployment,statefulset -l ${LABELS} -o=jsonpath='{.items[0].kind}/{.items[0].metadata.name}'
+    ...    render_in_commandlist=true
+    ...    env=${env}
+    ...    secret_file__kubeconfig=${kubeconfig}
+    ${rsp}=    RW.CLI.Run Cli
+    ...    cmd=${KUBERNETES_DISTRIBUTION_BINARY} rollout restart ${resource_name.stdout} --context=${CONTEXT} -n ${NAMESPACE}
+    ...    render_in_commandlist=true
+    ...    env=${env}
+    ...    secret_file__kubeconfig=${kubeconfig}
+    RW.Core.Add Pre To Report    Restarted the following workload: ${resource_name.stdout}
+    ${history}=    RW.CLI.Pop Shell History
+    RW.Core.Add Pre To Report    Commands Used: ${history}
+
+
+*** Keywords ***
+Suite Initialization
+    ${kubeconfig}=    RW.Core.Import Secret
+    ...    kubeconfig
+    ...    type=string
+    ...    description=The kubernetes kubeconfig yaml containing connection configuration used to connect to cluster(s).
+    ...    pattern=\w*
+    ...    example=For examples, start here https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/
+    ${kubectl}=    RW.Core.Import Service    kubectl
+    ...    description=The location service used to interpret shell commands.
+    ...    default=kubectl-service.shared
+    ...    example=kubectl-service.shared
+    ${KUBERNETES_DISTRIBUTION_BINARY}=    RW.Core.Import User Variable    KUBERNETES_DISTRIBUTION_BINARY
+    ...    type=string
+    ...    description=Which binary to use for Kubernetes CLI commands.
+    ...    enum=[kubectl,oc]
+    ...    example=kubectl
+    ...    default=kubectl
+    ${CONTEXT}=    RW.Core.Import User Variable    CONTEXT
+    ...    type=string
+    ...    description=Which Kubernetes context to operate within.
+    ...    pattern=\w*
+    ...    example=my-main-cluster
+    ${NAMESPACE}=    RW.Core.Import User Variable    NAMESPACE
+    ...    type=string
+    ...    description=The name of the namespace to search.
+    ...    pattern=\w*
+    ...    example=otel-demo
+    ...    default=
+    ${LABELS}=    RW.Core.Import User Variable    LABELS
+    ...    type=string
+    ...    description=The kubectl label string to use for selecting the resource.
+    ...    pattern=\w*
+    Set Suite Variable    ${kubeconfig}    ${kubeconfig}
+    Set Suite Variable    ${kubectl}    ${kubectl}
+    Set Suite Variable    ${KUBERNETES_DISTRIBUTION_BINARY}    ${KUBERNETES_DISTRIBUTION_BINARY}
+    Set Suite Variable    ${CONTEXT}    ${CONTEXT}
+    Set Suite Variable    ${NAMESPACE}    ${NAMESPACE}
+    Set Suite Variable    ${LABELS}    ${LABELS}
+    Set Suite Variable    ${env}    {"KUBECONFIG":"./${kubeconfig.key}"}


### PR DESCRIPTION
- Adds codebundle for triaging Azure internal loadbalancer errors
- Adds starter mvp for application troubleshooting on the platform
- Adds generalized azure monitor triage report and SLI for monitoring activity logs API as error metric
- Adds codebundle to restart kubernetes resources (using rollout to respect strategies), ideally recommended at the end of troubleshooting session