### PR TITLE
Enable AWS Role Assuming

### DIFF
--- a/codebundles/aws-eks-health/.runwhen/templates/aws-eks-health-sli.yaml
+++ b/codebundles/aws-eks-health/.runwhen/templates/aws-eks-health-sli.yaml
@@ -33,3 +33,5 @@ spec:
       workspaceKey: {{custom.aws_access_key_id}}
     - name: AWS_SECRET_ACCESS_KEY
       workspaceKey: {{custom.aws_secret_access_key}}
+    - name: AWS_ROLE_ARN
+      workspaceKey: {{custom.aws_role_arn}}

--- a/codebundles/aws-eks-health/.runwhen/templates/aws-eks-health-taskset.yaml
+++ b/codebundles/aws-eks-health/.runwhen/templates/aws-eks-health-taskset.yaml
@@ -29,3 +29,5 @@ spec:
       workspaceKey: {{custom.aws_access_key_id}}
     - name: AWS_SECRET_ACCESS_KEY
       workspaceKey: {{custom.aws_secret_access_key}}
+    - name: AWS_ROLE_ARN
+      workspaceKey: {{custom.aws_role_arn}}

--- a/codebundles/aws-eks-health/check_eks_cluster_health.sh
+++ b/codebundles/aws-eks-health/check_eks_cluster_health.sh
@@ -1,8 +1,25 @@
 #!/bin/bash
-source ./auth.sh
 
 # Environment Variables:
 # AWS_REGION
+auth() {
+    # if required AWS_ cli vars are not set, error and exit 1
+    if [[ -z $AWS_ACCESS_KEY_ID || -z $AWS_SECRET_ACCESS_KEY  || -z $AWS_REGION ]]; then
+        echo "AWS credentials not set. Please set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables."
+        exit 1
+    fi
+    # if AWS_ROLE_ARN then assume the role using sts and override the pre-existing key ENVs
+    if [[ -n $AWS_ROLE_ARN ]]; then
+        sts_output=$(aws sts assume-role --role-arn "$AWS_ROLE_ARN" --role-session-name "AssumeRoleSession")
+        AWS_ACCESS_KEY_ID=$(echo "$sts_output" | jq -r '.Credentials.AccessKeyId')
+        AWS_SECRET_ACCESS_KEY=$(echo "$sts_output" | jq -r '.Credentials.SecretAccessKey')
+        AWS_SESSION_TOKEN=$(echo "$sts_output" | jq -r '.Credentials.SessionToken')
+        export AWS_ACCESS_KEY_ID
+        export AWS_SECRET_ACCESS_KEY
+        export AWS_SESSION_TOKEN
+    fi
+}
+auth
 
 # get list of eks clusters
 eks_clusters=$(aws eks list-clusters --region $AWS_REGION --output json --query 'clusters[*]' | jq -r '.[]')

--- a/codebundles/aws-eks-health/check_eks_fargate_cluster_health_status.sh
+++ b/codebundles/aws-eks-health/check_eks_fargate_cluster_health_status.sh
@@ -1,8 +1,25 @@
 #!/bin/bash
-source ./auth.sh
 
 # Environment Variables:
 # AWS_REGION
+auth() {
+    # if required AWS_ cli vars are not set, error and exit 1
+    if [[ -z $AWS_ACCESS_KEY_ID || -z $AWS_SECRET_ACCESS_KEY  || -z $AWS_REGION ]]; then
+        echo "AWS credentials not set. Please set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables."
+        exit 1
+    fi
+    # if AWS_ROLE_ARN then assume the role using sts and override the pre-existing key ENVs
+    if [[ -n $AWS_ROLE_ARN ]]; then
+        sts_output=$(aws sts assume-role --role-arn "$AWS_ROLE_ARN" --role-session-name "AssumeRoleSession")
+        AWS_ACCESS_KEY_ID=$(echo "$sts_output" | jq -r '.Credentials.AccessKeyId')
+        AWS_SECRET_ACCESS_KEY=$(echo "$sts_output" | jq -r '.Credentials.SecretAccessKey')
+        AWS_SESSION_TOKEN=$(echo "$sts_output" | jq -r '.Credentials.SessionToken')
+        export AWS_ACCESS_KEY_ID
+        export AWS_SECRET_ACCESS_KEY
+        export AWS_SESSION_TOKEN
+    fi
+}
+auth
 
 # get list of eks clusters
 eks_clusters=$(aws eks list-clusters --region $AWS_REGION --output json --query 'clusters[*]' | jq -r '.[]')

