### PR TITLE
feat(env): support global http(s) proxy passthrough with CAs

### DIFF
--- a/libraries/RW/CLI/local_process.py
+++ b/libraries/RW/CLI/local_process.py
@@ -48,6 +48,17 @@ def execute_local_command(
     errors = []
     tmpdir = None
     run_with_env = {}
+        # Define the keys we want to check in the current environment for proxy settings / ca settings
+    keys_to_check = [
+        "HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY", "REQUESTS_CA_BUNDLE",
+        "CURL_CA_BUNDLE", "SSL_CERT_FILE", "NODE_EXTRA_CA_CERTS"
+    ]
+
+    # Update run_with_env with the environment variables that are set
+    run_with_env.update({key: os.getenv(key) for key in keys_to_check if os.getenv(key)})
+
+    # If additional environment settings are provided, update run_with_env with these,
+    # potentially overwriting the previously set values
     if env:
         run_with_env.update(env)
     try:

--- a/libraries/RW/CLI/local_process.py
+++ b/libraries/RW/CLI/local_process.py
@@ -48,7 +48,7 @@ def execute_local_command(
     errors = []
     tmpdir = None
     run_with_env = {}
-        # Define the keys we want to check in the current environment for proxy settings / ca settings
+    # Define the keys we want to check in the current environment for proxy settings / ca settings
     keys_to_check = [
         "HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY", "REQUESTS_CA_BUNDLE",
         "CURL_CA_BUNDLE", "SSL_CERT_FILE", "NODE_EXTRA_CA_CERTS"


### PR DESCRIPTION
This is mostly a workaround to support the use of proxies that require an internal CA until we move this logic into the platform (robot-runtime). It's not required, but it's much easier to allow the RunWhen Runner to set these values once by passing them through to the codebundle being executed than for the user to provide these for every SLX unless they are providing a unique CA via ConfigProvided & SecretsProvided via the SLX, in which case those values should take priority over the runner-provided values.