### PR TITLE
Minor touchups

### DIFF
--- a/codebundles/k8s-deployment-healthcheck/.runwhen/templates/k8s-deployment-health-taskset.yaml
+++ b/codebundles/k8s-deployment-healthcheck/.runwhen/templates/k8s-deployment-health-taskset.yaml
@@ -32,7 +32,7 @@ spec:
     - name: EXPECTED_AVAILABILITY
       value: "1"
     - name: ANOMALY_THRESHOLD
-      value: "3"
+      value: "0.2"
     - name: LOGS_ERROR_PATTERN
       value: ""
     - name: LOGS_EXCLUDE_PATTERN

--- a/codebundles/k8s-deployment-healthcheck/runbook.robot
+++ b/codebundles/k8s-deployment-healthcheck/runbook.robot
@@ -156,12 +156,13 @@ Troubleshoot Deployment Warning Events for `${DEPLOYMENT_NAME}`
     IF    len(@{object_list}) > 0
         FOR    ${item}    IN    @{object_list}
             ${message_string}=    Catenate    SEPARATOR;    @{item["messages"]}
-            ${messages}=    Replace String    ${message_string}    "    ${EMPTY}
-            ${issue_list}=    RW.CLI.Run Bash File
+            ${messages}=    RW.K8sHelper.Sanitize Messages    ${message_string}
+            ${issues}=    RW.CLI.Run Bash File
             ...    bash_file=workload_issues.sh
             ...    cmd_override=./workload_issues.sh "${messages}" "Deployment" "${DEPLOYMENT_NAME}"
             ...    env=${env}
             ...    include_in_history=False
+            ${issue_list}=    Evaluate    json.loads(r'''${issues.stdout}''')    json
             FOR    ${issue}    IN    @{issue_list}
                 RW.Core.Add Issue
                 ...    severity=${issue["severity"]}
@@ -171,6 +172,7 @@ Troubleshoot Deployment Warning Events for `${DEPLOYMENT_NAME}`
                 ...    reproduce_hint=${events.cmd}
                 ...    details=${issue["details"]}
                 ...    next_steps=${issue["next_steps"]}\n${related_resource_recommendations}
+            END
         END
     END
     ${history}=    RW.CLI.Pop Shell History
@@ -279,20 +281,23 @@ Check Deployment Event Anomalies for `${DEPLOYMENT_NAME}`
     IF    len($anomaly_list) > 0
         FOR    ${item}    IN    @{anomaly_list}
             IF    $item["average_events_per_minute"] > ${ANOMALY_THRESHOLD}
-                ${messages}=    Replace String    ${item["messages"][0]}    "    ${EMPTY}
-                ${item_next_steps}=    RW.CLI.Run Bash File
-                ...    bash_file=workload_next_steps.sh
-                ...    cmd_override=./workload_next_steps.sh "${messages}" "Deployment" "${DEPLOYMENT_NAME}"
+                ${messages}=    RW.K8sHelper.Sanitize Messages    ${item["messages"][0]}
+                ${issues}=    RW.CLI.Run Bash File
+                ...    bash_file=workload_issues.sh
+                ...    cmd_override=./workload_issues.sh "${messages}" "Deployment" "${DEPLOYMENT_NAME}"
                 ...    env=${env}
                 ...    include_in_history=False
-                RW.Core.Add Issue
-                ...    severity=3
-                ...    expected=Deployment `${DEPLOYMENT_NAME}` in namespace `${NAMESPACE}` has generated an average events per minute above the threshold of ${ANOMALY_THRESHOLD}.
-                ...    actual=Deployment `${DEPLOYMENT_NAME}` in namespace `${NAMESPACE}` should have less than ${ANOMALY_THRESHOLD} events per minute related to a specific object.
-                ...    title= ${item["kind"]} `${item["name"]}` has rapidly generated events that might warrant further investigation. 
-                ...    reproduce_hint=View Commands Used in Report Output
-                ...    details=${item["kind"]} `${item["name"]}` has an average of ${item["average_events_per_minute"]} events per minute (above the threshold of ${ANOMALY_THRESHOLD}):\n`${item}`
-                ...    next_steps=${item_next_steps.stdout}\n${related_resource_recommendations}
+                ${issue_list}=    Evaluate    json.loads(r'''${issues.stdout}''')    json
+                FOR    ${issue}    IN    @{issue_list}
+                    RW.Core.Add Issue
+                    ...    severity=${issue["severity"]}
+                    ...    expected=Warning events should not be present in namespace `${NAMESPACE}` for Deployment `${DEPLOYMENT_NAME}`
+                    ...    actual=Warning events are found in namespace `${NAMESPACE}` for Deployment `${DEPLOYMENT_NAME}` which indicate potential issues.
+                    ...    title= ${issue["title"]}
+                    ...    reproduce_hint=${events.cmd}
+                    ...    details=${issue["details"]}
+                    ...    next_steps=${issue["next_steps"]}\n${related_resource_recommendations}
+                END
             END
         END
         ${anomalies_report_output}=    Set Variable    ${recent_anomalies.stdout}
@@ -379,8 +384,8 @@ Suite Initialization
     ...    type=string
     ...    description=The rate of occurence per minute at which an Event becomes classified as an anomaly, even if Kubernetes considers it informational.
     ...    pattern=\d+(\.\d+)?
-    ...    example=5.0
-    ...    default=5.0
+    ...    example=1.0
+    ...    default=0.2
     ${LOGS_ERROR_PATTERN}=    RW.Core.Import User Variable    LOGS_ERROR_PATTERN
     ...    type=string
     ...    description=The error pattern to use when grep-ing logs.

--- a/codebundles/k8s-deployment-healthcheck/runbook.robot
+++ b/codebundles/k8s-deployment-healthcheck/runbook.robot
@@ -137,7 +137,7 @@ Check Readiness Probe Configuration for Deployment `${DEPLOYMENT_NAME}`
     RW.Core.Add Pre To Report    Readiness probe testing results:\n\n${readiness_probe_health.stdout}
     RW.Core.Add Pre To Report    Commands Used: ${readiness_probe_health.cmd}
 
-Troubleshoot Deployment Warning Events for `${DEPLOYMENT_NAME}`
+Inspect Deployment Warning Events for `${DEPLOYMENT_NAME}`
     [Documentation]    Fetches warning events related to the deployment workload in the namespace and triages any issues found in the events.
     [Tags]    events    workloads    errors    warnings    get    deployment    ${DEPLOYMENT_NAME}
     ${events}=    RW.CLI.Run Cli
@@ -192,7 +192,7 @@ Get Deployment Workload Details For `${DEPLOYMENT_NAME}` and Add to Report
     RW.Core.Add Pre To Report    Snapshot of deployment state:\n\n${deployment.stdout}
     RW.Core.Add Pre To Report    Commands Used: ${history}
 
-Troubleshoot Deployment Replicas for `${DEPLOYMENT_NAME}`
+Inspect Deployment Replicas for `${DEPLOYMENT_NAME}`
     [Documentation]    Pulls the replica information for a given deployment and checks if it's highly available
     ...    , if the replica counts are the expected / healthy values, and raises issues if it is not progressing
     ...    and is missing pods.
@@ -237,7 +237,7 @@ Troubleshoot Deployment Replicas for `${DEPLOYMENT_NAME}`
         ...    title= Deployment `${DEPLOYMENT_NAME}` in Namespace `${NAMESPACE}` has less than the desired availability
         ...    reproduce_hint=View Commands Used in Report Output
         ...    details=Deployment `${DEPLOYMENT_NAME}` has minimum availability, but has unready pods:\n`${deployment_status}`
-        ...    next_steps=Troubleshoot Deployment Warning Events for `${DEPLOYMENT_NAME}`
+        ...    next_steps=Inspect Deployment Warning Events for `${DEPLOYMENT_NAME}`
     END
     IF    $deployment_status["desired_replicas"] == 1
         RW.Core.Add Issue

--- a/codebundles/k8s-deployment-healthcheck/runbook.robot
+++ b/codebundles/k8s-deployment-healthcheck/runbook.robot
@@ -157,20 +157,20 @@ Troubleshoot Deployment Warning Events for `${DEPLOYMENT_NAME}`
         FOR    ${item}    IN    @{object_list}
             ${message_string}=    Catenate    SEPARATOR;    @{item["messages"]}
             ${messages}=    Replace String    ${message_string}    "    ${EMPTY}