--- a/codebundles/aws-eks-health/list_eks_fargate_metrics.sh
+++ b/codebundles/aws-eks-health/list_eks_fargate_metrics.sh
@@ -1,8 +1,26 @@
 #!/bin/bash
-source ./auth.sh
 
 # Environment Variables:
 # AWS_REGION
+auth() {
+    # if required AWS_ cli vars are not set, error and exit 1
+    if [[ -z $AWS_ACCESS_KEY_ID || -z $AWS_SECRET_ACCESS_KEY  || -z $AWS_REGION ]]; then
+        echo "AWS credentials not set. Please set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables."
+        exit 1
+    fi
+    # if AWS_ROLE_ARN then assume the role using sts and override the pre-existing key ENVs
+    if [[ -n $AWS_ROLE_ARN ]]; then
+        sts_output=$(aws sts assume-role --role-arn "$AWS_ROLE_ARN" --role-session-name "AssumeRoleSession")
+        AWS_ACCESS_KEY_ID=$(echo "$sts_output" | jq -r '.Credentials.AccessKeyId')
+        AWS_SECRET_ACCESS_KEY=$(echo "$sts_output" | jq -r '.Credentials.SecretAccessKey')
+        AWS_SESSION_TOKEN=$(echo "$sts_output" | jq -r '.Credentials.SessionToken')
+        export AWS_ACCESS_KEY_ID
+        export AWS_SECRET_ACCESS_KEY
+        export AWS_SESSION_TOKEN
+    fi
+}
+auth
+
 METRICS_LIST="vCPU Memory CPUUtilization Duration OnDemand Spot"
 START=$(date -d "1 day ago" +%s)
 END=$(date +%s)

--- a/codebundles/aws-eks-health/runbook.robot
+++ b/codebundles/aws-eks-health/runbook.robot
@@ -23,6 +23,7 @@ Check EKS Fargate Cluster Health Status
     ...    env=${env}
     ...    secret__AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
     ...    secret__AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+    ...    secret__AWS_ROLE_ARN=${AWS_ROLE_ARN}
     IF    "Error" in """${process.stdout}"""
         RW.Core.Add Issue    title=EKS Fargate Cluster in ${AWS_REGION} is Unhealthy
         ...    severity=3
@@ -41,6 +42,7 @@ Check EKS Cluster Health Status
     ...    env=${env}
     ...    secret__AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
     ...    secret__AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+    ...    secret__AWS_ROLE_ARN=${AWS_ROLE_ARN}
     IF    "Error" in """${process.stdout}"""
         RW.Core.Add Issue    title=EKS Cluster in ${AWS_REGION} is Unhealthy
         ...    severity=3
@@ -59,6 +61,7 @@ List EKS Cluster Metrics
     ...    env=${env}
     ...    secret__AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
     ...    secret__AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+    ...    secret__AWS_ROLE_ARN=${AWS_ROLE_ARN}
     RW.Core.Add Pre To Report    ${process.stdout}
 
 
@@ -76,10 +79,15 @@ Suite Initialization
     ...    type=string
     ...    description=AWS Secret Access Key
     ...    pattern=\w*
+    ${AWS_ROLE_ARN}=    RW.Core.Import Secret   AWS_ROLE_ARN
+    ...    type=string
+    ...    description=AWS Role ARN
+    ...    pattern=\w*
 
     Set Suite Variable    ${AWS_REGION}    ${AWS_REGION}
     Set Suite Variable    ${AWS_ACCESS_KEY_ID}    ${AWS_ACCESS_KEY_ID}
     Set Suite Variable    ${AWS_SECRET_ACCESS_KEY}    ${AWS_SECRET_ACCESS_KEY}
