### PR TITLE
Support Running Bash Files from root or /app in 'run_bash_file' Function

### DIFF
--- a/libraries/RW/CLI/CLI.py
+++ b/libraries/RW/CLI/CLI.py
@@ -171,8 +171,8 @@ def run_bash_file(
     else:
         cwd = os.getcwd()
 
-        # Check if the current working directory is the root
-        if cwd == "/":
+        # Check if the current working directory is the root or the /app
+        if cwd == "/" or cwd == "/app":
             # Check if RW_PATH_TO_ROBOT environment variable exists
             rw_path_to_robot = os.environ.get("RW_PATH_TO_ROBOT", None)
             if rw_path_to_robot:


### PR DESCRIPTION
#### What we tried:

We were trying to run our mitigation script via [runbook.robot](https://github.com/infracloudio/ifc-rw-codecollection/blob/f/codebundle-rds-mysql-conn/codebundles/rds-mysql-conn-count/runbook.robot) using `RW.CLI.Run Bash File`.

Built this [Dockerfile](https://github.com/infracloudio/ifc-rw-codecollection/blob/f/codebundle-rds-mysql-conn/Dockerfile) and run docker container as follow and we set `RW_PATH_TO_ROBOT` env

```
docker run --rm -d -p 3000:3000 --name rds-codecollection \
--network="host" \
-e ENV_PROMETHEUS_HOST="http://af2ee8b74f89e4f8a83cd53d3745ccdc-1654255243.us-west-2.elb.amazonaws.com//prometheus/api/v1" \
-e ENV_QUERY="aws_rds_database_connections_average{dimension_DBInstanceIdentifier="robotshopmysql"} > 1" \
-e MYSQL_USER="admin" \
-e MYSQL_PASSWORD_ENV="<password>" \
-e MYSQL_HOST="robotshopmysql.c9m6m4s8zo0.us-west-2.rds.amazonaws.com" \
-e PROCESS_USER="shipping" \
-e RW_PATH_TO_ROBOT="/app/codecollection/codebundles/rds-mysql-conn-count/runbook.robot" \
runwhen:latest

```

On running runbook.robot we get this error:

```
docker exec rds-codecollection bash -c "ro /app/codecollection/codebundles/rds-mysql-conn-count/runbook.robot && ls -R /robot_logs"
[ ERROR ] Error in library 'RW.Core': Adding keyword 'add_datagrid_to_report' failed: Union cannot be empty.
[ ERROR ] Error in library 'RW.Core': Adding keyword 'add_table_to_report' failed: Union cannot be empty.
==============================================================================
Runbook :: This taskset Kills the numbers of sleep process created in MySQL
==============================================================================
Run Bash File :: Runs a bash file to kill sleep processes created ... [ WARN ] File 'kill-mysql-sleep-processes.sh' not found in the current directory and current directory is not root.
| FAIL |
FileNotFoundError: [Errno 2] No such file or directory: 'kill-mysql-sleep-processes.sh'
------------------------------------------------------------------------------
Runbook :: This taskset Kills the numbers of sleep process created... | FAIL |
1 task, 0 passed, 1 failed
==============================================================================
Output:  /robot_logs/rds-mysql-conn-count/runbook-output.xml
Log:     /robot_logs/rds-mysql-conn-count/runbook-log.html
Report:  /robot_logs/rds-mysql-conn-count/runbook-report.html

```

On looking into implementation of `CLI.py` we found that on line no. 175  `if cwd == "/":` it only check into root which is not the case with our Dockerfile or even with  codecollection-devtools [Dockerfile](https://github.com/runwhen-contrib/codecollection-devtools/blob/main/Dockerfile). 

To Fix we added `"/app"`  because that's is the current working directory. Here is the result of this fix. 

Bash script is executed and this is the script error because it can't connect to RDS private endpoint. 

```
 docker exec rds-codecollection bash -c "ro /app/codecollection/codebundles/rds-mysql-conn-count/runbook.robot && ls -R /robot_logs"
[ ERROR ] Error in library 'RW.Core': Adding keyword 'add_datagrid_to_report' failed: Union cannot be empty.
[ ERROR ] Error in library 'RW.Core': Adding keyword 'add_table_to_report' failed: Union cannot be empty.
==============================================================================
Runbook :: This taskset Kills the numbers of sleep process created in MySQL
==============================================================================
Run Bash File :: Runs a bash file to kill sleep processes created ...
Command Stdout:
Error connecting to MySQL



Command Stderr:
ERROR 2005 (HY000): Unknown MySQL server host 'robotshopmysql.c9m6m4s8zo0.us-west-2.rds.amazonaws.com' (-2)


| PASS |
------------------------------------------------------------------------------
Runbook :: This taskset Kills the numbers of sleep process created... | PASS |
1 task, 1 passed, 0 failed
==============================================================================
Output:  /robot_logs/rds-mysql-conn-count/runbook-output.xml
Log:     /robot_logs/rds-mysql-conn-count/runbook-log.html
Report:  /robot_logs/rds-mysql-conn-count/runbook-report.html
/robot_logs:
rds-mysql-conn-count

/robot_logs/rds-mysql-conn-count:
runbook-log.html
runbook-output.xml
runbook-report.html

```

