### PR TITLE
Fix k8s-deployment-gitops-remediate

### DIFF
--- a/codebundles/k8s-deployment-gitops-gh-remediate/runbook.robot
+++ b/codebundles/k8s-deployment-gitops-gh-remediate/runbook.robot
@@ -27,7 +27,7 @@ Remediate Readiness and Liveness Probe GitOps Manifests Namespace `${NAMESPACE}`
     ...    secret_file__kubeconfig=${kubeconfig}
     ...    timeout_seconds=180
     ${remediation_list}=    RW.CLI.Run Cli
-    ...    cmd=awk "/Remediation Steps:/ {start=1; getline} start" <<< "${probe_health.stdout}"
+    ...    cmd=awk "/Remediation Steps:/ {start=1; getline} start" <<< '''${probe_health.stdout}'''
     ...    env=${env}
     ...    include_in_history=false
     ${gh_updates}=    RW.CLI.Run Bash File


### PR DESCRIPTION
change var passing into script with triple quotes to avoid bash processing of the output that causes the recommendations to be filtered incorrectly.