+    Set Suite Variable    ${AWS_ROLE_ARN}    ${AWS_ROLE_ARN}
 
 
     Set Suite Variable

--- a/codebundles/aws-eks-health/sli.robot
+++ b/codebundles/aws-eks-health/sli.robot
@@ -16,13 +16,14 @@ Library             Process
 Suite Setup         Suite Initialization
 
 *** Tasks ***
-Check EKS Fargate Cluster Health Status
+Check EKS Cluster Health Status
     [Documentation]   This script checks the health status of an Amazon EKS cluster.
     [Tags]  EKS    Cluster Health    AWS    Kubernetes    Pods    Nodes  
-    ${process}=    RW.CLI.Run Bash File    check_eks_cluster_health_status.sh
+    ${process}=    RW.CLI.Run Bash File    check_eks_cluster_health.sh
     ...    env=${env}
     ...    secret__AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
     ...    secret__AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+    ...    secret__AWS_ROLE_ARN=${AWS_ROLE_ARN}
     IF    "Error" in """${process.stdout}"""
         RW.Core.Push Metric    0
     ELSE
@@ -43,10 +44,15 @@ Suite Initialization
     ...    type=string
     ...    description=AWS Secret Access Key
     ...    pattern=\w*
+    ${AWS_ROLE_ARN}=    RW.Core.Import Secret   AWS_ROLE_ARN
+    ...    type=string
+    ...    description=AWS Role ARN
+    ...    pattern=\w*
 
     Set Suite Variable    ${AWS_REGION}    ${AWS_REGION}
     Set Suite Variable    ${AWS_ACCESS_KEY_ID}    ${AWS_ACCESS_KEY_ID}
     Set Suite Variable    ${AWS_SECRET_ACCESS_KEY}    ${AWS_SECRET_ACCESS_KEY}
+    Set Suite Variable    ${AWS_ROLE_ARN}    ${AWS_ROLE_ARN}
 
     Set Suite Variable
     ...    &{env}

--- a/codebundles/aws-elasticache-redis-health/.runwhen/templates/aws-elasticache-redis-health-sli.yaml
+++ b/codebundles/aws-elasticache-redis-health/.runwhen/templates/aws-elasticache-redis-health-sli.yaml
@@ -33,3 +33,5 @@ spec:
       workspaceKey: {{custom.aws_access_key_id}}
     - name: AWS_SECRET_ACCESS_KEY
       workspaceKey: {{custom.aws_secret_access_key}}
+    - name: AWS_ROLE_ARN
+      workspaceKey: {{custom.aws_role_arn}}

--- a/codebundles/aws-elasticache-redis-health/.runwhen/templates/aws-elasticache-redis-health-taskset.yaml
+++ b/codebundles/aws-elasticache-redis-health/.runwhen/templates/aws-elasticache-redis-health-taskset.yaml
@@ -29,3 +29,5 @@ spec:
       workspaceKey: {{custom.aws_access_key_id}}
     - name: AWS_SECRET_ACCESS_KEY
       workspaceKey: {{custom.aws_secret_access_key}}
+    - name: AWS_ROLE_ARN
+      workspaceKey: {{custom.aws_role_arn}}

--- a/codebundles/aws-elasticache-redis-health/analyze_aws_elasticache_redis_metrics.sh
+++ b/codebundles/aws-elasticache-redis-health/analyze_aws_elasticache_redis_metrics.sh
@@ -1,8 +1,25 @@
 #!/bin/bash
-source ./auth.sh
 
 # Environment Variables:
 # AWS_REGION
