### PR TITLE
Hide deployment Ops Manifests from Discovery

### DIFF
--- a/codebundles/k8s-deployment-ops/.runwhen/generation-rules/k8s-deployment-ops.yaml
+++ b/codebundles/k8s-deployment-ops/.runwhen/generation-rules/k8s-deployment-ops.yaml
@@ -1,20 +1,20 @@
-# apiVersion: runwhen.com/v1
-# kind: GenerationRules
-# spec:
-#   generationRules:
-#     - resourceTypes:
-#         - deployment
-#       matchRules:
-#         - type: pattern
-#           pattern: ".+"
-#           properties: [name]
-#           mode: substring
-#       slxs:
-#         - baseName: depl-ops
-#           levelOfDetail: detailed
-#           qualifiers: ["resource", "namespace", "cluster"]
-#           baseTemplateName: k8s-deployment-ops
-#           outputItems:
-#             - type: slx
-#             - type: runbook
-#               templateName: k8s-deployment-ops-taskset.yaml
+apiVersion: runwhen.com/v1
+kind: GenerationRules
+spec:
+  generationRules:
+    - resourceTypes:
+        - deployment
+      matchRules:
+        - type: pattern
+          pattern: ".+"
+          properties: [name]
+          mode: substring
+      slxs:
+        - baseName: depl-ops
+          levelOfDetail: detailed
+          qualifiers: ["resource", "namespace", "cluster"]
+          baseTemplateName: k8s-deployment-ops
+          outputItems:
+            - type: slx
+            - type: runbook
+              templateName: k8s-deployment-ops-taskset.yaml

--- a/codebundles/k8s-deployment-ops/.runwhen/generation-rules/k8s-deployment-ops.yaml
+++ b/codebundles/k8s-deployment-ops/.runwhen/generation-rules/k8s-deployment-ops.yaml
@@ -1,20 +1,20 @@
-apiVersion: runwhen.com/v1
-kind: GenerationRules
-spec:
-  generationRules:
-    - resourceTypes:
-        - deployment
-      matchRules:
-        - type: pattern
-          pattern: ".+"
-          properties: [name]
-          mode: substring
-      slxs:
-        - baseName: depl-ops
-          levelOfDetail: detailed
-          qualifiers: ["resource", "namespace", "cluster"]
-          baseTemplateName: k8s-deployment-ops
-          outputItems:
-            - type: slx
-            - type: runbook
-              templateName: k8s-deployment-ops-taskset.yaml
+# apiVersion: runwhen.com/v1
+# kind: GenerationRules
+# spec:
+#   generationRules:
+#     - resourceTypes:
+#         - deployment
+#       matchRules:
+#         - type: pattern
+#           pattern: ".+"
+#           properties: [name]
+#           mode: substring
+#       slxs:
+#         - baseName: depl-ops
+#           levelOfDetail: detailed
+#           qualifiers: ["resource", "namespace", "cluster"]
+#           baseTemplateName: k8s-deployment-ops
+#           outputItems:
+#             - type: slx
+#             - type: runbook
+#               templateName: k8s-deployment-ops-taskset.yaml

--- a/codebundles/k8s-deployment-ops/.runwhen/generation-rules/k8s-deployment-ops.yaml
+++ b/codebundles/k8s-deployment-ops/.runwhen/generation-rules/k8s-deployment-ops.yaml
@@ -14,7 +14,7 @@ spec:
           levelOfDetail: detailed
           qualifiers: ["resource", "namespace", "cluster"]
           baseTemplateName: k8s-deployment-ops
-          outputItems:
-            - type: slx
-            - type: runbook
-              templateName: k8s-deployment-ops-taskset.yaml
+          outputItems: []
+            # - type: slx
+            # - type: runbook
+            #   templateName: k8s-deployment-ops-taskset.yaml


### PR DESCRIPTION
Until persona ACLs are applied, these codebundles should only be manually added when desired