-            ${item_next_steps}=    RW.CLI.Run Bash File
-            ...    bash_file=workload_next_steps.sh
-            ...    cmd_override=./workload_next_steps.sh "${messages}" "Deployment" "${DEPLOYMENT_NAME}"
+            ${issue_list}=    RW.CLI.Run Bash File
+            ...    bash_file=workload_issues.sh
+            ...    cmd_override=./workload_issues.sh "${messages}" "Deployment" "${DEPLOYMENT_NAME}"
             ...    env=${env}
             ...    include_in_history=False
-            # FIXME - Should we add severity mappings in the next steps to make the issue more dynamic?
-            RW.Core.Add Issue
-            ...    severity=4
-            ...    expected=Warning events should not be present in namespace `${NAMESPACE}` for Deployment `${DEPLOYMENT_NAME}`
-            ...    actual=Warning events are found in namespace `${NAMESPACE}` for Deployment `${DEPLOYMENT_NAME}` which indicate potential issues.
-            ...    title= Deployment `${DEPLOYMENT_NAME}` generated warning events for ${item["kind"]} `${item["name"]}`.
-            ...    reproduce_hint=View Commands Used in Report Output
-            ...    details=${item["kind"]} `${item["name"]}` generated the following warning details:\n`${item}`
-            ...    next_steps=${item_next_steps.stdout}\n${related_resource_recommendations}
+            FOR    ${issue}    IN    @{issue_list}
+                RW.Core.Add Issue
+                ...    severity=${issue["severity"]}
+                ...    expected=Warning events should not be present in namespace `${NAMESPACE}` for Deployment `${DEPLOYMENT_NAME}`
+                ...    actual=Warning events are found in namespace `${NAMESPACE}` for Deployment `${DEPLOYMENT_NAME}` which indicate potential issues.
+                ...    title= ${issue["title"]}
+                ...    reproduce_hint=${events.cmd}
+                ...    details=${issue["details"]}
+                ...    next_steps=${issue["next_steps"]}\n${related_resource_recommendations}
         END
     END
     ${history}=    RW.CLI.Pop Shell History

--- a/codebundles/k8s-deployment-healthcheck/workload_issues.sh
+++ b/codebundles/k8s-deployment-healthcheck/workload_issues.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+# -----------------------------------------------------------------------------
+# Script Information and Metadata
+# -----------------------------------------------------------------------------
+# Author: @stewartshea
+# Description: This script takes in event message strings captured from a 
+# Kubernetes based system and provides more concrete issue details in json format. This is a migratio naway from workload_next_steps.sh in order to support dynamic severity generation and more robust next step details. 
+# -----------------------------------------------------------------------------
+# Input: List of event messages, related owner kind, and related owner name
+messages="$1"
+owner_kind="$2"  
+owner_name="$3"
+
+if [[ $messages =~ "ContainersNotReady" && $owner_kind == "Deployment" ]]; then
+    issue_details="{\"severity\":\"2\",\"title\":\"$owner_kind \`$owner_name\` has unready containers\",\"details\":\"$messages\",\"next_steps\":\"Troubleshoot Deployment Replicas for \`$owner_name\`\"}"
+fi
+
+if [[ $messages =~ "Misconfiguration" && $owner_kind == "Deployment" ]]; then
+    issue_details="{\"severity\":\"2\",\"title\":\"$owner_kind \`$owner_name\` has a misconfiguration\",\"details\":\"$messages\",\"next_steps\":\"Check Deployment Log For Issues for \`$owner_name\`\nGet Deployment Workload Details For \`$owner_name\` and Add to Report\"}"
+fi
+
+if [[ $messages =~ "PodInitializing" ]]; then
+    issue_details="{\"severity\":\"4\",\"title\":\"$owner_kind \`$owner_name\` is initializing\",\"details\":\"$messages\",\"next_steps\":\"Retry in a few minutes and verify that \`$owner_name\` is running.\nTroubleshoot $owner_kind Warning Events for \`$owner_name\`\"}"
+fi
+
+if [[ $messages =~ "Liveness probe failed" || $messages =~ "Liveness probe errored" ]]; then
+    issue_details="{\"severity\":\"3\",\"title\":\"$owner_kind \`$owner_name\` is restarting\",\"details\":\"$messages\",\"next_steps\":\"Check Liveliness Probe Configuration for $owner_kind \`$owner_name\`\"}"
+
+fi
+
+if [[ $messages =~ "Readiness probe errored" || $messages =~ "Readiness probe failed" ]]; then
+    issue_details="{\"severity\":\"2\",\"title\":\"$owner_kind \`$owner_name\` is unable to start\",\"details\":\"$messages\",\"next_steps\":\"Check Readiness Probe Configuration for $owner_kind \`$owner_name\`\"}"
+fi
+
+if [[ $messages =~ "PodFailed" ]]; then
+    issue_details="{\"severity\":\"2\",\"title\":\"$owner_kind \`$owner_name\` has failed pods\",\"details\":\"$messages\",\"next_steps\":\"Check Readiness Probe Configuration for $owner_kind \`$owner_name\`\"}"
+fi
+
+if [[ $messages =~ "ImagePullBackOff" || $messages =~ "Back-off pulling image" || $messages =~ "ErrImagePull" ]]; then
+    issue_details="{\"severity\":\"2\",\"title\":\"$owner_kind \`$owner_name\` has image access issues\",\"details\":\"$messages\",\"next_steps\":\"List Images and Tags for Every Container in Failed Pods for Namespace \`$NAMESPACE\`\nList ImagePullBackoff Events and Test Path and Tags for Namespace \`$NAMESPACE\`\"}"
+fi
+
+if [[ $messages =~ "Back-off restarting failed container" ]]; then
+    issue_details="{\"severity\":\"2\",\"title\":\"$owner_kind \`$owner_name\` has failing containers\",\"details\":\"$messages\",\"next_steps\":\"Check Log for $owner_kind \`$owner_name\`\nTroubleshoot Warning Events for $owner_kind \`$owner_name\`\"}"
+fi
+
+
+if [[ $messages =~ "forbidden: failed quota" || $messages =~ "forbidden: exceeded quota" ]]; then
+    issue_details="{\"severity\":\"3\",\"title\":\"$owner_kind \`$owner_name\` has resources that cannot be scheduled\",\"details\":\"$messages\",\"next_steps\":\"Check Resource Quota Utilization in Namepace \`${NAMESPACE}\`\"}"
+fi
+
+if [[ $messages =~ "No preemption victims found for incoming pod" || $messages =~ "Insufficient cpu" ]]; then
+    issue_details="{\"severity\":\"2\",\"title\":\"$owner_kind \`$owner_name\` cannot be scheduled - not enough cluster resources.\",\"details\":\"$messages\",\"next_steps\":\"Not enough node resources available to schedule pods. Escalate this issue to your cluster owner.\nIncrease Node Count in Cluster\nCheck for Quota Errors\"}"
+
+fi
+
+if [[ $messages =~ "max node group size reached" ]]; then
+    issue_details="{\"severity\":\"2\",\"title\":\"$owner_kind \`$owner_name\` cannot be scheduled - cannot increase cluster size.\",\"details\":\"$messages\",\"next_steps\":\"Not enough node resources available to schedule pods. Escalate this issue to your cluster owner.\nIncrease Max Node Group Size in Cluster\"}"
+fi
+
+if [[ $messages =~ "Health check failed after" ]]; then
+    issue_details="{\"severity\":\"3\",\"title\":\"$owner_kind \`$owner_name\` health check failed.\",\"details\":\"$messages\",\"next_steps\":\"Check $owner_kind \`$owner_name\` Health\"}"
+fi
+
+if [[ $messages =~ "Deployment does not have minimum availability" ]]; then
+    issue_details="{\"severity\":\"3\",\"title\":\"$owner_kind \`$owner_name\` is not available.\",\"details\":\"$messages\",\"next_steps\":\"Troubleshoot Deployment Warning Events for \`$owner_name\`\"}"
+fi
+
+
+# Outputting recommendations as JSON
+if [ -n "$issue_details" ]; then
+    echo "Issue details:"
+    echo "$issue_details" | jq .
+else
+    echo "No issues found."
+fi