+auth() {
+    # if required AWS_ cli vars are not set, error and exit 1
+    if [[ -z $AWS_ACCESS_KEY_ID || -z $AWS_SECRET_ACCESS_KEY  || -z $AWS_REGION ]]; then
+        echo "AWS credentials not set. Please set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables."
+        exit 1
+    fi
+    # if AWS_ROLE_ARN then assume the role using sts and override the pre-existing key ENVs
+    if [[ -n $AWS_ROLE_ARN ]]; then
+        sts_output=$(aws sts assume-role --role-arn "$AWS_ROLE_ARN" --role-session-name "AssumeRoleSession")
+        AWS_ACCESS_KEY_ID=$(echo "$sts_output" | jq -r '.Credentials.AccessKeyId')
+        AWS_SECRET_ACCESS_KEY=$(echo "$sts_output" | jq -r '.Credentials.SecretAccessKey')
+        AWS_SESSION_TOKEN=$(echo "$sts_output" | jq -r '.Credentials.SessionToken')
+        export AWS_ACCESS_KEY_ID
+        export AWS_SECRET_ACCESS_KEY
+        export AWS_SESSION_TOKEN
+    fi
+}
+auth
 
 # Variables
 METRIC_NAMESPACE="AWS/ElastiCache"

--- a/codebundles/aws-elasticache-redis-health/monitor_redis_performance.sh
+++ b/codebundles/aws-elasticache-redis-health/monitor_redis_performance.sh
@@ -1,8 +1,26 @@
 #!/bin/bash
-source ./auth.sh
+
 # Environment Variables:
 # AWS_REGION
 # REDIS_PASSWORD
+auth() {
+    # if required AWS_ cli vars are not set, error and exit 1
+    if [[ -z $AWS_ACCESS_KEY_ID || -z $AWS_SECRET_ACCESS_KEY  || -z $AWS_REGION ]]; then
+        echo "AWS credentials not set. Please set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables."
+        exit 1
+    fi
+    # if AWS_ROLE_ARN then assume the role using sts and override the pre-existing key ENVs
+    if [[ -n $AWS_ROLE_ARN ]]; then
+        sts_output=$(aws sts assume-role --role-arn "$AWS_ROLE_ARN" --role-session-name "AssumeRoleSession")
+        AWS_ACCESS_KEY_ID=$(echo "$sts_output" | jq -r '.Credentials.AccessKeyId')
+        AWS_SECRET_ACCESS_KEY=$(echo "$sts_output" | jq -r '.Credentials.SecretAccessKey')
+        AWS_SESSION_TOKEN=$(echo "$sts_output" | jq -r '.Credentials.SessionToken')
+        export AWS_ACCESS_KEY_ID
+        export AWS_SECRET_ACCESS_KEY
+        export AWS_SESSION_TOKEN
+    fi
+}
+auth
 
 SLOWLOG_ENTRY_LIMIT="10"
 

--- a/codebundles/aws-elasticache-redis-health/redis_status_scan.sh
+++ b/codebundles/aws-elasticache-redis-health/redis_status_scan.sh
@@ -1,8 +1,25 @@
 #!/bin/bash
-source ./auth.sh
 
 # Environment Variables:
 # AWS_REGION
+auth() {
+    # if required AWS_ cli vars are not set, error and exit 1
+    if [[ -z $AWS_ACCESS_KEY_ID || -z $AWS_SECRET_ACCESS_KEY  || -z $AWS_REGION ]]; then
+        echo "AWS credentials not set. Please set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables."
+        exit 1
+    fi
+    # if AWS_ROLE_ARN then assume the role using sts and override the pre-existing key ENVs
+    if [[ -n $AWS_ROLE_ARN ]]; then
+        sts_output=$(aws sts assume-role --role-arn "$AWS_ROLE_ARN" --role-session-name "AssumeRoleSession")
+        AWS_ACCESS_KEY_ID=$(echo "$sts_output" | jq -r '.Credentials.AccessKeyId')
+        AWS_SECRET_ACCESS_KEY=$(echo "$sts_output" | jq -r '.Credentials.SecretAccessKey')
+        AWS_SESSION_TOKEN=$(echo "$sts_output" | jq -r '.Credentials.SessionToken')
+        export AWS_ACCESS_KEY_ID
+        export AWS_SECRET_ACCESS_KEY
+        export AWS_SESSION_TOKEN
+    fi
+}
+auth
 
 # Variables
 serverless_caches=$(aws elasticache describe-serverless-caches --region "$AWS_REGION")

