### PR TITLE
remove task

### DIFF
--- a/codebundles/k8s-namespace-healthcheck/README.md
+++ b/codebundles/k8s-namespace-healthcheck/README.md
@@ -8,7 +8,6 @@ This codebundle is used for searching in a namespace for possible issues to tria
 `Troubleshoot Workload Status Conditions In Namespace`
 `Get Listing Of Workloads In Namespace`
 `Check For Namespace Event Anomalies`
-`Troubleshoot Namespace Services And Application Workloads`
 `Check Missing or Risky PodDisruptionBudget Policies`
 
 


### PR DESCRIPTION
This task tends to provide duplicate error checking in which the issue output is radically close to other tasks. Currently it tends to create more noise that necessary. 