### PR TITLE
Update severity levels for various health checks across Azure resources to reflect informational status

### DIFF
--- a/codebundles/azure-aks-triage/aks_cluster_health.sh
+++ b/codebundles/azure-aks-triage/aks_cluster_health.sh
@@ -83,7 +83,7 @@ if [ "$AUTOSCALING_DISABLED_COUNT" -gt 0 ]; then
     issues_json=$(echo "$issues_json" | jq \
         --arg title "Autoscaling Disabled in Node Pools" \
         --arg nextStep "Enable autoscaling on all node pools for better resource management." \
-        --arg severity "3" \
+        --arg severity "4" \
         --arg details "$AUTOSCALING_DISABLED_COUNT node pools have autoscaling disabled." \
         '.issues += [{"title": $title, "next_step": $nextStep, "severity": ($severity | tonumber), "details": $details}]'
     )

--- a/codebundles/azure-apim-health/gather_apim_resource_information.sh
+++ b/codebundles/azure-apim-health/gather_apim_resource_information.sh
@@ -114,46 +114,46 @@ echo "${APIM_HOSTNAME_CONFIGS}" | jq -cr '.[]?' | while read -r config; do
   echo "   TLS Min:  ${tlsVersion}"
   echo "   Cert:     ${certSubject}"
 
-  # Example check: TLS < 1.2 => severity=1 (critical)
+  # Example check: TLS < 1.2 => severity=4 (informational)
   if [ "${tlsVersion}" != "N/A" ] && [ "${tlsVersion}" != "1.2" ] && [ "${tlsVersion}" != "1.3" ]; then
     t="TLS version below 1.2"
     d="Host '${hostName}' is using TLS < 1.2 (current: ${tlsVersion})."
     n="Review runbook task for adjusting TLS settings. A minimum of 1.2 is recommended for APIM '${APIM_NAME}' in RG '${AZ_RESOURCE_GROUP}'."
-    s=1
+    s=4
     echo "[WARNING] ${d}"
     add_issue "${t}" "${d}" "${n}" "${s}"
   fi
 
-  # Example check: Missing cert for Proxy => severity=2 (major)
+  # Example check: Missing cert for Proxy => severity=4 (informational)
   if [ "${certSubject}" == "No Certificate Found" ] && [ "${hostType}" == "Proxy" ]; then
     t="Proxy host missing certificate"
     d="Host '${hostName}' is configured as Proxy but no certificate is attached."
     n="Review runbook task for custom domain certificate assignment. APIM '${APIM_NAME}' in RG '${AZ_RESOURCE_GROUP}'."
-    s=2
+    s=4
     echo "[WARNING] ${d}"
     add_issue "${t}" "${d}" "${n}" "${s}"
   fi
 done
 
 ###############################################################################
-# Example: No VNET integration => severity=3 (minor)
+# Example: No VNET integration => severity=4 (informational)
 if [ -z "${APIM_VNET_TYPE}" ]; then
   echo "[INFO] APIM is NOT using a VNET (publicly accessible)."
   t="No VNET integration for APIM \`${APIM_NAME}\`"
   d="APIM ${APIM_NAME} in is publicly accessible; no VNET integration is configured."
   n="Enable VNET integration on APIM \`${APIM_NAME}\` in Resource Group \`${AZ_RESOURCE_GROUP}\`."
-  s=3
+  s=4
   add_issue "${t}" "${d}" "${n}" "${s}"
 fi
 
-# Example: Public IP assigned => severity=2 (major)
+# Example: Public IP assigned => severity=4 (informational)
 if [ -n "${APIM_PUBLIC_IP_ID}" ]; then
   echo "[WARNING] APIM has a Public IP (${APIM_PUBLIC_IP_ID}). Ensure external access is intended."
 
   t="APIM \`${APIM_NAME}\` is assigned a Public IP"
   d="APIM ${APIM_NAME} has a public IP bound, making it externally reachable."
   n="Remove or disable the Public IP if private access is required. APIM \`${APIM_NAME}\` in Resource Group \`${AZ_RESOURCE_GROUP}\`."
-  s=2
+  s=4
   add_issue "${t}" "${d}" "${n}" "${s}"
 fi
 

--- a/codebundles/azure-appservice-functionapp-health/appservice_config_health.sh
+++ b/codebundles/azure-appservice-functionapp-health/appservice_config_health.sh
@@ -90,7 +90,7 @@ if [ "$HTTPS_ONLY" != "true" ]; then
     issues_json=$(echo "$issues_json" | jq \
         --arg title "HTTPS Enforcement Disabled" \
         --arg nextStep "Enable the HTTPS-only setting for \`$FUNCTION_APP_NAME\` in resource group \`$AZ_RESOURCE_GROUP\`." \
-        --arg severity "2" \
+        --arg severity "4" \
         --arg details "HTTPS is not enforced on the Function App." \
         '.issues += [{"title": $title, "next_step": $nextStep, "severity": ($severity | tonumber), "details": $details}]'
     )
