### PR TITLE
Kubectl generic

### DIFF
--- a/codebundles/k8s-kubectl-cmd/README.md
+++ b/codebundles/k8s-kubectl-cmd/README.md
@@ -1,0 +1,15 @@
+# Kubernetes kubectl cmd
+A generic codebundle used for running bare kubectl commands in a bash shell. 
+
+## SLI
+The command provided must provide a single metric that is pushed to the RunWhen Platform. 
+
+Example: `kubectl get pods -n online-boutique -o json | jq '[.items[]] | length`
+
+## TaskSet
+The command has all output added to the report for review during a RunSession. 
+
+Example: `kubectl describe pods -n online-boutique`
+
+## Requirements
+- A kubeconfig with appropriate RBAC permissions to perform the desired command.

--- a/codebundles/k8s-kubectl-cmd/runbook.robot
+++ b/codebundles/k8s-kubectl-cmd/runbook.robot
@@ -1,5 +1,5 @@
 *** Settings ***
-Documentation       This taskset runs a user provided kubectl command andadds the output to the report. Command line tools like jq are available. 
+Documentation       This taskset runs a user provided kubectl command andadds the output to the report. Command line tools like jq are available.
 Metadata            Author    stewartshea
 
 Library             BuiltIn
@@ -24,6 +24,7 @@ Run User Provided Kubectl Command
     RW.Core.Add Pre To Report    Command stderr: ${rsp.stderr}
     RW.Core.Add Pre To Report    Commands Used: ${history}
 
+
 *** Keywords ***
 Suite Initialization
     ${kubeconfig}=    RW.Core.Import Secret
@@ -34,6 +35,6 @@ Suite Initialization
     ...    example=For examples, start here https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/
     ${KUBECTL_COMMAND}=    RW.Core.Import User Variable    KUBECTL_COMMAND
     ...    type=string
-    ...    description=The kubectl command to run. Must produce a single value that can be pushed as a metric. Can use tools like jq. 
+    ...    description=The kubectl command to run. Can use tools like jq.
     ...    pattern=\w*
     ...    example="kubectl describe pods -n online-boutique"

--- a/codebundles/k8s-kubectl-cmd/runbook.robot
+++ b/codebundles/k8s-kubectl-cmd/runbook.robot
@@ -1,0 +1,39 @@
+*** Settings ***
+Documentation       This taskset runs a user provided kubectl command andadds the output to the report. Command line tools like jq are available. 
+Metadata            Author    stewartshea
+
+Library             BuiltIn
+Library             RW.Core
+Library             RW.platform
+Library             OperatingSystem
+Library             RW.CLI
+
+Suite Setup         Suite Initialization
+
+
+*** Tasks ***
+Run User Provided Kubectl Command
+    [Documentation]    Runs a user provided kubectl command and adds the output to the report.
+    [Tags]    kubectl    cli
+    ${rsp}=    RW.CLI.Run Cli
+    ...    cmd=${KUBECTL_COMMAND}
+    ...    env={"KUBECONFIG":"./${kubeconfig.key}"}
+    ...    secret_file__kubeconfig=${kubeconfig}
+    ${history}=    RW.CLI.Pop Shell History
+    RW.Core.Add Pre To Report    Command stdout: ${rsp.stdout}
+    RW.Core.Add Pre To Report    Command stderr: ${rsp.stderr}
+    RW.Core.Add Pre To Report    Commands Used: ${history}
+
+*** Keywords ***
+Suite Initialization
+    ${kubeconfig}=    RW.Core.Import Secret
+    ...    kubeconfig
+    ...    type=string
+    ...    description=The kubernetes kubeconfig yaml containing connection configuration used to connect to cluster(s).
+    ...    pattern=\w*
+    ...    example=For examples, start here https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/
+    ${KUBECTL_COMMAND}=    RW.Core.Import User Variable    KUBECTL_COMMAND
+    ...    type=string
+    ...    description=The kubectl command to run. Must produce a single value that can be pushed as a metric. Can use tools like jq. 
+    ...    pattern=\w*
+    ...    example="kubectl describe pods -n online-boutique"

--- a/codebundles/k8s-kubectl-cmd/sli.robot
+++ b/codebundles/k8s-kubectl-cmd/sli.robot
@@ -1,0 +1,36 @@
+*** Settings ***
+Documentation       This taskset runs a user provided kubectl command and pushes the metric. The supplied command must result in distinct single metric. Command line tools like jq are available. 
+Metadata            Author    stewartshea
+
+Library             BuiltIn
+Library             RW.Core
+Library             RW.platform
+Library             OperatingSystem
+Library             RW.CLI
+
+Suite Setup         Suite Initialization
+
+
+*** Tasks ***
+Run User Provided Kubectl Command
+    [Documentation]    Runs a user provided kubectl command and pushes the metric as an SLI
+    [Tags]    kubectl    cli    metric    sli
+    ${rsp}=    RW.CLI.Run Cli
+    ...    cmd=${KUBECTL_COMMAND}
+    ...    env={"KUBECONFIG":"./${kubeconfig.key}"}
+    ...    secret_file__kubeconfig=${kubeconfig}
+    RW.Core.Push Metric    ${rsp.stdout}
+
+*** Keywords ***
+Suite Initialization
+    ${kubeconfig}=    RW.Core.Import Secret
+    ...    kubeconfig
+    ...    type=string
+    ...    description=The kubernetes kubeconfig yaml containing connection configuration used to connect to cluster(s).
+    ...    pattern=\w*
+    ...    example=For examples, start here https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/
+    ${KUBECTL_COMMAND}=    RW.Core.Import User Variable    KUBECTL_COMMAND
+    ...    type=string
+    ...    description=The kubectl command to run. Must produce a single value that can be pushed as a metric. Can use tools like jq. 
+    ...    pattern=\w*
+    ...    example="kubectl get pods -n online-boutique -o json | jq '[.items[]] | length"


### PR DESCRIPTION
adds a generic kubectl k8s codebundle. the other one in rw-public sort of forces the use of jmespath which is not ideal in all cases, so this one is more generic and relies on the user to ensure the output is a metric (for the sli) rather than providing a keyword to help. 