--- a/codebundles/k8s-deployment-healthcheck/workload_issues.sh
+++ b/codebundles/k8s-deployment-healthcheck/workload_issues.sh
@@ -25,7 +25,7 @@ add_issue() {
 
 # Check conditions and add issues to the array
 if [[ $messages =~ "ContainersNotReady" && $owner_kind == "Deployment" ]]; then
-    add_issue "2" "$owner_kind \`$owner_name\` has unready containers" "$messages" "Troubleshoot Deployment Replicas for \`$owner_name\`"
+    add_issue "2" "$owner_kind \`$owner_name\` has unready containers" "$messages" "Inspect Deployment Replicas for \`$owner_name\`"
 fi
 
 if [[ $messages =~ "Misconfiguration" && $owner_kind == "Deployment" ]]; then
@@ -33,7 +33,7 @@ if [[ $messages =~ "Misconfiguration" && $owner_kind == "Deployment" ]]; then
 fi
 
 if [[ $messages =~ "PodInitializing" ]]; then
-    add_issue "4" "$owner_kind \`$owner_name\` is initializing" "$messages" "Retry in a few minutes and verify that \`$owner_name\` is running.\nTroubleshoot $owner_kind Warning Events for \`$owner_name\`"
+    add_issue "4" "$owner_kind \`$owner_name\` is initializing" "$messages" "Retry in a few minutes and verify that \`$owner_name\` is running.\nInspect $owner_kind Warning Events for \`$owner_name\`"
 fi
 
 if [[ $messages =~ "Liveness probe failed" || $messages =~ "Liveness probe errored" ]]; then
@@ -53,7 +53,7 @@ if [[ $messages =~ "ImagePullBackOff" || $messages =~ "Back-off pulling image" |
 fi
 
 if [[ $messages =~ "Back-off restarting failed container" ]]; then
-    add_issue "2" "$owner_kind \`$owner_name\` has failing containers" "$messages" "Check $owner_kind Log for \`$owner_name\`\nTroubleshoot Warning Events for $owner_kind \`$owner_name\`"
+    add_issue "2" "$owner_kind \`$owner_name\` has failing containers" "$messages" "Check $owner_kind Log for \`$owner_name\`\nInspect Warning Events for $owner_kind \`$owner_name\`"
 fi
 
 if [[ $messages =~ "forbidden: failed quota" || $messages =~ "forbidden: exceeded quota" ]]; then
@@ -77,7 +77,7 @@ if [[ $messages =~ "Health check failed after" ]]; then
 fi
 
 if [[ $messages =~ "Deployment does not have minimum availability" ]]; then
-    add_issue "3" "$owner_kind \`$owner_name\` is not available." "$messages" "Troubleshoot Deployment Warning Events for \`$owner_name\`"
+    add_issue "3" "$owner_kind \`$owner_name\` is not available." "$messages" "Inspect Deployment Warning Events for \`$owner_name\`"
 fi
 
 

--- a/codebundles/k8s-deployment-healthcheck/workload_next_steps.sh
+++ b/codebundles/k8s-deployment-healthcheck/workload_next_steps.sh
@@ -18,7 +18,7 @@ next_steps=()
 
 
 if [[ $messages =~ "ContainersNotReady" && $owner_kind == "Deployment" ]]; then
-    next_steps+=("Troubleshoot Deployment Replicas for \`$owner_name\`")
+    next_steps+=("Inspect Deployment Replicas for \`$owner_name\`")
 fi
 
 if [[ $messages =~ "Misconfiguration" && $owner_kind == "Deployment" ]]; then
@@ -33,7 +33,7 @@ fi
 
 if [[ $messages =~ "PodInitializing" ]]; then
     next_steps+=("Check $owner_kind Health for \`$owner_name\`")
-    next_steps+=("Troubleshoot $owner_kind Warning Events for \`$owner_name\`")
+    next_steps+=("Inspect $owner_kind Warning Events for \`$owner_name\`")
 fi
 
 if [[ $messages =~ "Liveness probe failed" || $messages =~ "Liveness probe errored" ]]; then
@@ -55,7 +55,7 @@ fi
 
 if [[ $messages =~ "Back-off restarting failed container" ]]; then
     next_steps+=("Check Log for $owner_kind \`$owner_name\`")
-    next_steps+=("Troubleshoot Warning Events for $owner_kind \`$owner_name\`")
+    next_steps+=("Inspect Warning Events for $owner_kind \`$owner_name\`")
 
 fi
 
@@ -85,7 +85,7 @@ if [[ $messages =~ "Health check failed after" ]]; then
 fi
 
 if [[ $messages =~ "Deployment does not have minimum availability" ]]; then
-    next_steps+=("Troubleshoot Deployment Warning Events for \`$owner_name\`")
+    next_steps+=("Inspect Deployment Warning Events for \`$owner_name\`")
 fi
 
 

--- a/codebundles/k8s-namespace-healthcheck/runbook.robot
+++ b/codebundles/k8s-namespace-healthcheck/runbook.robot
@@ -7,6 +7,7 @@ Metadata            Supports    Kubernetes,AKS,EKS,GKE,OpenShift
 Library             BuiltIn
 Library             RW.Core
 Library             RW.CLI
+Library             RW.K8sHelper
 Library             RW.NextSteps
 Library             RW.platform
 Library             OperatingSystem
@@ -48,7 +49,7 @@ Troubleshoot Warning Events in Namespace `${NAMESPACE}`
             ...    env=${env}
             ...    secret_file__kubeconfig=${kubeconfig}
             ...    include_in_history=False
-            ${messages}=    Replace String    ${item["summary_messages"]}    "    ${EMPTY}
+            ${messages}=    RW.K8sHelper.Sanitize Messages    ${item["summary_messages"]}
             ${item_owner_output}=    RW.CLI.Run Cli
             ...    cmd=echo "${item_owner.stdout}" | sed 's/ *$//' | tr -d '\n'
             ...    env=${env}
@@ -60,20 +61,36 @@ Troubleshoot Warning Events in Namespace `${NAMESPACE}`
                 ${owner_kind}=    Set Variable    "Unknown"
                 ${owner_name}=    Set Variable    "Unknown"
             END
-            ${item_next_steps}=    RW.CLI.Run Bash File
-            ...    bash_file=workload_next_steps.sh
-            ...    cmd_override=./workload_next_steps.sh "${messages}" "${owner_kind}" "${owner_name}"
+            ${issues}=    RW.CLI.Run Bash File
+            ...    bash_file=workload_issues.sh
+            ...    cmd_override=./workload_issues.sh "${messages}" "${owner_kind}" "${owner_name}"
             ...    env=${env}
-            ...    secret_file__kubeconfig=${kubeconfig}
             ...    include_in_history=False
-            RW.Core.Add Issue
-            ...    severity=3
-            ...    expected=Warning events should not be present in namespace `${NAMESPACE}` for ${owner_kind} `${owner_name}`
-            ...    actual=Warning events are found in namespace `${NAMESPACE}` for ${owner_kind} `${owner_name}` which indicate potential issues.
-            ...    title= ${owner_kind} `${owner_name}` generated ${item["total_events"]} **warning** events and should be reviewed.
-            ...    reproduce_hint=View Commands Used in Report Output
-            ...    details=Item `${item["object"]}` generated a total of ${item["total_events"]} events containing some of the following messages and types:\n`${item["summary_messages"]}`
-            ...    next_steps=${item_next_steps.stdout}
+            ${issue_list}=    Evaluate    json.loads(r'''${issues.stdout}''')    json
+            FOR    ${issue}    IN    @{issue_list}
+                RW.Core.Add Issue
+                ...    severity=${issue["severity"]}
+                ...    expected=Warning events should not be present in namespace `${NAMESPACE}` for ${owner_kind} `${owner_name}`
+                ...    actual=Warning events are found in namespace `${NAMESPACE}` for ${owner_kind} `${owner_name}` which indicate potential issues.
+                ...    title= ${issue["title"]}
+                ...    reproduce_hint=${warning_events_by_object.cmd}
+                ...    details=${issue["details"]}
+                ...    next_steps=${issue["next_steps"]}
+            END
+            # ${item_next_steps}=    RW.CLI.Run Bash File
+            # ...    bash_file=workload_next_steps.sh
+            # ...    cmd_override=./workload_next_steps.sh "${messages}" "${owner_kind}" "${owner_name}"
+            # ...    env=${env}
+            # ...    secret_file__kubeconfig=${kubeconfig}
+            # ...    include_in_history=False
+            # RW.Core.Add Issue
+            # ...    severity=3
+            # ...    expected=Warning events should not be present in namespace `${NAMESPACE}` for ${owner_kind} `${owner_name}`
+            # ...    actual=Warning events are found in namespace `${NAMESPACE}` for ${owner_kind} `${owner_name}` which indicate potential issues.
+            # ...    title= ${owner_kind} `${owner_name}` generated ${item["total_events"]} **warning** events and should be reviewed.
+            # ...    reproduce_hint=View Commands Used in Report Output
+            # ...    details=Item `${item["object"]}` generated a total of ${item["total_events"]} events containing some of the following messages and types:\n`${item["summary_messages"]}`
+            # ...    next_steps=${item_next_steps.stdout}
         END
     END
     ${history}=    RW.CLI.Pop Shell History
@@ -128,64 +145,64 @@ Troubleshoot Pending Pods In Namespace `${NAMESPACE}`
     [Documentation]    Fetches pods that are pending and provides details.
     [Tags]    namespace    pods    status    pending    ${NAMESPACE}
     ${pending_pods}=    RW.CLI.Run Cli
-    ...    cmd=${KUBERNETES_DISTRIBUTION_BINARY} get pods --context=${CONTEXT} -n ${NAMESPACE} --field-selector=status.phase=Pending --no-headers -o json | jq -r '.items[] | "pod_name: \\(.metadata.name)\\nstatus: \\(.status.phase // "N/A")\\nmessage: \\(.status.conditions[0].message // "N/A")\\nreason: \\(.status.conditions[0].reason // "N/A")\\ncontainerStatus: \\((.status.containerStatuses[0].state // "N/A"))\\ncontainerMessage: \\(.status.containerStatuses[0].state.waiting?.message // "N/A")\\ncontainerReason: \\(.status.containerStatuses[0].state.waiting?.reason // "N/A")\\n_______-"'
+    # ...    cmd=${KUBERNETES_DISTRIBUTION_BINARY} get pods --context=${CONTEXT} -n ${NAMESPACE} --field-selector=status.phase=Pending --no-headers -o json | jq -r '.items[] | "pod_name: \\(.metadata.name)\\nstatus: \\(.status.phase // "N/A")\\nmessage: \\(.status.conditions[0].message // "N/A")\\nreason: \\(.status.conditions[0].reason // "N/A")\\ncontainerStatus: \\((.status.containerStatuses[0].state // "N/A"))\\ncontainerMessage: \\(.status.containerStatuses[0].state.waiting?.message // "N/A")\\ncontainerReason: \\(.status.containerStatuses[0].state.waiting?.reason // "N/A")\\n_______-"'
+    ...    cmd=${KUBERNETES_DISTRIBUTION_BINARY} get pods --context=${CONTEXT} -n ${NAMESPACE} --field-selector=status.phase=Pending --no-headers -o json | jq -r '[.items[] | {pod_name: .metadata.name, status: (.status.phase // "N/A"), message: (.status.conditions[0].message // "N/A"), reason: (.status.conditions[0].reason // "N/A"), containerStatus: (.status.containerStatuses[0].state // "N/A"), containerMessage: (.status.containerStatuses[0].state.waiting?.message // "N/A"), containerReason: (.status.containerStatuses[0].state.waiting?.reason // "N/A")}]'
     ...    env=${env}
     ...    secret_file__kubeconfig=${kubeconfig}
     ...    show_in_rwl_cheatsheet=true
     ...    render_in_commandlist=true
-    ${pending_pod_list}=    Split String    ${pending_pods.stdout}    _______-
+    ${pending_pod_list}=    Evaluate    json.loads(r'''${pending_pods.stdout}''')    json
     IF    len($pending_pod_list) > 0
         FOR    ${item}    IN    @{pending_pod_list}
-            ${is_not_just_newline}=    Evaluate    '''${item}'''.strip() != ''
-            IF    ${is_not_just_newline}
-                ${pod_name}=    RW.CLI.Run Cli
-                ...    cmd=echo '${item}' | grep pod_name: | sed 's/^pod_name: //' | sed 's/ *$//' | tr -d '\n'
-                ...    env=${env}
-                ...    include_in_history=false
-                ${pod_message}=    RW.CLI.Run Cli
-                ...    cmd=echo '${item}' | grep message: | sed 's/^message: //' | sed 's/ *$//' | tr -d '\n'| sed 's/\"//g'
-                ...    env=${env}
-                ...    include_in_history=false
-                ${container_message}=    RW.CLI.Run Cli
-                ...    cmd=echo '${item}' | grep containerMessage: | sed 's/^containerMessage: //' | sed 's/ *$//' | tr -d '\n'| sed 's/\"//g'
-                ...    env=${env}
-                ...    include_in_history=false
-                ${container_reason}=    RW.CLI.Run Cli
-                ...    cmd=echo '${item}' | grep containerReason: | sed 's/^containerReason: //' | sed 's/ *$//' | tr -d '\n'| sed 's/\"//g'
-                ...    env=${env}
-                ...    include_in_history=false
-                ${item_owner}=    RW.CLI.Run Bash File
-                ...    bash_file=find_resource_owners.sh
-                ...    cmd_override=./find_resource_owners.sh Pod ${pod_name.stdout} ${NAMESPACE} ${CONTEXT}
-                ...    env=${env}
-                ...    secret_file__kubeconfig=${kubeconfig}
-                ...    include_in_history=False
-                ${item_owner_output}=    RW.CLI.Run Cli
-                ...    cmd=echo "${item_owner.stdout}" | sed 's/ *$//' | tr -d '\n'
-                ...    env=${env}
-                ...    include_in_history=False
-                IF    len($item_owner_output.stdout) > 0 and ($item_owner_output.stdout) != "No resource found"
-                    ${owner_kind}    ${owner_name}=    Split String    ${item_owner_output.stdout}    ${SPACE}
-                    ${owner_name}=    Replace String    ${owner_name}    \n    ${EMPTY}
-                ELSE
-                    ${owner_kind}=    Set Variable    "Unknown"
-                    ${owner_name}=    Set Variable    "Unknown"
-                END
-                ${item_next_steps}=    RW.CLI.Run Bash File
-                ...    bash_file=workload_next_steps.sh
-                ...    cmd_override=./workload_next_steps.sh "${container_reason.stdout};${pod_message.stdout};${container_reason.stdout}" "${owner_kind}" "${owner_name}"
-                ...    env=${env}
-                ...    secret_file__kubeconfig=${kubeconfig}
-                ...    include_in_history=False
-                RW.Core.Add Issue
-                ...    severity=2
-                ...    expected=Pods should not be pending in `${NAMESPACE}`.
-                ...    actual=Pod `${pod_name.stdout}` in `${NAMESPACE}` is pending.
-                ...    title= Pod `${pod_name.stdout}` is pending with ${container_reason.stdout}
-                ...    reproduce_hint=View Commands Used in Report Output
-                ...    details=Pod `${pod_name.stdout}` is owned by ${owner_kind} `${owner_name}` and is pending with the following details:\n${item}
-                ...    next_steps=${item_next_steps.stdout}
+            ${item_owner}=    RW.CLI.Run Bash File
+            ...    bash_file=find_resource_owners.sh
+            ...    cmd_override=./find_resource_owners.sh Pod ${item["pod_name"]} ${NAMESPACE} ${CONTEXT}
+            ...    env=${env}
+            ...    secret_file__kubeconfig=${kubeconfig}
+            ...    include_in_history=False
+            ${item_owner_output}=    RW.CLI.Run Cli
+            ...    cmd=echo "${item_owner.stdout}" | sed 's/ *$//' | tr -d '\n'
+            ...    env=${env}
+            ...    include_in_history=False
+            IF    len($item_owner_output.stdout) > 0 and ($item_owner_output.stdout) != "No resource found"
+                ${owner_kind}    ${owner_name}=    Split String    ${item_owner_output.stdout}    ${SPACE}
+                ${owner_name}=    Replace String    ${owner_name}    \n    ${EMPTY}
+            ELSE
+                ${owner_kind}=    Set Variable    "Unknown"
+                ${owner_name}=    Set Variable    "Unknown"
             END
+            ${message_string}=    Evaluate    "${item.get('message', '')};${item.get('containerMessage', '')};${item.get('containerReason', '')}"
+            ${messages}=    RW.K8sHelper.Sanitize Messages    ${message_string}
+            ${issues}=    RW.CLI.Run Bash File
+            ...    bash_file=workload_issues.sh
+            ...    cmd_override=./workload_issues.sh "${messages}" "${owner_kind}" "${owner_name}"
+            ...    env=${env}
+            ...    include_in_history=False
+            ${issue_list}=    Evaluate    json.loads(r'''${issues.stdout}''')    json
+            FOR    ${issue}    IN    @{issue_list}
+                RW.Core.Add Issue
+                ...    severity=${issue["severity"]}
+                ...    expected=Pods should not be pending in `${NAMESPACE}`.
+                ...    actual=Pod `${pod_name.stdout}` is pending with ${item["containerReason"]}
+                ...    title= ${issue["title"]}
+                ...    reproduce_hint=${pending_pods.cmd}
+                ...    details=${issue["details"]}
+                ...    next_steps=${issue["next_steps"]}
+            END
+            # ${item_next_steps}=    RW.CLI.Run Bash File
+            # ...    bash_file=workload_next_steps.sh
+            # ...    cmd_override=./workload_next_steps.sh "${container_reason.stdout};${pod_message.stdout};${container_reason.stdout}" "${owner_kind}" "${owner_name}"
+            # ...    env=${env}
+            # ...    secret_file__kubeconfig=${kubeconfig}
+            # ...    include_in_history=False
+            # RW.Core.Add Issue
+            # ...    severity=2
+            # ...    expected=Pods should not be pending in `${NAMESPACE}`.
+            # ...    actual=Pod `${pod_name.stdout}` in `${NAMESPACE}` is pending.
+            # ...    title= Pod `${pod_name.stdout}` is pending with ${container_reason.stdout}
+            # ...    reproduce_hint=View Commands Used in Report Output
+            # ...    details=Pod `${pod_name.stdout}` is owned by ${owner_kind} `${owner_name}` and is pending with the following details:\n${item}
+            # ...    next_steps=${item_next_steps.stdout}
         END
     END
     ${history}=    RW.CLI.Pop Shell History
@@ -197,63 +214,49 @@ Troubleshoot Failed Pods In Namespace `${NAMESPACE}`
     [Documentation]    Fetches all pods which are not running (unready) in the namespace and adds them to a report for future review.
     [Tags]    namespace    pods    status    unready    not starting    phase    failed    ${NAMESPACE}
     ${unreadypods_details}=    RW.CLI.Run Cli
-    ...    cmd=${KUBERNETES_DISTRIBUTION_BINARY} get pods --context=${CONTEXT} -n ${NAMESPACE} --field-selector=status.phase=Failed --no-headers -o json | jq -r --argjson exit_code_explanations '{"0": "Success", "1": "Error", "2": "Misconfiguration", "130": "Pod terminated by SIGINT", "134": "Abnormal Termination SIGABRT", "137": "Pod terminated by SIGKILL - Possible OOM", "143":"Graceful Termination SIGTERM"}' '.items[] | "pod_name: \\(.metadata.name)\\nrestart_count: \\(.status.containerStatuses[0].restartCount // "N/A")\\nmessage: \\(.status.message // "N/A")\\nterminated_finishedAt: \\(.status.containerStatuses[0].state.terminated.finishedAt // "N/A")\\nexit_code: \\(.status.containerStatuses[0].state.terminated.exitCode // "N/A")\\nexit_code_explanation: \\($exit_code_explanations[.status.containerStatuses[0].state.terminated.exitCode | tostring] // "Unknown exit code")\\n_______-"'
+    # ...    cmd=${KUBERNETES_DISTRIBUTION_BINARY} get pods --context=${CONTEXT} -n ${NAMESPACE} --field-selector=status.phase=Failed --no-headers -o json | jq -r --argjson exit_code_explanations '{"0": "Success", "1": "Error", "2": "Misconfiguration", "130": "Pod terminated by SIGINT", "134": "Abnormal Termination SIGABRT", "137": "Pod terminated by SIGKILL - Possible OOM", "143":"Graceful Termination SIGTERM"}' '.items[] | "pod_name: \\(.metadata.name)\\nrestart_count: \\(.status.containerStatuses[0].restartCount // "N/A")\\nmessage: \\(.status.message // "N/A")\\nterminated_finishedAt: \\(.status.containerStatuses[0].state.terminated.finishedAt // "N/A")\\nexit_code: \\(.status.containerStatuses[0].state.terminated.exitCode // "N/A")\\nexit_code_explanation: \\($exit_code_explanations[.status.containerStatuses[0].state.terminated.exitCode | tostring] // "Unknown exit code")\\n_______"'
+    ...    cmd=${KUBERNETES_DISTRIBUTION_BINARY} get pods --context=${CONTEXT} -n ${NAMESPACE} --field-selector=status.phase=Failed --no-headers -o json | jq -r --argjson exit_code_explanations '{"0": "Success", "1": "Error", "2": "Misconfiguration", "130": "Pod terminated by SIGINT", "134": "Abnormal Termination SIGABRT", "137": "Pod terminated by SIGKILL - Possible OOM", "143":"Graceful Termination SIGTERM"}' '[.items[] | {pod_name: .metadata.name, restart_count: (.status.containerStatuses[0].restartCount // "N/A"), message: (.status.message // "N/A"), terminated_finishedAt: (.status.containerStatuses[0].state.terminated.finishedAt // "N/A"), exit_code: (.status.containerStatuses[0].state.terminated.exitCode // "N/A"), exit_code_explanation: ($exit_code_explanations[.status.containerStatuses[0].state.terminated.exitCode | tostring] // "Unknown exit code")}]'
     ...    env=${env}
     ...    secret_file__kubeconfig=${kubeconfig}
     ...    show_in_rwl_cheatsheet=true
     ...    render_in_commandlist=true
-    ${unready_pods_list}=    Split String    ${unreadypods_details.stdout}    _______-
+    ${unready_pods_list}=     Evaluate    json.loads(r'''${unreadypods_details.stdout}''')    json
     IF    len($unready_pods_list) > 0
         FOR    ${item}    IN    @{unready_pods_list}
-            ${is_not_just_newline}=    Evaluate    '''${item}'''.strip() != ''
-            IF    ${is_not_just_newline}
-                ${pod_name}=    RW.CLI.Run Cli
-                ...    cmd=echo '${item}' | grep pod_name: | sed 's/^pod_name: //' | sed 's/ *$//' | tr -d '\n'
-                ...    env=${env}
-                ...    include_in_history=false
-                ${pod_message}=    RW.CLI.Run Cli
-                ...    cmd=echo '${item}' | grep message: | sed 's/^message: //' | sed 's/ *$//' | tr -d '\n'| sed 's/\"//g'
-                ...    env=${env}
-                ...    include_in_history=false
-                ${container_message}=    RW.CLI.Run Cli
-                ...    cmd=echo '${item}' | grep containerMessage: | sed 's/^containerMessage: //' | sed 's/ *$//' | tr -d '\n'| sed 's/\"//g'
-                ...    env=${env}
-                ...    include_in_history=false
-                ${exit_code_explanation}=    RW.CLI.Run Cli
-                ...    cmd=echo '${item}' | grep exit_code_explanation: | sed 's/^exit_code_explanation: //' | sed 's/ *$//' | tr -d '\n'| sed 's/\"//g'
-                ...    env=${env}
-                ...    include_in_history=false
-                ${item_owner}=    RW.CLI.Run Bash File
-                ...    bash_file=find_resource_owners.sh
-                ...    cmd_override=./find_resource_owners.sh Pod ${pod_name.stdout} ${NAMESPACE} ${CONTEXT}
-                ...    env=${env}
-                ...    secret_file__kubeconfig=${kubeconfig}
-                ...    include_in_history=False
-                ${item_owner_output}=    RW.CLI.Run Cli
-                ...    cmd=echo "${item_owner.stdout}" | sed 's/ *$//' | tr -d '\n'
-                ...    env=${env}
-                ...    include_in_history=False
-                IF    len($item_owner_output.stdout) > 0 and ($item_owner_output.stdout) != "No resource found"
-                    ${owner_kind}    ${owner_name}=    Split String    ${item_owner_output.stdout}    ${SPACE}
-                    ${owner_name}=    Replace String    ${owner_name}    \n    ${EMPTY}
-                ELSE
-                    ${owner_kind}=    Set Variable    "Unknown"
-                    ${owner_name}=    Set Variable    "Unknown"
-                END
-                ${item_next_steps}=    RW.CLI.Run Bash File
-                ...    bash_file=workload_next_steps.sh
-                ...    cmd_override=./workload_next_steps.sh "${container_message.stdout};${pod_message.stdout}" "${owner_kind}" "${owner_name}"
-                ...    env=${env}
-                ...    secret_file__kubeconfig=${kubeconfig}
-                ...    include_in_history=False
+            ${item_owner}=    RW.CLI.Run Bash File
+            ...    bash_file=find_resource_owners.sh
+            ...    cmd_override=./find_resource_owners.sh Pod ${item["pod_name"]} ${NAMESPACE} ${CONTEXT}
+            ...    env=${env}
+            ...    secret_file__kubeconfig=${kubeconfig}
+            ...    include_in_history=False
+            ${item_owner_output}=    RW.CLI.Run Cli
+            ...    cmd=echo "${item_owner.stdout}" | sed 's/ *$//' | tr -d '\n'
+            ...    env=${env}
+            ...    include_in_history=False
+            IF    len($item_owner_output.stdout) > 0 and ($item_owner_output.stdout) != "No resource found"
+                ${owner_kind}    ${owner_name}=    Split String    ${item_owner_output.stdout}    ${SPACE}
+                ${owner_name}=    Replace String    ${owner_name}    \n    ${EMPTY}
+            ELSE
+                ${owner_kind}=    Set Variable    "Unknown"
+                ${owner_name}=    Set Variable    "Unknown"
+            END
+            ${message_string}=    Evaluate    "${item.get('message', '')};${item.get('containerMessage', '')}"
+            ${messages}=    RW.K8sHelper.Sanitize Messages    ${message_string}
+            ${issues}=    RW.CLI.Run Bash File
+            ...    bash_file=workload_issues.sh
+            ...    cmd_override=./workload_issues.sh "${messages}" "${owner_kind}" "${owner_name}"
+            ...    env=${env}
+            ...    include_in_history=False
+            ${issue_list}=    Evaluate    json.loads(r'''${issues.stdout}''')    json
+            FOR    ${issue}    IN    @{issue_list}
                 RW.Core.Add Issue
-                ...    severity=2
+                ...    severity=${issue["severity"]}
                 ...    expected=No pods should be in an unready state in namespace `${NAMESPACE}`.
-                ...    actual=Pod `${pod_name.stdout}` in `${NAMESPACE}` is NotReady or Failed.
-                ...    title= Pod `${pod_name.stdout}` exited with ${exit_code_explanation.stdout}
-                ...    reproduce_hint=View Commands Used in Report Output
-                ...    details=Pod `${pod_name.stdout}` is owned by ${owner_kind} `${owner_name}` and is pending with the following details:\n${item}
-                ...    next_steps=${item_next_steps.stdout}
+                ...    actual=Pod `${item["pod_name"]}` in `${NAMESPACE}` is NotReady or Failed.
+                ...    title= ${issue["title"]}
+                ...    reproduce_hint=${unreadypods_details.cmd}
+                ...    details=${issue["details"]}
+                ...    next_steps=${issue["next_steps"]}
             END
         END
     END
@@ -378,7 +381,7 @@ Check Event Anomalies in Namespace `${NAMESPACE}`
             ...    env=${env}
             ...    secret_file__kubeconfig=${kubeconfig}
             ...    include_in_history=False
-            ${messages}=    Replace String    ${item["summary_messages"]}    "    ${EMPTY}
+            ${messages}=    RW.K8sHelper.Sanitize Messages    ${item["summary_messages"]}
             ${item_owner_output}=    RW.CLI.Run Cli
             ...    cmd=echo "${item_owner.stdout}" | sed 's/ *$//' | tr -d '\n'
             ...    env=${env}

--- a/codebundles/k8s-namespace-healthcheck/runbook.robot
+++ b/codebundles/k8s-namespace-healthcheck/runbook.robot
@@ -1,7 +1,7 @@
 *** Settings ***
 Documentation       This taskset runs general troubleshooting checks against all applicable objects in a namespace. Looks for warning events, odd or frequent normal events, restarting containers and failed or pending pods.
 Metadata            Author    stewartshea
-Metadata            Display Name    Kubernetes Namespace Troubleshoot
+Metadata            Display Name    Kubernetes Namespace Inspection
 Metadata            Supports    Kubernetes,AKS,EKS,GKE,OpenShift
 
 Library             BuiltIn
@@ -19,7 +19,7 @@ Suite Setup         Suite Initialization
 
 
 *** Tasks ***
-Troubleshoot Warning Events in Namespace `${NAMESPACE}`
+Inspect Warning Events in Namespace `${NAMESPACE}`
     [Documentation]    Queries all warning events in a given namespace within the last 30 minutes,
     ...    fetches the list of involved pod names, groups the events, collects event message details
     ...    and searches for a useful next step based on these details.
@@ -84,7 +84,7 @@ Troubleshoot Warning Events in Namespace `${NAMESPACE}`
     RW.Core.Add Pre To Report    ${warning_events_by_object.stdout}
     RW.Core.Add Pre To Report    Commands Used:\n${history}
 
-Troubleshoot Container Restarts In Namespace `${NAMESPACE}`
+Inspect Container Restarts In Namespace `${NAMESPACE}`
     [Documentation]    Fetches pods that have container restarts and provides a report of the restart issues.
     [Tags]    namespace    containers    status    restarts    ${NAMESPACE}
     ${container_restart_details}=    RW.CLI.Run Cli
@@ -127,7 +127,7 @@ Troubleshoot Container Restarts In Namespace `${NAMESPACE}`
     RW.Core.Add Pre To Report    ${container_restart_analysis.stdout}
     RW.Core.Add Pre To Report    Commands Used:\n${history}
 
-Troubleshoot Pending Pods In Namespace `${NAMESPACE}`
+Inspect Pending Pods In Namespace `${NAMESPACE}`
     [Documentation]    Fetches pods that are pending and provides details.
     [Tags]    namespace    pods    status    pending    ${NAMESPACE}
     ${pending_pods}=    RW.CLI.Run Cli
@@ -181,7 +181,7 @@ Troubleshoot Pending Pods In Namespace `${NAMESPACE}`
     RW.Core.Add Pre To Report    ${pending_pods.stdout}
     RW.Core.Add Pre To Report    Commands Used:\n${history}
 
-Troubleshoot Failed Pods In Namespace `${NAMESPACE}`
+Inspect Failed Pods In Namespace `${NAMESPACE}`
     [Documentation]    Fetches all pods which are not running (unready) in the namespace and adds them to a report for future review.
     [Tags]    namespace    pods    status    unready    not starting    phase    failed    ${NAMESPACE}
     ${unreadypods_details}=    RW.CLI.Run Cli
@@ -240,7 +240,7 @@ Troubleshoot Failed Pods In Namespace `${NAMESPACE}`
     RW.Core.Add Pre To Report    ${unreadypods_details}
     RW.Core.Add Pre To Report    Commands Used:\n${history}
 
-Troubleshoot Workload Status Conditions In Namespace `${NAMESPACE}`
+Inspect Workload Status Conditions In Namespace `${NAMESPACE}`
     [Documentation]    Parses all workloads in a namespace and inspects their status conditions for issues. Status conditions with a status value of False are considered an error.
     [Tags]    namespace    status    conditions    pods    reasons    workloads    ${NAMESPACE}
     ${workload_info}=    RW.CLI.Run Cli

--- a/codebundles/k8s-namespace-healthcheck/runbook.robot
+++ b/codebundles/k8s-namespace-healthcheck/runbook.robot
@@ -77,20 +77,6 @@ Troubleshoot Warning Events in Namespace `${NAMESPACE}`
                 ...    details=${issue["details"]}
                 ...    next_steps=${issue["next_steps"]}
             END
-            # ${item_next_steps}=    RW.CLI.Run Bash File
-            # ...    bash_file=workload_next_steps.sh
-            # ...    cmd_override=./workload_next_steps.sh "${messages}" "${owner_kind}" "${owner_name}"
-            # ...    env=${env}
-            # ...    secret_file__kubeconfig=${kubeconfig}
-            # ...    include_in_history=False
-            # RW.Core.Add Issue
-            # ...    severity=3
-            # ...    expected=Warning events should not be present in namespace `${NAMESPACE}` for ${owner_kind} `${owner_name}`
-            # ...    actual=Warning events are found in namespace `${NAMESPACE}` for ${owner_kind} `${owner_name}` which indicate potential issues.
-            # ...    title= ${owner_kind} `${owner_name}` generated ${item["total_events"]} **warning** events and should be reviewed.
-            # ...    reproduce_hint=View Commands Used in Report Output
-            # ...    details=Item `${item["object"]}` generated a total of ${item["total_events"]} events containing some of the following messages and types:\n`${item["summary_messages"]}`
-            # ...    next_steps=${item_next_steps.stdout}
         END
     END
     ${history}=    RW.CLI.Pop Shell History
@@ -145,7 +131,6 @@ Troubleshoot Pending Pods In Namespace `${NAMESPACE}`
     [Documentation]    Fetches pods that are pending and provides details.
     [Tags]    namespace    pods    status    pending    ${NAMESPACE}
     ${pending_pods}=    RW.CLI.Run Cli
-    # ...    cmd=${KUBERNETES_DISTRIBUTION_BINARY} get pods --context=${CONTEXT} -n ${NAMESPACE} --field-selector=status.phase=Pending --no-headers -o json | jq -r '.items[] | "pod_name: \\(.metadata.name)\\nstatus: \\(.status.phase // "N/A")\\nmessage: \\(.status.conditions[0].message // "N/A")\\nreason: \\(.status.conditions[0].reason // "N/A")\\ncontainerStatus: \\((.status.containerStatuses[0].state // "N/A"))\\ncontainerMessage: \\(.status.containerStatuses[0].state.waiting?.message // "N/A")\\ncontainerReason: \\(.status.containerStatuses[0].state.waiting?.reason // "N/A")\\n_______-"'
     ...    cmd=${KUBERNETES_DISTRIBUTION_BINARY} get pods --context=${CONTEXT} -n ${NAMESPACE} --field-selector=status.phase=Pending --no-headers -o json | jq -r '[.items[] | {pod_name: .metadata.name, status: (.status.phase // "N/A"), message: (.status.conditions[0].message // "N/A"), reason: (.status.conditions[0].reason // "N/A"), containerStatus: (.status.containerStatuses[0].state // "N/A"), containerMessage: (.status.containerStatuses[0].state.waiting?.message // "N/A"), containerReason: (.status.containerStatuses[0].state.waiting?.reason // "N/A")}]'
     ...    env=${env}
     ...    secret_file__kubeconfig=${kubeconfig}
@@ -189,20 +174,6 @@ Troubleshoot Pending Pods In Namespace `${NAMESPACE}`
                 ...    details=${issue["details"]}
                 ...    next_steps=${issue["next_steps"]}
             END
-            # ${item_next_steps}=    RW.CLI.Run Bash File
-            # ...    bash_file=workload_next_steps.sh
-            # ...    cmd_override=./workload_next_steps.sh "${container_reason.stdout};${pod_message.stdout};${container_reason.stdout}" "${owner_kind}" "${owner_name}"
-            # ...    env=${env}
-            # ...    secret_file__kubeconfig=${kubeconfig}
-            # ...    include_in_history=False
-            # RW.Core.Add Issue
-            # ...    severity=2
-            # ...    expected=Pods should not be pending in `${NAMESPACE}`.
-            # ...    actual=Pod `${pod_name.stdout}` in `${NAMESPACE}` is pending.
-            # ...    title= Pod `${pod_name.stdout}` is pending with ${container_reason.stdout}
-            # ...    reproduce_hint=View Commands Used in Report Output
-            # ...    details=Pod `${pod_name.stdout}` is owned by ${owner_kind} `${owner_name}` and is pending with the following details:\n${item}
-            # ...    next_steps=${item_next_steps.stdout}
         END
     END
     ${history}=    RW.CLI.Pop Shell History
@@ -214,7 +185,6 @@ Troubleshoot Failed Pods In Namespace `${NAMESPACE}`
     [Documentation]    Fetches all pods which are not running (unready) in the namespace and adds them to a report for future review.
     [Tags]    namespace    pods    status    unready    not starting    phase    failed    ${NAMESPACE}
     ${unreadypods_details}=    RW.CLI.Run Cli
-    # ...    cmd=${KUBERNETES_DISTRIBUTION_BINARY} get pods --context=${CONTEXT} -n ${NAMESPACE} --field-selector=status.phase=Failed --no-headers -o json | jq -r --argjson exit_code_explanations '{"0": "Success", "1": "Error", "2": "Misconfiguration", "130": "Pod terminated by SIGINT", "134": "Abnormal Termination SIGABRT", "137": "Pod terminated by SIGKILL - Possible OOM", "143":"Graceful Termination SIGTERM"}' '.items[] | "pod_name: \\(.metadata.name)\\nrestart_count: \\(.status.containerStatuses[0].restartCount // "N/A")\\nmessage: \\(.status.message // "N/A")\\nterminated_finishedAt: \\(.status.containerStatuses[0].state.terminated.finishedAt // "N/A")\\nexit_code: \\(.status.containerStatuses[0].state.terminated.exitCode // "N/A")\\nexit_code_explanation: \\($exit_code_explanations[.status.containerStatuses[0].state.terminated.exitCode | tostring] // "Unknown exit code")\\n_______"'
     ...    cmd=${KUBERNETES_DISTRIBUTION_BINARY} get pods --context=${CONTEXT} -n ${NAMESPACE} --field-selector=status.phase=Failed --no-headers -o json | jq -r --argjson exit_code_explanations '{"0": "Success", "1": "Error", "2": "Misconfiguration", "130": "Pod terminated by SIGINT", "134": "Abnormal Termination SIGABRT", "137": "Pod terminated by SIGKILL - Possible OOM", "143":"Graceful Termination SIGTERM"}' '[.items[] | {pod_name: .metadata.name, restart_count: (.status.containerStatuses[0].restartCount // "N/A"), message: (.status.message // "N/A"), terminated_finishedAt: (.status.containerStatuses[0].state.terminated.finishedAt // "N/A"), exit_code: (.status.containerStatuses[0].state.terminated.exitCode // "N/A"), exit_code_explanation: ($exit_code_explanations[.status.containerStatuses[0].state.terminated.exitCode | tostring] // "Unknown exit code")}]'
     ...    env=${env}
     ...    secret_file__kubeconfig=${kubeconfig}

--- a/codebundles/k8s-namespace-healthcheck/workload_issues.sh
+++ b/codebundles/k8s-namespace-healthcheck/workload_issues.sh
@@ -25,7 +25,7 @@ add_issue() {
 
 # Check conditions and add issues to the array
 if [[ $messages =~ "ContainersNotReady" && $owner_kind == "Deployment" ]]; then
-    add_issue "2" "$owner_kind \`$owner_name\` has unready containers" "$messages" "Troubleshoot Deployment Replicas for \`$owner_name\`"
+    add_issue "2" "$owner_kind \`$owner_name\` has unready containers" "$messages" "Inspect Deployment Replicas for \`$owner_name\`"
 fi
 
 if [[ $messages =~ "Misconfiguration" && $owner_kind == "Deployment" ]]; then
@@ -33,7 +33,7 @@ if [[ $messages =~ "Misconfiguration" && $owner_kind == "Deployment" ]]; then
 fi
 
 if [[ $messages =~ "PodInitializing" ]]; then
-    add_issue "4" "$owner_kind \`$owner_name\` is initializing" "$messages" "Retry in a few minutes and verify that \`$owner_name\` is running.\nTroubleshoot $owner_kind Warning Events for \`$owner_name\`"
+    add_issue "4" "$owner_kind \`$owner_name\` is initializing" "$messages" "Retry in a few minutes and verify that \`$owner_name\` is running.\nInspect $owner_kind Warning Events for \`$owner_name\`"
 fi
 
 if [[ $messages =~ "Liveness probe failed" || $messages =~ "Liveness probe errored" ]]; then
@@ -53,7 +53,7 @@ if [[ $messages =~ "ImagePullBackOff" || $messages =~ "Back-off pulling image" |
 fi
 
 if [[ $messages =~ "Back-off restarting failed container" ]]; then
-    add_issue "2" "$owner_kind \`$owner_name\` has failing containers" "$messages" "Check $owner_kind Log for \`$owner_name\`\nTroubleshoot Warning Events for $owner_kind \`$owner_name\`"
+    add_issue "2" "$owner_kind \`$owner_name\` has failing containers" "$messages" "Check $owner_kind Log for \`$owner_name\`\nInspect Warning Events for $owner_kind \`$owner_name\`"
 fi
 
 if [[ $messages =~ "forbidden: failed quota" || $messages =~ "forbidden: exceeded quota" ]]; then
@@ -77,7 +77,7 @@ if [[ $messages =~ "Health check failed after" ]]; then
 fi
 
 if [[ $messages =~ "Deployment does not have minimum availability" ]]; then
-    add_issue "3" "$owner_kind \`$owner_name\` is not available." "$messages" "Troubleshoot Deployment Warning Events for \`$owner_name\`"
+    add_issue "3" "$owner_kind \`$owner_name\` is not available." "$messages" "Inspect Deployment Warning Events for \`$owner_name\`"
 fi
 
 

--- a/codebundles/k8s-namespace-healthcheck/workload_issues.sh
+++ b/codebundles/k8s-namespace-healthcheck/workload_issues.sh
@@ -64,7 +64,7 @@ if [[ $messages =~ "is forbidden: [minimum cpu usage per Container" || $messages
     add_issue "2" "$owner_kind \`$owner_name\` has invalid resource configuration" "$messages" "Adjust resource configuration for $owner_kind \`$owner_name\` according to issue details."
 fi
 
-if [[ $messages =~ "No preemption victims found for incoming pod" || $messages =~ "Insufficient cpu" ]]; then
+if [[ $messages =~ "No preemption victims found for incoming pod" || $messages =~ "Insufficient cpu" || $messages =~ "The node was low on resource" ]]; then
     add_issue "2" "$owner_kind \`$owner_name\` cannot be scheduled - not enough cluster resources." "$messages" "Not enough node resources available to schedule pods. Escalate this issue to your cluster owner.\nIncrease Node Count in Cluster\nCheck for Quota Errors\nIdentify High Utilization Nodes for Cluster \`${CONTEXT}\`"
 fi
 

--- a/codebundles/k8s-namespace-healthcheck/workload_next_steps.sh
+++ b/codebundles/k8s-namespace-healthcheck/workload_next_steps.sh
@@ -18,7 +18,7 @@ next_steps=()
 
 
 if [[ $messages =~ "ContainersNotReady" && $owner_kind == "Deployment" ]]; then
-    next_steps+=("Troubleshoot Deployment Replicas for \`$owner_name\`")
+    next_steps+=("Inspect Deployment Replicas for \`$owner_name\`")
 fi
 
 if [[ $messages =~ "Misconfiguration" && $owner_kind == "Deployment" ]]; then
@@ -33,7 +33,7 @@ fi
 
 if [[ $messages =~ "PodInitializing" ]]; then
     next_steps+=("Check $owner_kind Health for \`$owner_name\`")
-    next_steps+=("Troubleshoot $owner_kind Warning Events for \`$owner_name\`")
+    next_steps+=("Inspect $owner_kind Warning Events for \`$owner_name\`")
 fi
 
 if [[ $messages =~ "Liveness probe failed" || $messages =~ "Liveness probe errored" ]]; then
@@ -55,7 +55,7 @@ fi
 
 if [[ $messages =~ "Back-off restarting failed container" ]]; then
     next_steps+=("Check Log for $owner_kind \`$owner_name\`")
-    next_steps+=("Troubleshoot Warning Events for $owner_kind \`$owner_name\`")
+    next_steps+=("Inspect Warning Events for $owner_kind \`$owner_name\`")
 
 fi
 
@@ -85,7 +85,7 @@ if [[ $messages =~ "Health check failed after" ]]; then
 fi
 
 if [[ $messages =~ "Deployment does not have minimum availability" ]]; then
-    next_steps+=("Troubleshoot Deployment Warning Events for \`$owner_name\`")
+    next_steps+=("Inspect Deployment Warning Events for \`$owner_name\`")
 fi
 
 if [[ ${#next_steps[@]} -eq 0 ]]; then

--- a/libraries/RW/K8sHelper/k8s_helper.py
+++ b/libraries/RW/K8sHelper/k8s_helper.py
@@ -1,5 +1,6 @@
 import json
 
+
 def get_related_resource_recommendations(k8s_object):
     """
     Parse a Kubernetes object JSON for specific annotations or labels and return recommendations.
@@ -23,24 +24,45 @@ def get_related_resource_recommendations(k8s_object):
     annotations = obj_json.get("metadata", {}).get("annotations", {})
 
     # Checking for an ArgoCD label
-    if 'argocd.argoproj.io/instance' in labels:
-        app_name = labels['argocd.argoproj.io/instance'].split('_')[0]
+    if "argocd.argoproj.io/instance" in labels:
+        app_name = labels["argocd.argoproj.io/instance"].split("_")[0]
         recommendations = f"Troubleshoot ArgoCD Application `{app_name.capitalize()}`"
 
     # Check for Flux Helm Resources
-    elif 'helm.toolkit.fluxcd.io/name' in labels:
-        fluxcd_helm_name = labels['helm.toolkit.fluxcd.io/name']
-        fluxcd_helm_namespace = labels['helm.toolkit.fluxcd.io/namespace']
+    elif "helm.toolkit.fluxcd.io/name" in labels:
+        fluxcd_helm_name = labels["helm.toolkit.fluxcd.io/name"]
+        fluxcd_helm_namespace = labels["helm.toolkit.fluxcd.io/namespace"]
         recommendations = f"Troubleshoot `{fluxcd_helm_name}` Helm Release Health in Namespace `{fluxcd_helm_namespace}`"
 
     # Check for Flux Kustomize Resources
-    elif 'kustomize.toolkit.fluxcd.io/name' in labels:
-        fluxcd_helm_name = labels['kustomize.toolkit.fluxcd.io/name']
-        fluxcd_helm_namespace = labels['kustomize.toolkit.fluxcd.io/namespace']
+    elif "kustomize.toolkit.fluxcd.io/name" in labels:
+        fluxcd_helm_name = labels["kustomize.toolkit.fluxcd.io/name"]
+        fluxcd_helm_namespace = labels["kustomize.toolkit.fluxcd.io/namespace"]
         recommendations = f"Get details for unready Kustomizations in Namespace `{fluxcd_helm_namespace}`"
-        
+
+    # Check helm after flux or argo helm managed resources
+    elif "helm.sh/chart" in labels:
+        helm_chart = labels["helm.sh/chart"]
+        helm_namespace = annotations["meta.helm.sh/release-namespace"]
+        helm_release_name = annotations["meta.helm.sh/release-name"]
+        recommendations = f"Get Health Status of Helm Release `{helm_release_name}` Namespace `{helm_namespace}`"
     # Extend this function to check for other specific labels or annotations as needed
 
     return recommendations
 
+def sanitize_messages(input_string):
+    """Sanitize the message string by replacing ncharacters that can't be processed into json issue details.
 
+    Args:
+    - input_string: The string to be sanitized.
+
+    Returns:
+    - The sanitized string.
+    """
+    # Replace newline characters with an empty string
+    sanitized_string = input_string.replace('\n', '')
+
+    # Remove double quotes
+    sanitized_string = sanitized_string.replace('"', '')
+
+    return sanitized_string


### PR DESCRIPTION
Changes out the deployment and namespace health checks  to use dynamic issue detail generation for things like warning events, anomolies, etc. Still leaves the older workload_next_steps script in there which needs to be deprecated. This does generate *more* issues, but in theory the issue clustering should handle this. I tested in b-online-boutique for our standard test and it appeared to function well. We will need to test more in t-sandbox to determine if the noise is too much and we need additional noise reduction in the script. 