### PR TITLE
Update action - generalized task title in metadata 

### DIFF
--- a/.github/scripts/meta.py
+++ b/.github/scripts/meta.py
@@ -198,6 +198,9 @@ def generate_metadata(directory_path):
         for item in interesting_commands:
             name = item['name']
             command = item['command']
+
+            #Remove special chars for vars in name
+            name = name.replace('`', '').replace('${', '').replace('}', '')
             # Convert name to lower snake case
             name_snake_case = re.sub(r'\W+', '_', name.lower())
 

--- a/codebundles/curl-gmp-nginx-ingress-inspection/meta.yaml
+++ b/codebundles/curl-gmp-nginx-ingress-inspection/meta.yaml
@@ -41,7 +41,7 @@ commands:
     \ | jq -r 'if .data.result[0] then \"Host:\" + .data.result[0].metric.host + \"\
     \ Ingress:\" + .data.result[0].metric.ingress + \" Namespace:\" + .data.result[0].metric.exported_namespace\
     \ + \" Service:\" + .data.result[0].metric.service else \"\" end'"
-  name: fetch_nginx_http_errors_from_gmp_for_ingress_ingress_object_name_
+  name: fetch_nginx_http_errors_from_gmp_for_ingress_ingress_object_name
 - command: 'namespace="${NAMESPACE}"; context="${CONTEXT}"; ingress="${INGRESS_OBJECT_NAME}";
     echo "Ingress: $ingress"; health_status="NA"; services=(); backend_services=$(kubectl
     get ingress "$ingress" -n "$namespace" --context "$context" -ojsonpath=''{range
@@ -170,4 +170,4 @@ commands:
     \        echo \"Validation: Service $SERVICE does not exist\"\n    else\n    \
     \    ENDPOINT_EXISTS=$(kubectl get endpoints \"$SERVICE\" -n \"$NAMESPACE\" --context\
     \ \"$CONTEXT\" -ojsonpath='{.metadata.name}')\n        # Validate that the Service"
-  name: find_owner_and_service_health_for_ingress_ingress_object_name_
+  name: find_owner_and_service_health_for_ingress_ingress_object_name

--- a/codebundles/k8s-certmanager-healthcheck/meta.yaml
+++ b/codebundles/k8s-certmanager-healthcheck/meta.yaml
@@ -60,7 +60,7 @@ commands:
     # Echo the final result
 
     echo "${RESULT}"'
-  name: get_namespace_certificate_summary_for_namespace_namespace_
+  name: get_namespace_certificate_summary_for_namespace_namespace
 - command: 'kubectl get certificaterequests.cert-manager.io --context=${CONTEXT} -n
     ${NAMESPACE} -o json | jq -r ''.items[] | select(.status.conditions[] | select(.type
     == "Ready" and .status != "True")) | {certRequest: .metadata.name, certificate:
@@ -111,4 +111,4 @@ commands:
     , \"Certificate: \\(.certificate)\", \"Issuer: \\(.issuer)\", \"Ready Status:\
     \ \\(.readyStatus)\", \"Ready Message: \\(.readyMessage)\", \"Approved Status:\
     \ \\(.approvedStatus)\", \"Approved Message: \\(.approvedMessage)\"'"
-  name: find_failed_certificate_requests_and_identify_issues_for_namespace_namespace_
+  name: find_failed_certificate_requests_and_identify_issues_for_namespace_namespace

--- a/codebundles/k8s-deployment-healthcheck/meta.yaml
+++ b/codebundles/k8s-deployment-healthcheck/meta.yaml
@@ -54,7 +54,7 @@ commands:
     \ | unique, \n            firstTimestamp: map(.firstTimestamp | fromdateiso8601)\
     \ | sort | .[0] | todateiso8601, \\\n            lastTimestamp: map(.lastTimestamp\
     \ | fromdateiso8601) | sort | reverse | .[0] | todateiso8601})'"
-  name: troubleshoot_deployment_warning_events_for_deployment_name_
+  name: troubleshoot_deployment_warning_events_for_deployment_name
 - command: kubectl get deployment/${DEPLOYMENT_NAME} --context ${CONTEXT} -n ${NAMESPACE}
     -o yaml
   doc_links: '
@@ -129,7 +129,7 @@ commands:
     \ end), progressing_condition: (if any(.conditions[]; .type == \"Progressing\"\
     ) then (.conditions[] | select(.type == \"Progressing\")) else \"Condition not\
     \ available\" end)}'"
-  name: troubleshoot_deployment_replicas_for_deployment_name_
+  name: troubleshoot_deployment_replicas_for_deployment_name
 - command: 'kubectl get events --context ${CONTEXT} -n ${NAMESPACE} -o json | jq ''(now
     - (60*60)) as $time_limit | [ .items[] | select(.type != "Warning" and (.involvedObject.kind
     == "Deployment" or .involvedObject.kind == "ReplicaSet" or .involvedObject.kind
@@ -180,4 +180,4 @@ commands:
     \ == 1 then 1 else ((map(.count) | add)/.[0].duration ) end),firstTimestamp: map(.firstTimestamp\
     \ | fromdateiso8601) | sort | .[0] | todateiso8601, lastTimestamp: map(.lastTimestamp\
     \ | fromdateiso8601) | sort | reverse | .[0] | todateiso8601})'"
-  name: check_deployment_event_anomalies_for_deployment_name_
+  name: check_deployment_event_anomalies_for_deployment_name

--- a/codebundles/k8s-image-check/meta.yaml
+++ b/codebundles/k8s-image-check/meta.yaml
@@ -33,7 +33,7 @@ commands:
     \ Started Times:\" + (.status.containerStatuses[].state.running.startedAt|tostring)]'\
     \ \\ \n# Select information for each pod including the image being used and the\
     \ last time it was started."
-  name: check_image_rollover_times_for_namespace_namespace_
+  name: check_image_rollover_times_for_namespace_namespace
 - command: 'kubectl get pods --context=${CONTEXT} -n ${NAMESPACE} --field-selector=status.phase==Running
     -o=json | jq -r ''.items[] | "---", "pod_name: " + .metadata.name, "Status: "
     + .status.phase, "containers:", (.spec.containers[] | "- container_name: " + .name,
@@ -71,7 +71,7 @@ commands:
     \ split(\":\")[0]), #Retrieves an image's path\n    \" \\ image_tag: \" + (.image\
     \ | split(\":\")[1])), #Retrievs an image's tag\n    \"---\"' #Represents end\
     \ of a pod data"
-  name: list_images_and_tags_for_every_container_in_running_pods_for_namespace_namespace_
+  name: list_images_and_tags_for_every_container_in_running_pods_for_namespace_namespace
 - command: 'kubectl get pods --context=${CONTEXT} -n ${NAMESPACE} --field-selector=status.phase==Failed
     -o=json | jq -r ''.items[] | "---", "pod_name: " + .metadata.name, "Status: "
     + .status.phase, "containers:", (.spec.containers[] | "- container_name: " + .name,
@@ -110,7 +110,7 @@ commands:
     \ | \"- container_name: \" + .name, \" \\ image_path: \" + \\(.image | split(\"\
     :\")[0]), \" \\ image_tag: \" + (.image | split(\":\")[1])), \"---\"')\n\n# Print\
     \ the result\necho $OUTPUT"
-  name: list_images_and_tags_for_every_container_in_failed_pods_for_namespace_namespace_
+  name: list_images_and_tags_for_every_container_in_failed_pods_for_namespace_namespace
 - command: 'NAMESPACE=${NAMESPACE}; POD_NAME="skopeo-pod"; CONTEXT="${CONTEXT}"; events=$(kubectl
     get events -n $NAMESPACE --context=$CONTEXT -o json | jq --arg timestamp "$(date
     -u -v -5M +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u -d "-5 minutes" +"%Y-%m-%dT%H:%M:%SZ")"
@@ -219,4 +219,4 @@ commands:
     \ );\n    echo \"$available_tags\";\n  fi;\n\n# Loop ends here.\ndone <<<\"$image_pull_backoff_events\"\
     \n# Cleanup the pod once the loop has finished.\necho \"Deleting Skopeo pod\"\n\
     kubectl delete pod $POD_NAME -n $NAMESPACE --context=$CONTEXT\necho \"Done\""
-  name: list_imagepullbackoff_events_and_test_path_and_tags_for_namespace_namespace_
+  name: list_imagepullbackoff_events_and_test_path_and_tags_for_namespace_namespace

--- a/codebundles/k8s-image-check/runbook.robot
+++ b/codebundles/k8s-image-check/runbook.robot
@@ -53,7 +53,7 @@ List Images and Tags for Every Container in Running Pods for Namespace `${NAMESP
     ${history}=    RW.CLI.Pop Shell History
     RW.Core.Add Pre To Report    Commands Used: ${history}
 
-List Images and Tags for Every Container in Failed Pods for Namespace`${NAMESPACE}`
+List Images and Tags for Every Container in Failed Pods for Namespace `${NAMESPACE}`
     [Documentation]    Display the status, image name, image tag, and container name for failed pods in the namespace.
     [Tags]    pods    containers    image    images    tag
     ${image_details}=    RW.CLI.Run Cli

--- a/codebundles/k8s-ingress-healthcheck/meta.yaml
+++ b/codebundles/k8s-ingress-healthcheck/meta.yaml
@@ -123,7 +123,7 @@ commands:
     \         echo \"$endpoint_pods\";\n            health_status=\"Healthy\";\n \
     \       fi\n\n    done<<<\"$backend_services\";\n\n    echo \"Health Status: $health_status\"\
     ;\n    echo \"------------\";\ndone"
-  name: fetch_ingress_object_health_in_namespace_namespace_
+  name: fetch_ingress_object_health_in_namespace_namespace
 - command: 'CONTEXT="${CONTEXT}"; NAMESPACE="${NAMESPACE}"; kubectl --context "${CONTEXT}"
     --namespace "${NAMESPACE}" get ingress -o json | jq -r ''.items[] | select(.status.loadBalancer.ingress)
     | .metadata.name as \$name | .status.loadBalancer.ingress[0].ip as \$ingress_ip
@@ -182,4 +182,4 @@ commands:
     \ - Service \\($service_name) is of type LoadBalancer with IP (\\($service_ip))\"\
     \ end else \"OK: Ingress \\($ingress_name) - Service \\($service_name) is of type\
     \ \\(.spec.type) on port \\($service_port)\" end'; done"
-  name: check_for_ingress_and_service_conflicts_in_namespace_namespace_
+  name: check_for_ingress_and_service_conflicts_in_namespace_namespace

--- a/codebundles/k8s-namespace-healthcheck/meta.yaml
+++ b/codebundles/k8s-namespace-healthcheck/meta.yaml
@@ -53,7 +53,7 @@ commands:
     \ | sort | first), most_recent_timestamp: (map(.lastTimestamp) | sort | last)})\
     \ | \\\n map(select((now - ((.most_recent_timestamp | fromdateiso8601)))/60 <=\
     \ 30))' \\\n > $HOME/warning_events_summary.json"
-  name: troubleshoot_warning_events_in_namespace_namespace_
+  name: troubleshoot_warning_events_in_namespace_namespace
 - command: 'kubectl get pods --context=${CONTEXT} -n ${NAMESPACE} -o json | jq -r
     --argjson exit_code_explanations ''{"0": "Success", "1": "Error", "2": "Misconfiguration",
     "130": "Pod terminated by SIGINT", "134": "Abnormal Termination SIGABRT", "137":
@@ -111,7 +111,7 @@ commands:
     )\\nterminated_finishedAt: \\(.lastState.terminated.finishedAt // \"N/A\")\\nterminated_exitCode:\
     \ \\(.lastState.terminated.exitCode // \"N/A\")\\nexit_code_explanation: \\($exit_code_explanations[.lastState.terminated.exitCode\
     \ | tostring] // \"Unknown exit code\")\") + \"\\n---\\n\""
-  name: troubleshoot_container_restarts_in_namespace_namespace_
+  name: troubleshoot_container_restarts_in_namespace_namespace
 - command: 'kubectl get pods --context=${CONTEXT} -n ${NAMESPACE} --field-selector=status.phase=Pending
     --no-headers -o json | jq -r ''.items[] | "pod_name: \(.metadata.name)\nstatus:
     \(.status.phase // "N/A")\nmessage: \(.status.conditions[0].message // "N/A")\nreason:
@@ -147,7 +147,7 @@ commands:
     \ \\((.status.containerStatuses[0].state // \"N/A\"))\\ncontainerMessage: \\(.status.containerStatuses[0].state.waiting?.message\
     \ // \"N/A\")\\ncontainerReason: \\(.status.containerStatuses[0].state.waiting?.reason\
     \ // \"N/A\")\\n------------\"'"
-  name: troubleshoot_pending_pods_in_namespace_namespace_
+  name: troubleshoot_pending_pods_in_namespace_namespace
 - command: 'kubectl get pods --context=${CONTEXT} -n ${NAMESPACE} --field-selector=status.phase=Failed
     --no-headers -o json | jq -r --argjson exit_code_explanations ''{"0": "Success",
     "1": "Error", "2": "Misconfiguration", "130": "Pod terminated by SIGINT", "134":
@@ -204,7 +204,7 @@ commands:
     \ \\($exit_code_explanations[.status.containerStatuses[0].state.terminated.exitCode\
     \ | tostring] // \"Unknown exit code\")\\n------------\"' # Output the fields\
     \ we are interested in in a user friendly format"
-  name: troubleshoot_failed_pods_in_namespace_namespace_
+  name: troubleshoot_failed_pods_in_namespace_namespace
 - command: 'kubectl get pods --context ${CONTEXT} -n ${NAMESPACE} -o json | jq -r
     ''.items[] | select(.status.conditions[]? | select(.type == "Ready" and .status
     == "False" and .reason != "PodCompleted")) | {kind: .kind, name: .metadata.name,
@@ -236,7 +236,7 @@ commands:
     )) \n    # map the output to dictionary containing kind, name and conditions fields\n\
     \    | {kind: .kind, name: .metadata.name, conditions: .status.conditions}' \\\
     \n    # flatten results into an an array of objects\n    | jq -s '.'"
-  name: troubleshoot_workload_status_conditions_in_namespace_namespace_
+  name: troubleshoot_workload_status_conditions_in_namespace_namespace
 - command: kubectl api-resources --verbs=list --namespaced -o name --context=${CONTEXT}
     | xargs -n 1 kubectl get --show-kind --ignore-not-found -n ${NAMESPACE} --context=${CONTEXT}
   doc_links: '
@@ -269,7 +269,7 @@ commands:
     \ line-by-line\nxargs \\\n    -n 1 \\\n    kubectl \\\n        get \\\n      \
     \      --show-kind \\\n            --ignore-not-found \\\n            -n ${NAMESPACE}\
     \ \\\n            --context=${CONTEXT}"
-  name: get_listing_of_resources_in_namespace_namespace_
+  name: get_listing_of_resources_in_namespace_namespace
 - command: 'kubectl get events --field-selector type!=Warning --context ${CONTEXT}
     -n ${NAMESPACE} -o json > $HOME/events.json && cat $HOME/events.json | jq -r ''[.items[]
     | {namespace: .involvedObject.namespace, kind: .involvedObject.kind, name: ((if
@@ -330,7 +330,7 @@ commands:
     \ > $threshold)' \\\n\n# Convert the dataset into valid JSON array\n| jq -s '.'\
     \ \\\n\n# Validate and summarize the dataset using python3 script\n| python3 ${AIRGAP}/airgap_scripts/summary.py\
     \ -"
-  name: check_event_anomalies_in_namespace_namespace_
+  name: check_event_anomalies_in_namespace_namespace
 - command: 'services=($(kubectl get svc -o=name --context=${CONTEXT} -n ${NAMESPACE}))
     && [ \${#services[@]} -eq 0 ] && echo "No services found." || { > "logs.json";
     for service in "\${services[@]}"; do kubectl logs $service --limit-bytes=256000
@@ -390,7 +390,7 @@ commands:
     \ length}) | sort_by(.count) | reverse | .[0:3])})) ] | add' > $HOME/output;\n\
     \n        # Output the log entries in the formatted output\n        cat $HOME/output\n\
     \    fi\nfi"
-  name: troubleshoot_services_and_application_workloads_in_namespace_namespace_
+  name: troubleshoot_services_and_application_workloads_in_namespace_namespace
 - command: context="${CONTEXT}"; namespace="${NAMESPACE}"; check_health() { local
     type=$1; local name=$2; local replicas=$3; local selector=$4; local pdbs=$(kubectl
     --context "$context" --namespace "$namespace" get pdb -o json | jq -c --arg selector
@@ -489,4 +489,4 @@ commands:
     \ | to_entries[] | .key + \"=\" + .value)\"' | while read -r line; do\n\n    #\
     \ Step 5c: Invoke the check_health with relevant parameters\n    check_health\
     \ \"StatefulSet\" $(echo $line | tr -d '\"');\ndone"
-  name: check_missing_or_risky_poddisruptionbudget_policies_in_namepace_namespace_
+  name: check_missing_or_risky_poddisruptionbudget_policies_in_namepace_namespace

--- a/codebundles/k8s-podresources-health/meta.yaml
+++ b/codebundles/k8s-podresources-health/meta.yaml
@@ -56,7 +56,7 @@ commands:
 
     | jq -r ''[.items[] as $pod | ($pod.spec.containers // [][])[] | select(.resources.limits
     == null) | {pod: $pod.metadata.name, container_without_limits: .name}]'''
-  name: show_pods_without_resource_limit_or_resource_requests_set_in_namespace_namespace_
+  name: show_pods_without_resource_limit_or_resource_requests_set_in_namespace_namespace
 - command: 'kubectl get pods --context=${CONTEXT} -n ${NAMESPACE} ${LABELS} --field-selector=status.phase=Running
     -ojson | jq -r ''[.items[] as $pod | ($pod.spec.containers // [][])[] | select(.resources.requests
     == null) | {pod: $pod.metadata.name, container_without_requests: .name}]'''
@@ -90,7 +90,7 @@ commands:
     \ | select(.resources.requests == null) | {pod: $pod.metadata.name, container_without_requests:\
     \ .name}]'  # Process output using the jq utility, returning the names of pods\
     \ and containers which have no requests set"
-  name: show_pods_without_resource_limit_or_resource_requests_set_in_namespace_namespace_
+  name: show_pods_without_resource_limit_or_resource_requests_set_in_namespace_namespace
 - command: for pod in $(kubectl get pods ${LABELS} -n ${NAMESPACE} --context ${CONTEXT}
     -o custom-columns=":metadata.name" --field-selector=status.phase=Running); do
     kubectl top pod $pod -n ${NAMESPACE} --context ${CONTEXT} --containers; done
@@ -114,4 +114,4 @@ commands:
     # Iterate through the retrieved pod list\nfor pod in $POD_LIST; do\n    \n   \
     \ # For each pod, perform the top command for containers\n    kubectl top pod\
     \ $pod -n ${NAMESPACE} --context ${CONTEXT} --containers; \ndone"
-  name: get_pod_resource_utilization_with_top_in_namespace_namespace_
+  name: get_pod_resource_utilization_with_top_in_namespace_namespace

--- a/codebundles/k8s-pvc-healthcheck/meta.yaml
+++ b/codebundles/k8s-pvc-healthcheck/meta.yaml
@@ -31,7 +31,7 @@ commands:
     \ name and message for each event\n    echo $events | jq '.items[]| \"Last Timestamp:\
     \ \" + .lastTimestamp + \" Name: \" + .involvedObject.name + \" Message: \" +\
     \ .message'\n done"
-  name: fetch_events_for_unhealthy_kubernetes_persistentvolumeclaims_in_namespace_namespace_
+  name: fetch_events_for_unhealthy_kubernetes_persistentvolumeclaims_in_namespace_namespace
 - command: 'namespace=${NAMESPACE}; context=${CONTEXT}; kubectl get pvc -n $namespace
     --context=$context -o json | jq -r ''.items[] | select(.metadata.deletionTimestamp
     != null) | .metadata.name as $name | .metadata.deletionTimestamp as $deletion_time
@@ -85,7 +85,7 @@ commands:
     as $name | .metadata.deletionTimestamp as $deletion_time | .metadata.finalizers
     as $finalizers | "\($name) is in Terminating state (Deletion started at: \($deletion_time)).
     Finalizers: \($finalizers)"'''
-  name: list_persistentvolumeclaims_in_terminating_state_in_namespace_namespace_
+  name: list_persistentvolumeclaims_in_terminating_state_in_namespace_namespace
 - command: 'for pv in $(kubectl get pv --context ${CONTEXT} -o json | jq -r ''.items[]
     | select(.status.phase == "Terminating") | .metadata.name''); do kubectl get events
     --all-namespaces --field-selector involvedObject.name=$pv --context ${CONTEXT}
@@ -125,7 +125,7 @@ commands:
     \ in $\u0420V_EVENTS; do \n            echo $(echo $event | jq '\"Last Timestamp:\
     \ \" + .lastTimestamp + \" Name: \" + .involvedObject.name + \" Message: \" +\
     \ .message')\n        done\n    fi\ndone"
-  name: list_persistentvolumes_in_terminating_state_in_namespace_namespace_
+  name: list_persistentvolumes_in_terminating_state_in_namespace_namespace
 - command: 'for pod in $(kubectl get pods -n ${NAMESPACE} --field-selector=status.phase=Running
     --context ${CONTEXT} -o jsonpath=''{range .items[*]}{.metadata.name}{"\n"}{end}'');
     do for pvc in $(kubectl get pods $pod -n ${NAMESPACE} --context ${CONTEXT} -o
@@ -195,7 +195,7 @@ commands:
     nPod: $pod\\nPVC: $pvc\\nPV: $pv\\nStatus: $status\\nNode: $node\\nZone: $zone\\\
     nIngressClass: $ingressclass\\nAccessModes: $accessmode\\nReclaimPolicy: $reclaimpolicy\\\
     nCSIDriver: $csidriver\\n\"; \n    done;  \ndone"
-  name: list_pods_with_attached_volumes_and_related_persistentvolume_details_in_namespace_namespace_
+  name: list_pods_with_attached_volumes_and_related_persistentvolume_details_in_namespace_namespace
 - command: 'for pod in $(kubectl get pods -n ${NAMESPACE} --field-selector=status.phase=Running
     --context ${CONTEXT} -o jsonpath=''{range .items[*]}{.metadata.name}{"\n"}{end}'');
     do for pvc in $(kubectl get pods $pod -n ${NAMESPACE} --context ${CONTEXT} -o
@@ -254,7 +254,7 @@ commands:
     \ to query disk usage on the mountPath:\n            kubectl exec $pod -n ${NAMESPACE}\
     \ --context ${CONTEXT} -c $containerName -- df -h $mountPath; \n        done;\
     \ \n    done; \ndone;"
-  name: fetch_the_storage_utilization_for_pvc_mounts_in_namespace_namespace_
+  name: fetch_the_storage_utilization_for_pvc_mounts_in_namespace_namespace
 - command: 'NAMESPACE="${NAMESPACE}"; CONTEXT="${CONTEXT}"; PODS=$(kubectl get pods
     -n $NAMESPACE --context=$CONTEXT -o json); for pod in $(jq -r ''.items[] | @base64''
     <<< "$PODS"); do _jq() { jq -r \${1} <<< "$(base64 --decode <<< \${pod})"; };
@@ -332,4 +332,4 @@ commands:
     \ $pvc_name\";\n            echo \"PV: $PV_NAME\";\n            echo \"Node with\
     \ Pod: $POD_NODE_NAME\";\n            echo \"Node with Storage: $STORAGE_NODE_NAME\"\
     ;\n            echo;\n        fi;\n    done;\ndone"
-  name: check_for_rwo_persistent_volume_node_attachment_issues_in_namespace_namespace_
+  name: check_for_rwo_persistent_volume_node_attachment_issues_in_namespace_namespace

--- a/codebundles/k8s-statefulset-healthcheck/meta.yaml
+++ b/codebundles/k8s-statefulset-healthcheck/meta.yaml
@@ -122,4 +122,4 @@ commands:
     -o json \\\n| jq -r '.items[] | select(.status.availableReplicas < .status.replicas)\
     \ | \"---\\nStatefulSet Name: \" + (.metadata.name|tostring) + \"\\nDesired Replicas:\
     \ \" + (.status.replicas|tostring) + \"\\nAvailable Replicas: \" + (.status.availableReplicas|tostring)'"
-  name: list_statefulsets_with_unhealthy_replica_counts_in_namespace_namespace_
+  name: list_statefulsets_with_unhealthy_replica_counts_in_namespace_namespace


### PR DESCRIPTION
When adding resource names into task titles, we need to generalize the variable inside of metadata so that runwhen local and the platform can fetch the explanation and documentation links. Fixes https://github.com/runwhen-contrib/runwhen-local/issues/383