@@ -112,7 +112,7 @@ if [ -n "$APP_SERVICE_PLAN" ] && [[ "$APP_SERVICE_PLAN" != "null" ]]; then
             issues_json=$(echo "$issues_json" | jq \
                 --arg title "Free App Service Plan in Use" \
                 --arg nextStep "Consider upgrading to a paid App Service Plan for \`$FUNCTION_APP_NAME\` in resource group \`$AZ_RESOURCE_GROUP\`." \
-                --arg severity "3" \
+                --arg severity "4" \
                 --arg details "App Service Plan SKU: $SKUID" \
                 '.issues += [{"title": $title, "next_step": $nextStep, "severity": ($severity | tonumber), "details": $details}]'
             )

--- a/codebundles/azure-appservice-webapp-health/appservice_config_health.sh
+++ b/codebundles/azure-appservice-webapp-health/appservice_config_health.sh
@@ -65,7 +65,7 @@ if [ "$HTTPS_ONLY" != "true" ]; then
     issues_json=$(echo "$issues_json" | jq \
         --arg title "HTTPS Enforcement Disabled" \
         --arg nextStep "Enable HTTPS-only setting for \`$APP_SERVICE_NAME\` in resource group \`$AZ_RESOURCE_GROUP\`" \
-        --arg severity "2" \
+        --arg severity "4" \
         --arg details "HTTPS is not enforced on the App Service." \
         '.issues += [{"title": $title, "next_step": $nextStep, "severity": ($severity | tonumber), "details": $details}]'
     )
@@ -82,7 +82,7 @@ if [ "$SKUID" == "F1" ]; then
     issues_json=$(echo "$issues_json" | jq \
         --arg title "Free App Service Plan in Use" \
         --arg nextStep "Consider upgrading to a paid App Service Plan for \`$APP_SERVICE_NAME\` in resource group \`$AZ_RESOURCE_GROUP\`" \
-        --arg severity "3" \
+        --arg severity "4" \
         --arg details "App Service Plan SKU: $SKUID" \
         '.issues += [{"title": $title, "next_step": $nextStep, "severity": ($severity | tonumber), "details": $details}]'
     )

--- a/codebundles/azure-servicebus-health/service_bus_config_health.sh
+++ b/codebundles/azure-servicebus-health/service_bus_config_health.sh
@@ -63,17 +63,17 @@ add_issue() {
 ns_bt="\`$SB_NAMESPACE_NAME\`"   # back-ticked
 
 # --- Rules that apply to ALL SKUs --------------------------------------------------
-[[ "$tls" != 1.2 && "$tls" != 1.3 ]] && add_issue 3 \
+[[ "$tls" != 1.2 && "$tls" != 1.3 ]] && add_issue 4 \
   "TLS minimum version for $ns_bt is $tls (≥1.2 recommended)" \
   "az servicebus namespace update -g $AZ_RESOURCE_GROUP -n $SB_NAMESPACE_NAME --minimum-tls-version 1.2" \
   "minimumTlsVersion=$tls"
 
-[[ "$pna" == "Enabled" ]] && add_issue 2 \
+[[ "$pna" == "Enabled" ]] && add_issue 4 \
   "Public network access enabled on $ns_bt" \
   "Disable or restrict public access via firewall / Private Link" \
   "publicNetworkAccess=Enabled"
 
-[[ "$identity" == "None" ]] && add_issue 2 \
+[[ "$identity" == "None" ]] && add_issue 4 \
   "No managed identity assigned to $ns_bt" \
   "az servicebus namespace update -g $AZ_RESOURCE_GROUP -n $SB_NAMESPACE_NAME --assign-identity" \
   "identity.type=None"
@@ -81,7 +81,7 @@ ns_bt="\`$SB_NAMESPACE_NAME\`"   # back-ticked
 # --- Premium-only features ----------------------------------------------------------
 if [[ "$sku" == "Premium" ]]; then
   # Zone redundancy check (real warning)
-  [[ "$zone" != "true" ]] && add_issue 1 \
+  [[ "$zone" != "true" ]] && add_issue 4 \
     "Zone redundancy disabled on Premium $ns_bt" \
     "az servicebus namespace update -g $AZ_RESOURCE_GROUP -n $SB_NAMESPACE_NAME --zone-redundant true" \
     "zoneRedundant=$zone"


### PR DESCRIPTION
Configuration items moved to Severity 4 (Informational):
- TLS version settings
- Public network access policies
- HTTPS enforcement settings
- Service plan tier choices
- Managed identity assignments
- Zone redundancy preferences
- Autoscaling preferences

The rationale being while these are indeed incorrect configurations, the system will still be operational with the existence of these issue. Also these issues are straightforward to fix and do not require any further analysis to be done related to them.