--- a/codebundles/aws-elasticache-redis-health/runbook.robot
+++ b/codebundles/aws-elasticache-redis-health/runbook.robot
@@ -23,6 +23,7 @@ Scan AWS Elasticache Redis Status
     ...    env=${env}
     ...    secret__AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
     ...    secret__AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+    ...    secret__AWS_ROLE_ARN=${AWS_ROLE_ARN}
     RW.Core.Add Pre To Report    ${process.stdout}
     IF    "Snapshot retention limit is set to 0" in """${process.stdout}"""
         RW.Core.Add Issue    title=Snapshots not configured for Elasticache in region ${AWS_REGION}
@@ -57,11 +58,16 @@ Suite Initialization
     ...    type=string
     ...    description=AWS Secret Access Key
     ...    pattern=\w*
+    ${AWS_ROLE_ARN}=    RW.Core.Import Secret   AWS_ROLE_ARN
+    ...    type=string
+    ...    description=AWS Role ARN
+    ...    pattern=\w*
 
 
     Set Suite Variable    ${AWS_REGION}    ${AWS_REGION}
     Set Suite Variable    ${AWS_ACCESS_KEY_ID}    ${AWS_ACCESS_KEY_ID}
     Set Suite Variable    ${AWS_SECRET_ACCESS_KEY}    ${AWS_SECRET_ACCESS_KEY}
+    Set Suite Variable    ${AWS_ROLE_ARN}    ${AWS_ROLE_ARN}
 
 
     Set Suite Variable

--- a/codebundles/aws-elasticache-redis-health/sli.robot
+++ b/codebundles/aws-elasticache-redis-health/sli.robot
@@ -23,6 +23,7 @@ Scan ElastiCaches
     ...    env=${env}
     ...    secret__AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
     ...    secret__AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+    ...    secret__AWS_ROLE_ARN=${AWS_ROLE_ARN}
     Log    ${process.stdout}
     Log    ${process.stderr}
     IF    ${process.rc} != 0
@@ -46,10 +47,15 @@ Suite Initialization
     ...    type=string
     ...    description=AWS Secret Access Key
     ...    pattern=\w*
+    ${AWS_ROLE_ARN}=    RW.Core.Import Secret   AWS_ROLE_ARN
+    ...    type=string
+    ...    description=AWS Role ARN
+    ...    pattern=\w*
 
     Set Suite Variable    ${AWS_REGION}    ${AWS_REGION}
     Set Suite Variable    ${AWS_ACCESS_KEY_ID}    ${AWS_ACCESS_KEY_ID}
     Set Suite Variable    ${AWS_SECRET_ACCESS_KEY}    ${AWS_SECRET_ACCESS_KEY}
+    Set Suite Variable    ${AWS_ROLE_ARN}    ${AWS_ROLE_ARN}
 
     Set Suite Variable
     ...    &{env}

--- a/codebundles/aws-lambda-health/.runwhen/templates/aws-lambda-health-sli.yaml
+++ b/codebundles/aws-lambda-health/.runwhen/templates/aws-lambda-health-sli.yaml
@@ -33,3 +33,5 @@ spec:
       workspaceKey: {{custom.aws_access_key_id}}
     - name: AWS_SECRET_ACCESS_KEY
       workspaceKey: {{custom.aws_secret_access_key}}
+    - name: AWS_ROLE_ARN
+      workspaceKey: {{custom.aws_role_arn}}

--- a/codebundles/aws-lambda-health/.runwhen/templates/aws-lambda-health-taskset.yaml
+++ b/codebundles/aws-lambda-health/.runwhen/templates/aws-lambda-health-taskset.yaml
@@ -29,3 +29,5 @@ spec:
       workspaceKey: {{custom.aws_access_key_id}}
     - name: AWS_SECRET_ACCESS_KEY
       workspaceKey: {{custom.aws_secret_access_key}}
+    - name: AWS_ROLE_ARN
+      workspaceKey: {{custom.aws_role_arn}}

