### PR TITLE
Fix/path-change

### DIFF
--- a/codebundles/k8s-deployment-healthcheck/runbook.robot
+++ b/codebundles/k8s-deployment-healthcheck/runbook.robot
@@ -403,8 +403,8 @@ Suite Initialization
     ...    type=string
     ...    description=The home path of the runner
     ...    pattern=\w*
-    ...    example=/root
-    ...    default=/root    
+    ...    example=/home/runwhen
+    ...    default=/home/runwhen    
     Set Suite Variable    ${kubeconfig}    ${kubeconfig}
     Set Suite Variable    ${KUBERNETES_DISTRIBUTION_BINARY}    ${KUBERNETES_DISTRIBUTION_BINARY}
     Set Suite Variable    ${CONTEXT}    ${CONTEXT}

--- a/codebundles/k8s-gitops-gh-remediate/runbook.robot
+++ b/codebundles/k8s-gitops-gh-remediate/runbook.robot
@@ -214,8 +214,8 @@ Suite Initialization
     ...    type=string
     ...    description=The home path of the runner
     ...    pattern=\w*
-    ...    example=/root
-    ...    default=/root
+    ...    example=/home/runwhen
+    ...    default=/home/runwhen
     ${RW_TASK_TITLES}=    Get Environment Variable    RW_TASK_TITLES    "[]"
     ${RW_TASK_STRING}=    Evaluate    ${RW_TASK_TITLES}    json
     ${RW_TASK_STRING}=    Evaluate    ', '.join(${RW_TASK_STRING})    json

--- a/codebundles/k8s-jaeger-http-query/runbook.robot
+++ b/codebundles/k8s-jaeger-http-query/runbook.robot
@@ -85,8 +85,8 @@ Suite Initialization
     ...    type=string
     ...    description=The home path of the runner
     ...    pattern=\w*
-    ...    example=/root
-    ...    default=/root
+    ...    example=/home/runwhen
+    ...    default=/home/runwhen
     Set Suite Variable    ${kubeconfig}    ${kubeconfig}
     Set Suite Variable    ${CONTEXT}    ${CONTEXT}
     Set Suite Variable    ${KUBERNETES_DISTRIBUTION_BINARY}    ${KUBERNETES_DISTRIBUTION_BINARY}

--- a/codebundles/k8s-namespace-healthcheck/runbook.robot
+++ b/codebundles/k8s-namespace-healthcheck/runbook.robot
@@ -340,7 +340,7 @@ Get Listing Of Resources In Namespace `${NAMESPACE}`
     [Documentation]    Simple fetch all to provide a snapshot of information about the workloads in the namespace for future review in a report.
     [Tags]    get all    resources    info    workloads    namespace    manifests    ${namespace}
     ${all_results}=    RW.CLI.Run Cli
-    ...    cmd=${KUBERNETES_DISTRIBUTION_BINARY} api-resources --verbs=list --namespaced -o name --context=${CONTEXT} | xargs -n 1 bash -c '${KUBERNETES_DISTRIBUTION_BINARY} get --show-kind --ignore-not-found -n ${NAMESPACE} --context=${CONTEXT}'
+    ...    cmd=${KUBERNETES_DISTRIBUTION_BINARY} api-resources --verbs=list --namespaced -o name --context=${CONTEXT} | xargs -n 1 bash -c '${KUBERNETES_DISTRIBUTION_BINARY} get $0 --show-kind --ignore-not-found -n ${NAMESPACE} --context=${CONTEXT}'
     ...    env=${env}
     ...    secret_file__kubeconfig=${kubeconfig}
     ...    show_in_rwl_cheatsheet=true

--- a/codebundles/k8s-namespace-healthcheck/runbook.robot
+++ b/codebundles/k8s-namespace-healthcheck/runbook.robot
@@ -340,7 +340,7 @@ Get Listing Of Resources In Namespace `${NAMESPACE}`
     [Documentation]    Simple fetch all to provide a snapshot of information about the workloads in the namespace for future review in a report.
     [Tags]    get all    resources    info    workloads    namespace    manifests    ${namespace}
     ${all_results}=    RW.CLI.Run Cli
-    ...    cmd=${KUBERNETES_DISTRIBUTION_BINARY} api-resources --verbs=list --namespaced -o name --context=${CONTEXT} | xargs -n 1 ${KUBERNETES_DISTRIBUTION_BINARY} get --show-kind --ignore-not-found -n ${NAMESPACE} --context=${CONTEXT}
+    ...    cmd=${KUBERNETES_DISTRIBUTION_BINARY} api-resources --verbs=list --namespaced -o name --context=${CONTEXT} | xargs -n 1 bash -c '${KUBERNETES_DISTRIBUTION_BINARY} get --show-kind --ignore-not-found -n ${NAMESPACE} --context=${CONTEXT}'
     ...    env=${env}
     ...    secret_file__kubeconfig=${kubeconfig}
     ...    show_in_rwl_cheatsheet=true

