### PR TITLE
fix: handle empty JSON output in VPA recommendations task

### DIFF
--- a/codebundles/k8s-podresources-health/runbook.robot
+++ b/codebundles/k8s-podresources-health/runbook.robot
@@ -104,7 +104,10 @@ Identify VPA Pod Resource Recommendations in Namespace `${NAMESPACE}`
     ...    cmd=echo '${vpa_usage.stdout}' | awk '/Recommended Next Steps:/ {flag=1; next} flag'
     ...    env=${env}
     ...    include_in_history=false
-    ${recommendation_list}=    Evaluate    json.loads(r'''${recommendations.stdout}''')    json
+    ${recommendation_list}=    Set Variable    []
+    IF    """${recommendations.stdout}""" != ""
+        ${recommendation_list}=    Evaluate    json.loads(r'''${recommendations.stdout}''')    json
+    END
     IF    len(@{recommendation_list}) > 0
         FOR    ${item}    IN    @{recommendation_list}
             RW.Core.Add Issue
@@ -130,9 +133,12 @@ Identify Overutilized Pods in Namespace `${NAMESPACE}`
     ${overutilized_pods}=    RW.CLI.Run Cli
     ...    cmd=cat overutilized_pods.json | jq .
     ...    env=${env}
-    ${overutilized_pods_list}=    Evaluate
-    ...    json.loads(r'''${overutilized_pods.stdout}''')
-    ...    json
+    ${overutilized_pods_list}=    Set Variable    []
+    IF    """${overutilized_pods.stdout}""" != ""
+        ${overutilized_pods_list}=    Evaluate
+        ...    json.loads(r'''${overutilized_pods.stdout}''')
+        ...    json
+    END
     FOR    ${item}    IN    @{overutilized_pods_list}
         ${item_owner}=    RW.CLI.Run Bash File
         ...    bash_file=find_resource_owners.sh


### PR DESCRIPTION
- Add defensive checks for empty stdout before JSON parsing
- Fix JSONDecodeError when no VPA resources exist in namespace
- Apply same pattern to overutilized pods task for consistency
- Initialize recommendation lists as empty arrays by default
- Prevent parsing empty strings that cause JSONDecodeError

The issue occurred when the vpa_recommendations.sh script output "No recommendations." and the awk command returned an empty string, which was then passed to json.loads() causing the error.

Fixes: JSONDecodeError: Expecting value: line 1 column 1 (char 0)