--- a/codebundles/aws-lambda-health/analyze_lambda_invocation_errors.sh
+++ b/codebundles/aws-lambda-health/analyze_lambda_invocation_errors.sh
@@ -1,9 +1,25 @@
 #!/bin/bash
-source ./auth.sh
 
 # Environment Variables:
 #AWS_REGION
-
+auth() {
+    # if required AWS_ cli vars are not set, error and exit 1
+    if [[ -z $AWS_ACCESS_KEY_ID || -z $AWS_SECRET_ACCESS_KEY  || -z $AWS_REGION ]]; then
+        echo "AWS credentials not set. Please set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables."
+        exit 1
+    fi
+    # if AWS_ROLE_ARN then assume the role using sts and override the pre-existing key ENVs
+    if [[ -n $AWS_ROLE_ARN ]]; then
+        sts_output=$(aws sts assume-role --role-arn "$AWS_ROLE_ARN" --role-session-name "AssumeRoleSession")
+        AWS_ACCESS_KEY_ID=$(echo "$sts_output" | jq -r '.Credentials.AccessKeyId')
+        AWS_SECRET_ACCESS_KEY=$(echo "$sts_output" | jq -r '.Credentials.SecretAccessKey')
+        AWS_SESSION_TOKEN=$(echo "$sts_output" | jq -r '.Credentials.SessionToken')
+        export AWS_ACCESS_KEY_ID
+        export AWS_SECRET_ACCESS_KEY
+        export AWS_SESSION_TOKEN
+    fi
+}
+auth
 
 SINCE="24h"
 

--- a/codebundles/aws-lambda-health/list_lambda_runtimes.sh
+++ b/codebundles/aws-lambda-health/list_lambda_runtimes.sh
@@ -1,6 +1,22 @@
 #!/bin/bash
-source ./auth.sh
-
+auth() {
+    # if required AWS_ cli vars are not set, error and exit 1
+    if [[ -z $AWS_ACCESS_KEY_ID || -z $AWS_SECRET_ACCESS_KEY  || -z $AWS_REGION ]]; then
+        echo "AWS credentials not set. Please set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables."
+        exit 1
+    fi
+    # if AWS_ROLE_ARN then assume the role using sts and override the pre-existing key ENVs
+    if [[ -n $AWS_ROLE_ARN ]]; then
+        sts_output=$(aws sts assume-role --role-arn "$AWS_ROLE_ARN" --role-session-name "AssumeRoleSession")
+        AWS_ACCESS_KEY_ID=$(echo "$sts_output" | jq -r '.Credentials.AccessKeyId')
+        AWS_SECRET_ACCESS_KEY=$(echo "$sts_output" | jq -r '.Credentials.SecretAccessKey')
+        AWS_SESSION_TOKEN=$(echo "$sts_output" | jq -r '.Credentials.SessionToken')
+        export AWS_ACCESS_KEY_ID
+        export AWS_SECRET_ACCESS_KEY
+        export AWS_SESSION_TOKEN
+    fi
+}
+auth
 
 # Fetch all Lambda function names
 function_names=$(aws lambda list-functions --query 'Functions[*].FunctionName' --output text)

--- a/codebundles/aws-lambda-health/monitor_aws_lambda_performance_metrics.sh
+++ b/codebundles/aws-lambda-health/monitor_aws_lambda_performance_metrics.sh
@@ -1,9 +1,26 @@
 #!/bin/bash
-source ./auth.sh
-
 
 # Environment Variables:
 # AWS_REGION