--- a/codebundles/k8s-namespace-healthcheck/runbook.robot
+++ b/codebundles/k8s-namespace-healthcheck/runbook.robot
@@ -541,8 +541,8 @@ Suite Initialization
     ...    type=string
     ...    description=The home path of the runner
     ...    pattern=\w*
-    ...    example=/root
-    ...    default=/root
+    ...    example=/home/runwhen
+    ...    default=/home/runwhen
     Set Suite Variable    ${kubeconfig}    ${kubeconfig}
     Set Suite Variable    ${CONTEXT}    ${CONTEXT}
     Set Suite Variable    ${KUBERNETES_DISTRIBUTION_BINARY}    ${KUBERNETES_DISTRIBUTION_BINARY}

--- a/codebundles/k8s-namespace-healthcheck/sli.robot
+++ b/codebundles/k8s-namespace-healthcheck/sli.robot
@@ -17,10 +17,6 @@ Suite Initialization
     ...    description=The kubernetes kubeconfig yaml containing connection configuration used to connect to cluster(s).
     ...    pattern=\w*
     ...    example=For examples, start here https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/
-    ${kubectl}=    RW.Core.Import Service    kubectl
-    ...    description=The location service used to interpret shell commands.
-    ...    default=kubectl-service.shared
-    ...    example=kubectl-service.shared
     ${NAMESPACE}=    RW.Core.Import User Variable    NAMESPACE
     ...    type=string
     ...    description=The name of the Kubernetes namespace to scope actions and searching to. Supports csv list of namespaces. 
@@ -62,7 +58,7 @@ Suite Initialization
     ...    example=kubectl
     ...    default=kubectl
     Set Suite Variable    ${kubeconfig}    ${kubeconfig}
-    Set Suite Variable    ${kubectl}    ${kubectl}
+    Set Suite Variable    ${KUBERNETES_DISTRIBUTION_BINARY}    ${KUBERNETES_DISTRIBUTION_BINARY}
     Set Suite Variable    ${EVENT_AGE}    ${EVENT_AGE}
     Set Suite Variable    ${EVENT_THRESHOLD}    ${EVENT_THRESHOLD}
     Set Suite Variable    ${CONTAINER_RESTART_AGE}    ${CONTAINER_RESTART_AGE}
@@ -76,7 +72,7 @@ Get Event Count and Score
     [Documentation]    Captures error events and counts them within a configurable timeframe.
     [Tags]    Event    Count    Warning
     ${error_events}=    RW.CLI.Run Cli
-    ...    cmd=kubectl get events --field-selector type=Warning --context ${CONTEXT} -n ${NAMESPACE} -o json
+    ...    cmd=${KUBERNETES_DISTRIBUTION_BINARY} get events --field-selector type=Warning --context ${CONTEXT} -n ${NAMESPACE} -o json
     ...    env=${env}
     ...    secret_file__kubeconfig=${kubeconfig}
     ${EVENT_AGE}=    RW.CLI.String To Datetime    ${EVENT_AGE}
@@ -93,7 +89,7 @@ Get Container Restarts and Score
     [Documentation]    Counts the total sum of container restarts within a timeframe and determines if they're beyond a threshold.
     [Tags]    Restarts    Pods    Containers    Count    Status
     ${pods}=    RW.CLI.Run Cli
-    ...    cmd=kubectl get pods --context ${CONTEXT} -n ${NAMESPACE} -o json
+    ...    cmd=${KUBERNETES_DISTRIBUTION_BINARY} get pods --context ${CONTEXT} -n ${NAMESPACE} -o json
     ...    env=${env}
     ...    secret_file__kubeconfig=${kubeconfig}
     ${CONTAINER_RESTART_AGE}=    RW.CLI.String To Datetime    ${CONTAINER_RESTART_AGE}
@@ -111,7 +107,7 @@ Get NotReady Pods
     [Documentation]    Fetches a count of unready pods.
     [Tags]    Pods    Status    Phase    Ready    Unready    Running
     ${unreadypods_results}=    RW.CLI.Run Cli
-    ...    cmd=kubectl get pods --context=${CONTEXT} -n ${NAMESPACE} --sort-by='status.containerStatuses[0].restartCount' --field-selector=status.phase!=Running -ojson
+    ...    cmd=${KUBERNETES_DISTRIBUTION_BINARY} get pods --context=${CONTEXT} -n ${NAMESPACE} --sort-by='status.containerStatuses[0].restartCount' --field-selector=status.phase!=Running -ojson
     ...    env=${env}
     ...    secret_file__kubeconfig=${kubeconfig}
     ${unready_pod_count}=    RW.CLI.Parse Cli Json Output

--- a/codebundles/k8s-podresources-health/runbook.robot
+++ b/codebundles/k8s-podresources-health/runbook.robot
@@ -154,7 +154,7 @@ Suite Initialization
     ...    type=string
     ...    description=Home directory to execute scripts from
     ...    example=/home
-    ...    default=/root
+    ...    default=/home/runwhen
     Set Suite Variable    ${kubeconfig}    ${kubeconfig}
     Set Suite Variable    ${CONTEXT}    ${CONTEXT}
     Set Suite Variable    ${NAMESPACE}    ${NAMESPACE}

