### PR TITLE
fix: handle empty log output in k8s deployment healthcheck runbook

### DIFF
--- a/codebundles/k8s-deployment-healthcheck/runbook.robot
+++ b/codebundles/k8s-deployment-healthcheck/runbook.robot
@@ -398,8 +398,12 @@ Fetch Deployment Logs for `${DEPLOYMENT_NAME}` in Namespace `${NAMESPACE}`
             ...    env=${env}
             ...    include_in_history=false
             
-            ${total_count}=    Convert To Integer    ${total_lines.stdout.strip()}
-            ${health_count}=    Convert To Integer    ${health_check_lines.stdout.strip()}
+            # Handle empty output from wc -l by providing default values
+            ${total_lines_clean}=    Set Variable If    "${total_lines.stdout.strip()}" == ""    0    ${total_lines.stdout.strip()}
+            ${health_check_lines_clean}=    Set Variable If    "${health_check_lines.stdout.strip()}" == ""    0    ${health_check_lines.stdout.strip()}
+            
+            ${total_count}=    Convert To Integer    ${total_lines_clean}
+            ${health_count}=    Convert To Integer    ${health_check_lines_clean}
             
             # Create consolidated logs report
             IF    ${health_count} > ${total_count} * 0.8


### PR DESCRIPTION
- Fix ValueError when converting empty string to integer in log analysis
- Add proper error handling for wc -l command output when no logs exist
- Use Set Variable If to provide default values (0) for empty outputs
- Maintain backward compatibility for normal log scenarios
- Add comprehensive documentation in planning file

Resolves issue where "Fetch Deployment Logs" task failed with: ValueError: invalid literal for int() with base 10: ''

The fix ensures the runbook gracefully handles deployments with no logs, scaled-to-zero deployments, and other edge cases where log collection returns empty output.