+auth() {
+    # if required AWS_ cli vars are not set, error and exit 1
+    if [[ -z $AWS_ACCESS_KEY_ID || -z $AWS_SECRET_ACCESS_KEY  || -z $AWS_REGION ]]; then
+        echo "AWS credentials not set. Please set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables."
+        exit 1
+    fi
+    # if AWS_ROLE_ARN then assume the role using sts and override the pre-existing key ENVs
+    if [[ -n $AWS_ROLE_ARN ]]; then
+        sts_output=$(aws sts assume-role --role-arn "$AWS_ROLE_ARN" --role-session-name "AssumeRoleSession")
+        AWS_ACCESS_KEY_ID=$(echo "$sts_output" | jq -r '.Credentials.AccessKeyId')
+        AWS_SECRET_ACCESS_KEY=$(echo "$sts_output" | jq -r '.Credentials.SecretAccessKey')
+        AWS_SESSION_TOKEN=$(echo "$sts_output" | jq -r '.Credentials.SessionToken')
+        export AWS_ACCESS_KEY_ID
+        export AWS_SECRET_ACCESS_KEY
+        export AWS_SESSION_TOKEN
+    fi
+}
+auth
+
 START=$(date -d "60 minutes ago" +%s)
 END=$(date +%s)
 PERIOD=3600

--- a/codebundles/aws-lambda-health/runbook.robot
+++ b/codebundles/aws-lambda-health/runbook.robot
@@ -23,6 +23,7 @@ List Lambda Versions and Runtimes
     ...    env=${env}
     ...    secret__AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
     ...    secret__AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+    ...    secret__AWS_ROLE_ARN=${AWS_ROLE_ARN}
     RW.Core.Add Pre To Report    ${process.stdout}
 
 Analyze AWS Lambda Invocation Errors
@@ -32,6 +33,7 @@ Analyze AWS Lambda Invocation Errors
     ...    env=${env}
     ...    secret__AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
     ...    secret__AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+    ...    secret__AWS_ROLE_ARN=${AWS_ROLE_ARN}
     RW.Core.Add Pre To Report    ${process.stdout}
     IF    "ERROR" in """${process.stdout}"""
         RW.Core.Add Issue    title=AWS Lambda Invocation Errors
@@ -50,6 +52,7 @@ Monitor AWS Lambda Performance Metrics
     ...    env=${env}
     ...    secret__AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
     ...    secret__AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+    ...    secret__AWS_ROLE_ARN=${AWS_ROLE_ARN}
     RW.Core.Add Pre To Report    ${process.stdout}
 
 
@@ -68,10 +71,15 @@ Suite Initialization
     ...    type=string
     ...    description=AWS Secret Access Key
     ...    pattern=\w*
+    ${AWS_ROLE_ARN}=    RW.Core.Import Secret   AWS_ROLE_ARN
+    ...    type=string
+    ...    description=AWS Role ARN
+    ...    pattern=\w*
 
     Set Suite Variable    ${AWS_REGION}    ${AWS_REGION}
     Set Suite Variable    ${AWS_ACCESS_KEY_ID}    ${AWS_ACCESS_KEY_ID}
     Set Suite Variable    ${AWS_SECRET_ACCESS_KEY}    ${AWS_SECRET_ACCESS_KEY}
+    Set Suite Variable    ${AWS_ROLE_ARN}    ${AWS_ROLE_ARN}
 
     Set Suite Variable
     ...    &{env}

--- a/codebundles/aws-lambda-health/sli.robot
+++ b/codebundles/aws-lambda-health/sli.robot
@@ -23,6 +23,7 @@ Analyze AWS Lambda Invocation Errors
     ...    env=${env}
     ...    secret__AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
     ...    secret__AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+    ...    secret__AWS_ROLE_ARN=${AWS_ROLE_ARN}
     IF    "ERROR" in """${process.stdout}"""
         RW.Core.Push Metric    0
     ELSE
@@ -43,10 +44,15 @@ Suite Initialization
     ...    type=string
     ...    description=AWS Secret Access Key
     ...    pattern=\w*
+    ${AWS_ROLE_ARN}=    RW.Core.Import Secret   AWS_ROLE_ARN
+    ...    type=string
+    ...    description=AWS Role ARN
+    ...    pattern=\w*
 
     Set Suite Variable    ${AWS_REGION}    ${AWS_REGION}
     Set Suite Variable    ${AWS_ACCESS_KEY_ID}    ${AWS_ACCESS_KEY_ID}
     Set Suite Variable    ${AWS_SECRET_ACCESS_KEY}    ${AWS_SECRET_ACCESS_KEY}