--- a/codebundles/k8s-pvc-healthcheck/runbook.robot
+++ b/codebundles/k8s-pvc-healthcheck/runbook.robot
@@ -227,8 +227,8 @@ Suite Initialization
     ...    type=string
     ...    description=The home path of the runner
     ...    pattern=\w*
-    ...    example=/root
-    ...    default=/root
+    ...    example=/home/runwhen
+    ...    default=/home/runwhen
     Set Suite Variable    ${kubeconfig}    ${kubeconfig}
     Set Suite Variable    ${KUBERNETES_DISTRIBUTION_BINARY}    ${KUBERNETES_DISTRIBUTION_BINARY}
     Set Suite Variable    ${CONTEXT}    ${CONTEXT}

--- a/libraries/RW/CLI/CLI.py
+++ b/libraries/RW/CLI/CLI.py
@@ -164,19 +164,16 @@ def resolve_path_to_robot():
     if "$(HOME)" in repo_path_to_robot:
         repo_path_to_robot = repo_path_to_robot.replace("$(HOME)", home)
 
-    # Prepare a list of paths to check
-    paths_to_check = set()  # Use a set to avoid duplicate paths
-    
-    # Add the path directly if it appears to be absolute
-    if os.path.isabs(repo_path_to_robot):
-        paths_to_check.add(repo_path_to_robot)
+    # Normalize path by removing a leading slash for relative path construction
+    normalized_path = repo_path_to_robot.lstrip('/')
 
-    # Add other derived paths
-    paths_to_check.update([
-        os.path.join(runwhen_home, repo_path_to_robot.lstrip('/')),  # Path relative to RUNWHEN_HOME
-        os.path.join(home, repo_path_to_robot.lstrip('/')),          # Path relative to HOME
-        os.path.join("/collection", repo_path_to_robot.lstrip('/')), # Common collection path
-        os.path.join("/", repo_path_to_robot.lstrip('/'))            # Root relative path
+    # Prepare a list of paths to check
+    paths_to_check = set([
+        repo_path_to_robot,  # Check the path as is (absolute or relative)
+        os.path.join(runwhen_home, normalized_path),  # Path relative to RUNWHEN_HOME
+        os.path.join(home, normalized_path),          # Path relative to HOME
+        os.path.join("/collection", normalized_path), # Common collection path
+        os.path.join("/", normalized_path)            # Checking as absolute from root
     ])
 
     # Try to find the file in any of the specified paths

--- a/libraries/RW/CLI/CLI.py
+++ b/libraries/RW/CLI/CLI.py
@@ -144,7 +144,7 @@ def _create_secrets_from_kwargs(**kwargs) -> list[platform.ShellServiceRequestSe
     return request_secrets
 
 def find_file(*paths):
-    """ Helper function to check if file exists in given paths. """
+    """ Helper function to check if a file exists in the given paths. """
     for path in paths:
         if os.path.isfile(path):
             return path
@@ -155,27 +155,17 @@ def resolve_path_to_robot():
     runwhen_home = os.getenv("RUNWHEN_HOME", "").rstrip('/')
     home = os.getenv("HOME", "").rstrip('/')
     
-    # Get the path to the robot file
-    repo_path_to_robot = os.getenv("RW_PATH_TO_ROBOT", "")
-    
-    # Check if the path includes environment variable placeholders
-    if "$(RUNWHEN_HOME)" in repo_path_to_robot:
-        repo_path_to_robot = repo_path_to_robot.replace("$(RUNWHEN_HOME)", runwhen_home)
-    if "$(HOME)" in repo_path_to_robot:
-        repo_path_to_robot = repo_path_to_robot.replace("$(HOME)", home)
-
-    # Normalize path by removing a leading slash for relative path construction
-    normalized_path = repo_path_to_robot.lstrip('/')
+    # Get the path to the robot file, ensure it's clean for concatenation
+    repo_path_to_robot = os.getenv("RW_PATH_TO_ROBOT", "").lstrip('/')
 
     # Prepare a list of paths to check
     paths_to_check = set([
-        repo_path_to_robot,  # Check the path as is (absolute or relative)
-        os.path.join(runwhen_home, normalized_path),  # Path relative to RUNWHEN_HOME
-        os.path.join(runwhen_home, 'collection', normalized_path),  # Path relative to RUNWHEN_HOME
-        os.path.join(home, normalized_path),          # Path relative to HOME
-        os.path.join(home, 'collection', normalized_path),          # Path relative to HOME
-        os.path.join("/collection", normalized_path), # Common collection path
-        os.path.join("/", normalized_path)            # Checking as absolute from root
+        os.path.join('/', repo_path_to_robot),  # Check as absolute path
+        os.path.join(runwhen_home, repo_path_to_robot),  # Path relative to RUNWHEN_HOME
+        os.path.join(runwhen_home, 'collection', repo_path_to_robot),  # Further nested within RUNWHEN_HOME
+        os.path.join(home, repo_path_to_robot),  # Path relative to HOME
+        os.path.join(home, 'collection', repo_path_to_robot),  # Further nested within HOME
+        os.path.join("/collection", repo_path_to_robot), # Common collection path
     ])
 
     # Try to find the file in any of the specified paths

--- a/libraries/RW/CLI/CLI.py
+++ b/libraries/RW/CLI/CLI.py
@@ -172,6 +172,8 @@ def resolve_path_to_robot():
         os.path.join(home, repo_path_to_robot),  # Path relative to HOME
         os.path.join(home, 'collection', repo_path_to_robot),  # Further nested within HOME
         os.path.join("/collection", repo_path_to_robot), # Common collection path
+        os.path.join("/root/", repo_path_to_robot), # Backwards compatible /root
+        os.path.join("/root/collection", repo_path_to_robot), # Backwards compatible /root
     ])
 
     # Try to find the file in any of the specified paths

--- a/libraries/RW/CLI/CLI.py
+++ b/libraries/RW/CLI/CLI.py
@@ -171,82 +171,42 @@ def run_bash_file(
     else:
         cwd = os.getcwd()
         runwhen_home=os.environ.get("RUNWHEN_HOME", None)
-
+        rw_path_to_robot = os.environ.get("RW_PATH_TO_ROBOT", None)
         ## Users will expect to run the command from within the current working directory
         ## Here we will rewrite the path so that it executes properly from the cwd
-        if cwd == runwhen_home:
-            rw_path_to_robot = os.environ.get("RW_PATH_TO_ROBOT", None)
-            if rw_path_to_robot:
-                # Split the path at the patterns you provided and join with the new prefix
-                for pattern in ["sli.robot", "runbook.robot"]:
-                    if pattern in rw_path_to_robot:
-                        path, _ = rw_path_to_robot.split(pattern)
+        if rw_path_to_robot:
+            # Split the path at the patterns you provided and join with the new prefix
+            for pattern in ["sli.robot", "runbook.robot"]:
+                if pattern in rw_path_to_robot:
+                    path, _ = rw_path_to_robot.split(pattern)
+                    if cwd == runwhen_home:
                         new_path = path
-                        # Modify the bash_file to point to the new directory
-                        local_bash_file = f"./{bash_file}"
-                        bash_file = os.path.join(new_path, bash_file)
-                        if os.path.exists(bash_file):
-                            logger.info(
-                                f"File '{bash_file}' found at derived path: {new_path}."
-                            )
-                            if cmd_override:
-                                cmd_override = cmd_override.replace(
-                                    f"{local_bash_file}", f"{bash_file}"
-                                )
-                            else:
-                                cmd_override = f"{bash_file}"
-                            break
-                        else:
-                            logger.warning(
-                                f"File '{bash_file}' not found at derived path: {new_path}."
-                            )
-            else:
-                logger.warning(
-                    f"Current directory is '{runwhen_home}', but 'RW_PATH_TO_ROBOT' is not set."
-                )
-        else:
-            logger.warning(
-                f"File '{bash_file}' not found in the current directory and current directory is '{runwhen_home}'."
-            )            
-        ## Keep this for backwards compatibility, though the new robot runtime
-        ## images should run out of /home/runwhen instead of /
-        # Check if the current working directory is the root or the /app
-        if cwd == "/" or cwd == "/app":
-            # Check if RW_PATH_TO_ROBOT environment variable exists
-            rw_path_to_robot = os.environ.get("RW_PATH_TO_ROBOT", None)
-            if rw_path_to_robot:
-                # Split the path at the patterns you provided and join with the new prefix
-                for pattern in ["sli.robot", "runbook.robot"]:
-                    if pattern in rw_path_to_robot:
-                        path, _ = rw_path_to_robot.split(pattern)
+                    else:
+                        # This for backwards compatibility for older images
+                        # that have /collection at the root 
                         new_path = os.path.join("/collection", path)
-                        # Modify the bash_file to point to the new directory
-                        local_bash_file = f"./{bash_file}"
-                        bash_file = os.path.join(new_path, bash_file)
-                        if os.path.exists(bash_file):
-                            logger.info(
-                                f"File '{bash_file}' found at derived path: {new_path}."
+                    # Modify the bash_file to point to the new directory
+                    local_bash_file = f"./{bash_file}"
+                    bash_file = os.path.join(new_path, bash_file)
+                    if os.path.exists(bash_file):
+                        logger.info(
+                            f"File '{bash_file}' found at derived path: {new_path}."
+                        )
+                        if cmd_override:
+                            cmd_override = cmd_override.replace(
+                                f"{local_bash_file}", f"{bash_file}"
                             )
-                            if cmd_override:
-                                cmd_override = cmd_override.replace(
-                                    f"{local_bash_file}", f"{bash_file}"
-                                )
-                            else:
-                                cmd_override = f"{bash_file}"
-                            break
                         else:
-                            logger.warning(
-                                f"File '{bash_file}' not found at derived path: {new_path}."
-                            )
-            else:
-                logger.warning(
-                    "Current directory is root, but 'RW_PATH_TO_ROBOT' is not set."
-                )
+                            cmd_override = f"{bash_file}"
+                        break
+                    else:
+                        logger.warning(
+                            f"File '{bash_file}' not found at derived path: {new_path}."
+                        )
         else:
             logger.warning(
-                f"File '{bash_file}' not found in the current directory and current directory is not root."
+                f"Current directory is '{cwd}', but 'RW_PATH_TO_ROBOT' is not set."
             )
-
     if not cmd_override:
         cmd_override = f"./{bash_file}"
     logger.info(f"Received kwargs: {kwargs}")

--- a/libraries/RW/CLI/CLI.py
+++ b/libraries/RW/CLI/CLI.py
@@ -171,7 +171,9 @@ def resolve_path_to_robot():
     paths_to_check = set([
         repo_path_to_robot,  # Check the path as is (absolute or relative)
         os.path.join(runwhen_home, normalized_path),  # Path relative to RUNWHEN_HOME
+        os.path.join(runwhen_home, 'collection', normalized_path),  # Path relative to RUNWHEN_HOME
         os.path.join(home, normalized_path),          # Path relative to HOME
+        os.path.join(home, 'collection', normalized_path),          # Path relative to HOME
         os.path.join("/collection", normalized_path), # Common collection path
         os.path.join("/", normalized_path)            # Checking as absolute from root
     ])

--- a/libraries/RW/CLI/CLI.py
+++ b/libraries/RW/CLI/CLI.py
@@ -179,7 +179,7 @@ def resolve_path_to_robot():
         os.path.join("/collection/", repo_path_to_robot),
         os.path.join("/", repo_path_to_robot),
         os.path.join("/home/runwhen/collection/", repo_path_to_robot),
-        os.path.join("/home/runwhen/collection/", repo_path_to_robot) 
+        os.path.join("/home/runwhen/collection", repo_path_to_robot) 
 
     ]
 

--- a/libraries/RW/CLI/CLI.py
+++ b/libraries/RW/CLI/CLI.py
@@ -151,38 +151,26 @@ def find_file(*paths):
     return None
 
 def resolve_path_to_robot():
-    # Environment variable
-    runwhen_home = os.getenv("RUNWHEN_HOME", "")
-
-    # RW_PATH_TO_ROBOT might be set relative to RUNWHEN_HOME or it could be elsewhere
-    repo_path_to_robot = os.getenv("RW_PATH_TO_ROBOT", "")
-
-    # Substitute RUNWHEN_HOME in path if specified
-    if "$(RUNWHEN_HOME)" in repo_path_to_robot:
-        repo_path_to_robot = repo_path_to_robot.replace("$(RUNWHEN_HOME)", runwhen_home)
-
+    # Get and clean environment variables
+    runwhen_home = os.getenv("RUNWHEN_HOME", "").rstrip('/')
+    home = os.getenv("HOME", "").rstrip('/')
+    
+    # Get the path to the robot file, handling potential environment variable substitution
+    repo_path_to_robot = os.getenv("RW_PATH_TO_ROBOT", "").replace("$(RUNWHEN_HOME)", runwhen_home)
+    
     # Check if path is already absolute
-    if os.path.isabs(repo_path_to_robot):
-        file_path = find_file(repo_path_to_robot)
-        if file_path:
-            return file_path
-
-    # # Check relative to RUNWHEN_HOME if it exists
-    # if runwhen_home:
-    #     os.path
-    #     file_path = find_file(os.path.join(runwhen_home, repo_path_to_robot))
-    #     if file_path:
-    #         return file_path
-
-    # Also check under commonly known directories
+    if os.path.isabs(repo_path_to_robot) and os.path.isfile(repo_path_to_robot):
+        return repo_path_to_robot
+    
+    # Define common paths to check, based on likely directories
     common_paths = [
         os.path.join("/collection", repo_path_to_robot),
-        os.path.join("/collection/", repo_path_to_robot),
         os.path.join("/", repo_path_to_robot),
-        os.path.join(f"{runwhen_home}/collection", repo_path_to_robot),
-        os.path.join(f"{runwhen_home}/collection/", repo_path_to_robot)
+        os.path.join(runwhen_home, "collection", repo_path_to_robot),
+        os.path.join(home, "collection", repo_path_to_robot)
     ]
 
+    # Attempt to find the file in any of the common paths
     file_path = find_file(*common_paths)
     if file_path:
         return file_path

--- a/libraries/RW/CLI/CLI.py
+++ b/libraries/RW/CLI/CLI.py
@@ -155,14 +155,14 @@ def resolve_path_to_robot():
     runwhen_home = os.getenv("RUNWHEN_HOME", "").rstrip('/')
     home = os.getenv("HOME", "").rstrip('/')
 
+    # Get the path to the robot file, ensure it's clean for concatenation
+    repo_path_to_robot = os.getenv("RW_PATH_TO_ROBOT", "").lstrip('/')
+
     # Check if the path includes environment variable placeholders
     if "$(RUNWHEN_HOME)" in repo_path_to_robot:
         repo_path_to_robot = repo_path_to_robot.replace("$(RUNWHEN_HOME)", runwhen_home)
     if "$(HOME)" in repo_path_to_robot:
         repo_path_to_robot = repo_path_to_robot.replace("$(HOME)", home)
-
-    # Get the path to the robot file, ensure it's clean for concatenation
-    repo_path_to_robot = os.getenv("RW_PATH_TO_ROBOT", "").lstrip('/')
 
     # Prepare a list of paths to check
     paths_to_check = set([

--- a/libraries/RW/CLI/CLI.py
+++ b/libraries/RW/CLI/CLI.py
@@ -154,7 +154,13 @@ def resolve_path_to_robot():
     # Environment variables
     runwhen_home = os.getenv("RUNWHEN_HOME", "").rstrip('/')
     home = os.getenv("HOME", "").rstrip('/')
-    
+
+    # Check if the path includes environment variable placeholders
+    if "$(RUNWHEN_HOME)" in repo_path_to_robot:
+        repo_path_to_robot = repo_path_to_robot.replace("$(RUNWHEN_HOME)", runwhen_home)
+    if "$(HOME)" in repo_path_to_robot:
+        repo_path_to_robot = repo_path_to_robot.replace("$(HOME)", home)
+
     # Get the path to the robot file, ensure it's clean for concatenation
     repo_path_to_robot = os.getenv("RW_PATH_TO_ROBOT", "").lstrip('/')
 

--- a/libraries/RW/CLI/CLI.py
+++ b/libraries/RW/CLI/CLI.py
@@ -167,20 +167,20 @@ def resolve_path_to_robot():
         if file_path:
             return file_path
 
-    # Check relative to RUNWHEN_HOME if it exists
-    if runwhen_home:
-        file_path = find_file(os.path.join(runwhen_home, repo_path_to_robot))
-        if file_path:
-            return file_path
+    # # Check relative to RUNWHEN_HOME if it exists
+    # if runwhen_home:
+    #     os.path
+    #     file_path = find_file(os.path.join(runwhen_home, repo_path_to_robot))
+    #     if file_path:
+    #         return file_path
 
     # Also check under commonly known directories
     common_paths = [
         os.path.join("/collection", repo_path_to_robot),
         os.path.join("/collection/", repo_path_to_robot),
         os.path.join("/", repo_path_to_robot),
-        os.path.join("/home/runwhen/collection/", repo_path_to_robot),
-        os.path.join("/home/runwhen/collection", repo_path_to_robot) 
-
+        os.path.join(f"{runwhen_home}/collection", repo_path_to_robot),
+        os.path.join(f"{runwhen_home}/collection/", repo_path_to_robot)
     ]
 
     file_path = find_file(*common_paths)

--- a/libraries/RW/CLI/CLI.py
+++ b/libraries/RW/CLI/CLI.py
@@ -170,7 +170,46 @@ def run_bash_file(
         logger.info(f"File '{bash_file}' found in the current working directory.")
     else:
         cwd = os.getcwd()
+        runwhen_home=os.environ.get("RUNWHEN_HOME", None)
 
+        ## Users will expect to run the command from within the current working directory
+        ## Here we will rewrite the path so that it executes properly from the cwd
+        if cwd == runwhen_home:
+            rw_path_to_robot = os.environ.get("RW_PATH_TO_ROBOT", None)
+            if rw_path_to_robot:
+                # Split the path at the patterns you provided and join with the new prefix
+                for pattern in ["sli.robot", "runbook.robot"]:
+                    if pattern in rw_path_to_robot:
+                        path, _ = rw_path_to_robot.split(pattern)
+                        new_path = path
+                        # Modify the bash_file to point to the new directory
+                        local_bash_file = f"./{bash_file}"
+                        bash_file = os.path.join(new_path, bash_file)
+                        if os.path.exists(bash_file):
+                            logger.info(
+                                f"File '{bash_file}' found at derived path: {new_path}."
+                            )
+                            if cmd_override:
+                                cmd_override = cmd_override.replace(
+                                    f"{local_bash_file}", f"{bash_file}"
+                                )
+                            else:
+                                cmd_override = f"{bash_file}"
+                            break
+                        else:
+                            logger.warning(
+                                f"File '{bash_file}' not found at derived path: {new_path}."
+                            )
+            else:
+                logger.warning(
+                    f"Current directory is '{runwhen_home}', but 'RW_PATH_TO_ROBOT' is not set."
+                )
+        else:
+            logger.warning(
+                f"File '{bash_file}' not found in the current directory and current directory is '{runwhen_home}'."
+            )            
+        ## Keep this for backwards compatibility, though the new robot runtime
+        ## images should run out of /home/runwhen instead of /
         # Check if the current working directory is the root or the /app
         if cwd == "/" or cwd == "/app":
             # Check if RW_PATH_TO_ROBOT environment variable exists

--- a/libraries/RW/CLI/CLI.py
+++ b/libraries/RW/CLI/CLI.py
@@ -151,7 +151,7 @@ def find_file(*paths):
     return None
 
 def resolve_path_to_robot():
-    # Get and clean environment variables
+    # Get and normalize environment variables by stripping any potential trailing slash
     runwhen_home = os.getenv("RUNWHEN_HOME", "").rstrip('/')
     home = os.getenv("HOME", "").rstrip('/')
     
@@ -162,12 +162,12 @@ def resolve_path_to_robot():
     if os.path.isabs(repo_path_to_robot) and os.path.isfile(repo_path_to_robot):
         return repo_path_to_robot
     
-    # Define common paths to check, based on likely directories
+    # Common paths to check, adjusted for various likely directory structures
     common_paths = [
-        os.path.join("/collection", repo_path_to_robot),
-        os.path.join("/", repo_path_to_robot),
-        os.path.join(runwhen_home, "collection", repo_path_to_robot),
-        os.path.join(home, "collection", repo_path_to_robot)
+        os.path.join("/collection", repo_path_to_robot.lstrip('/')), # Ensuring no double slashes
+        os.path.join("/", repo_path_to_robot.lstrip('/')), # Direct path under root
+        os.path.join(runwhen_home, "collection", repo_path_to_robot.lstrip('/')), # Nested under collection
+        os.path.join(home, "collection", repo_path_to_robot.lstrip('/')) # Nested under collection in HOME
     ]
 
     # Attempt to find the file in any of the common paths

--- a/libraries/RW/CLI/CLI.py
+++ b/libraries/RW/CLI/CLI.py
@@ -176,7 +176,11 @@ def resolve_path_to_robot():
     # Also check under commonly known directories
     common_paths = [
         os.path.join("/collection", repo_path_to_robot),
-        os.path.join("/", repo_path_to_robot)  # Root relative
+        os.path.join("/collection/", repo_path_to_robot),
+        os.path.join("/", repo_path_to_robot),
+        os.path.join("/home/runwhen/collection/", repo_path_to_robot),
+        os.path.join("/home/runwhen/collection/", repo_path_to_robot) 
+
     ]
 
     file_path = find_file(*common_paths)

--- a/libraries/RW/CLI/CLI.py
+++ b/libraries/RW/CLI/CLI.py
@@ -215,18 +215,18 @@ def run_bash_file(
             for pattern in ["sli.robot", "runbook.robot"]:
                 if pattern in rw_path_to_robot:
                     path, _ = rw_path_to_robot.split(pattern)
-                    if cwd == runwhen_home:
-                        new_path = path
-                    else:
-                        # This for backwards compatibility for older images
-                        # that have /collection at the root 
-                        new_path = os.path.join("/collection", path)
-                    # Modify the bash_file to point to the new directory
+                    # if cwd == runwhen_home:
+                    #     new_path = path
+                    # else:
+                    #     # This for backwards compatibility for older images
+                    #     # that have /collection at the root 
+                    #     new_path = os.path.join("/collection", path)
+                    # # Modify the bash_file to point to the new directory
                     local_bash_file = f"./{bash_file}"
-                    bash_file = os.path.join(new_path, bash_file)
+                    bash_file = os.path.join(path, bash_file)
                     if os.path.exists(bash_file):
                         logger.info(
-                            f"File '{bash_file}' found at derived path: {new_path}."
+                            f"File '{bash_file}' found at derived path: {path}."
                         )
                         if cmd_override:
                             cmd_override = cmd_override.replace(
@@ -237,7 +237,7 @@ def run_bash_file(
                         break
                     else:
                         logger.warning(
-                            f"File '{bash_file}' not found at derived path: {new_path}."
+                            f"File '{bash_file}' not found at derived path: {path}."
                         )
         else:
             logger.warning(

--- a/libraries/RW/CLI/CLI.py
+++ b/libraries/RW/CLI/CLI.py
@@ -143,6 +143,43 @@ def _create_secrets_from_kwargs(**kwargs) -> list[platform.ShellServiceRequestSe
             )
     return request_secrets
 
+def resolve_rfile_path():
+    # Get environment variables
+    runwhen_home = os.getenv("RUNWHEN_HOME", "")
+    repo_path_to_robot = os.getenv("RW_PATH_TO_ROBOT", "")
+
+    # Check if RW_PATH_TO_ROBOT is an absolute path
+    if repo_path_to_robot.startswith("/"):
+        # It's an absolute path
+        if os.path.isfile(repo_path_to_robot):
+            return repo_path_to_robot
+        else:
+            # It's an absolute path but file does not exist, try prepending RUNWHEN_HOME
+            alternative_path = os.path.join(runwhen_home, repo_path_to_robot.lstrip("/"))
+            if os.path.isfile(alternative_path):
+                return alternative_path
+
+    # Handle environment variable substitution in the path
+    if "$(RUNWHEN_HOME)" in repo_path_to_robot:
+        repo_path_to_robot = repo_path_to_robot.replace("$(RUNWHEN_HOME)", runwhen_home)
+
+    # Construct full path using RUNWHEN_HOME if not already absolute
+    if not os.path.isabs(repo_path_to_robot):
+        full_path = os.path.join(runwhen_home, repo_path_to_robot)
+    else:
+        full_path = repo_path_to_robot
+
+    # Check if the constructed or transformed path is a file
+    if os.path.isfile(full_path):
+        return full_path
+    else:
+        # If none of the above, return a default robot file or raise an error
+        default_robot_file = os.path.join("/", "sli.robot")  # Default file
+        if os.path.isfile(default_robot_file):
+            return default_robot_file
+        else:
+            raise FileNotFoundError("Could not resolve the robot file path based on environment settings.")
+  
 
 def run_bash_file(
     bash_file: str,
@@ -170,8 +207,7 @@ def run_bash_file(
         logger.info(f"File '{bash_file}' found in the current working directory.")
     else:
         cwd = os.getcwd()
-        runwhen_home=os.environ.get("RUNWHEN_HOME", None)
-        rw_path_to_robot = os.environ.get("RW_PATH_TO_ROBOT", None)
+        rw_path_to_robot = resolve_path_to_robot()
         ## Users will expect to run the command from within the current working directory
         ## Here we will rewrite the path so that it executes properly from the cwd
         if rw_path_to_robot:

--- a/libraries/RW/CLI/CLI.py
+++ b/libraries/RW/CLI/CLI.py
@@ -151,27 +151,28 @@ def find_file(*paths):
     return None
 
 def resolve_path_to_robot():
-    # Get and normalize environment variables by stripping any potential trailing slash
+    # Get and clean environment variables
     runwhen_home = os.getenv("RUNWHEN_HOME", "").rstrip('/')
     home = os.getenv("HOME", "").rstrip('/')
     
-    # Get the path to the robot file, handling potential environment variable substitution
+    # RW_PATH_TO_ROBOT might contain a path that needs to be checked both directly and relative to RUNWHEN_HOME
     repo_path_to_robot = os.getenv("RW_PATH_TO_ROBOT", "").replace("$(RUNWHEN_HOME)", runwhen_home)
     
-    # Check if path is already absolute
-    if os.path.isabs(repo_path_to_robot) and os.path.isfile(repo_path_to_robot):
-        return repo_path_to_robot
+    # Normalize path by stripping any leading slashes for relative checking
+    normalized_path = repo_path_to_robot.lstrip('/')
     
-    # Common paths to check, adjusted for various likely directory structures
-    common_paths = [
-        os.path.join("/collection", repo_path_to_robot.lstrip('/')), # Ensuring no double slashes
-        os.path.join("/", repo_path_to_robot.lstrip('/')), # Direct path under root
-        os.path.join(runwhen_home, "collection", repo_path_to_robot.lstrip('/')), # Nested under collection
-        os.path.join(home, "collection", repo_path_to_robot.lstrip('/')) # Nested under collection in HOME
-    ]
+    # Prepare paths to check
+    absolute_path = repo_path_to_robot if os.path.isabs(repo_path_to_robot) else None
+    relative_to_runwhen_home = os.path.join(runwhen_home, normalized_path)
+    relative_to_home = os.path.join(home, normalized_path)
+    common_path = os.path.join("/collection", normalized_path)  # Adjusted for common setup
+    root_path = os.path.join("/", normalized_path)
+    
+    # List of all possible paths to check
+    paths_to_check = [path for path in [absolute_path, relative_to_runwhen_home, relative_to_home, common_path, root_path] if path]
 
-    # Attempt to find the file in any of the common paths
-    file_path = find_file(*common_paths)
+    # Attempt to find the file in any of the paths listed
+    file_path = find_file(*paths_to_check)
     if file_path:
         return file_path
 
@@ -180,7 +181,7 @@ def resolve_path_to_robot():
     if os.path.isfile(default_robot_file):
         return default_robot_file
 
-    # If all fails, raise error
+    # If all fails, raise an error
     raise FileNotFoundError("Could not find the robot file in any known locations.")
 
 

--- a/libraries/RW/CLI/CLI.py
+++ b/libraries/RW/CLI/CLI.py
@@ -143,7 +143,7 @@ def _create_secrets_from_kwargs(**kwargs) -> list[platform.ShellServiceRequestSe
             )
     return request_secrets
 
-def resolve_rfile_path():
+def resolve_path_to_robot():
     # Get environment variables
     runwhen_home = os.getenv("RUNWHEN_HOME", "")
     repo_path_to_robot = os.getenv("RW_PATH_TO_ROBOT", "")


### PR DESCRIPTION
This PR needs to be coordinated with the change for the Robot Runtime base image  (e.g. latest needs to be reassigned to the..err.. the latest image tag.. main-e767726f)

It also requires the latest corestate image so that the ENV vars get set with proper codebundle paths. 


Why? The base image, and the final runtime images, now change the WORKDIR to /home/runwhen. The changes should be applied right after that tag is changes and robot runtime is synced to each environment. 