+    Set Suite Variable    ${AWS_ROLE_ARN}    ${AWS_ROLE_ARN}
 
     Set Suite Variable
     ...    &{env}

--- a/codebundles/aws-s3-bucket-storage-report/.runwhen/templates/aws-s3-bucket-storage-report-taskset.yaml
+++ b/codebundles/aws-s3-bucket-storage-report/.runwhen/templates/aws-s3-bucket-storage-report-taskset.yaml
@@ -29,3 +29,5 @@ spec:
       workspaceKey: {{custom.aws_access_key_id}}
     - name: AWS_SECRET_ACCESS_KEY
       workspaceKey: {{custom.aws_secret_access_key}}
+    - name: AWS_ROLE_ARN
+      workspaceKey: {{custom.aws_role_arn}}

--- a/codebundles/aws-s3-bucket-storage-report/check_aws_s3_bucket_storage_utilization.sh
+++ b/codebundles/aws-s3-bucket-storage-report/check_aws_s3_bucket_storage_utilization.sh
@@ -1,5 +1,22 @@
 #!/bin/bash
-source ./auth.sh
+auth() {
+    # if required AWS_ cli vars are not set, error and exit 1
+    if [[ -z $AWS_ACCESS_KEY_ID || -z $AWS_SECRET_ACCESS_KEY  || -z $AWS_REGION ]]; then
+        echo "AWS credentials not set. Please set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables."
+        exit 1
+    fi
+    # if AWS_ROLE_ARN then assume the role using sts and override the pre-existing key ENVs
+    if [[ -n $AWS_ROLE_ARN ]]; then
+        sts_output=$(aws sts assume-role --role-arn "$AWS_ROLE_ARN" --role-session-name "AssumeRoleSession")
+        AWS_ACCESS_KEY_ID=$(echo "$sts_output" | jq -r '.Credentials.AccessKeyId')
+        AWS_SECRET_ACCESS_KEY=$(echo "$sts_output" | jq -r '.Credentials.SecretAccessKey')
+        AWS_SESSION_TOKEN=$(echo "$sts_output" | jq -r '.Credentials.SessionToken')
+        export AWS_ACCESS_KEY_ID
+        export AWS_SECRET_ACCESS_KEY
+        export AWS_SESSION_TOKEN
+    fi
+}
+auth
 
 # Variables
 # THRESHOLD=85

--- a/codebundles/aws-s3-bucket-storage-report/runbook.robot
+++ b/codebundles/aws-s3-bucket-storage-report/runbook.robot
@@ -23,6 +23,7 @@ Check AWS S3 Bucket Storage Utilization
     ...    env=${env}
     ...    secret__AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
     ...    secret__AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+    ...    secret__AWS_ROLE_ARN=${AWS_ROLE_ARN}
     RW.Core.Add Pre To Report    ${process.stdout}
 
 *** Keywords ***
@@ -39,10 +40,15 @@ Suite Initialization
     ...    type=string
     ...    description=AWS Secret Access Key
     ...    pattern=\w*
+    ${AWS_ROLE_ARN}=    RW.Core.Import Secret   AWS_ROLE_ARN
+    ...    type=string
+    ...    description=AWS Role ARN
+    ...    pattern=\w*
 
     Set Suite Variable    ${AWS_REGION}    ${AWS_REGION}
     Set Suite Variable    ${AWS_ACCESS_KEY_ID}    ${AWS_ACCESS_KEY_ID}
     Set Suite Variable    ${AWS_SECRET_ACCESS_KEY}    ${AWS_SECRET_ACCESS_KEY}
+    Set Suite Variable    ${AWS_ROLE_ARN}    ${AWS_ROLE_ARN}
 
     Set Suite Variable
     ...    &{env}


### PR DESCRIPTION
- rolls in the auth bash code into the scripts, this is due a design bug with subprocesses that only include the singular bash file in the environment, so `source` cant be used
- adds to genrules
- adds role arn secret to robot layer