### PR TITLE
Updates/012326-01

### DIFF
--- a/codebundles/gcp-project-cost-health/README.md
+++ b/codebundles/gcp-project-cost-health/README.md
@@ -170,9 +170,9 @@ brew install jq
 | `COST_ANALYSIS_LOOKBACK_DAYS` | Number of days to analyze (default: 30) | No | `30` |
 | `GCP_COST_BUDGET` | Optional budget threshold in USD. A severity 3 issue will be raised if total costs exceed this amount. Set to 0 to disable. | No | `50000` |
 | `GCP_PROJECT_COST_THRESHOLD_PERCENT` | Optional percentage threshold (0-100). A severity 3 issue will be raised if any single project exceeds this percentage of total costs. Set to 0 to disable. | No | `25` |
-| `NETWORK_COST_THRESHOLD_MONTHLY` | Minimum monthly network cost (in USD) to generate alerts. SKUs below this threshold are excluded from analysis. Default: 50 | No | `50` |
-| `NETWORK_COST_SEVERITY_MEDIUM_MULTIPLIER` | Multiplier for Medium severity threshold (base_threshold × multiplier). Default: 5 (e.g., $250 with $50 base) | No | `5` |
-| `NETWORK_COST_SEVERITY_HIGH_MULTIPLIER` | Multiplier for High severity threshold (base_threshold × multiplier). Default: 20 (e.g., $1000 with $50 base) | No | `20` |
+| `NETWORK_COST_THRESHOLD_MONTHLY` | Minimum monthly network cost (in USD) to generate alerts. SKUs below this threshold are excluded from analysis. Default: 200 | No | `200` |
+| `NETWORK_COST_SEVERITY_MEDIUM_MULTIPLIER` | Multiplier for Medium severity threshold (base_threshold × multiplier). Default: 5 (e.g., $1000 with $200 base) | No | `5` |
+| `NETWORK_COST_SEVERITY_HIGH_MULTIPLIER` | Multiplier for High severity threshold (base_threshold × multiplier). Default: 20 (e.g., $4000 with $200 base) | No | `20` |
 | `OUTPUT_FORMAT` | Output format: `table`, `csv`, `json`, or `all` | No | `table` |
 
 ### Billing Export Table Auto-Discovery
@@ -247,7 +247,7 @@ Network cost anomaly detection includes a minimum monthly cost threshold to redu
 - **Behavior**: Only SKUs with monthly costs exceeding this threshold will be analyzed and generate alerts
 - **Rationale**: Prevents alert fatigue from trivial network costs (e.g., a few cents of inter-zone traffic) and reduces BigQuery processing costs
 - **Configuration**: Set `NETWORK_COST_THRESHOLD_MONTHLY` to your preferred threshold in USD
-- **Example**: With threshold=$50, a $2/month SKU is excluded from detailed analysis, but a $100/month SKU will generate a severity 4 (Info) alert
+- **Example**: With threshold=$200, a $50/month SKU is excluded from detailed analysis, but a $500/month SKU will generate a severity 4 (Info) alert
 - **All Below Threshold**: If all network costs are below the threshold, the script reports this clearly and skips detailed queries entirely
 
 #### Alert Severity Levels
@@ -256,9 +256,9 @@ Network cost alerts use **configurable multipliers** of the base threshold for c
 
 | Severity | Default Threshold | Daily Equivalent | Description | Configuration |
 |----------|------------------|------------------|-------------|---------------|
-| **4 (Info)** | ≥ $50/month | ≥ $1.67/day | Above minimum threshold, worth tracking | `NETWORK_COST_THRESHOLD_MONTHLY` |
-| **3 (Medium)** | ≥ $250/month | ≥ $8.33/day | 5x threshold, warrants review | `NETWORK_COST_SEVERITY_MEDIUM_MULTIPLIER=5` |
-| **2 (High)** | ≥ $1,000/month | ≥ $33.33/day | 20x threshold, urgent optimization needed | `NETWORK_COST_SEVERITY_HIGH_MULTIPLIER=20` |
+| **4 (Info)** | ≥ $200/month | ≥ $6.67/day | Above minimum threshold, worth tracking | `NETWORK_COST_THRESHOLD_MONTHLY` |
+| **3 (Medium)** | ≥ $1,000/month | ≥ $33.33/day | 5x threshold, warrants review | `NETWORK_COST_SEVERITY_MEDIUM_MULTIPLIER=5` |
+| **2 (High)** | ≥ $4,000/month | ≥ $133.33/day | 20x threshold, urgent optimization needed | `NETWORK_COST_SEVERITY_HIGH_MULTIPLIER=20` |
 
 **Customization Example:**
 ```bash

--- a/codebundles/gcp-project-cost-health/gcp_network_cost_analysis.sh
+++ b/codebundles/gcp-project-cost-health/gcp_network_cost_analysis.sh
@@ -32,8 +32,8 @@ ISSUES_FILE="${NETWORK_COST_ISSUES_FILE:-gcp_network_cost_issues.json}"
 OUTPUT_FORMAT="${OUTPUT_FORMAT:-all}"
 
 # Network cost thresholds and severity multipliers
-# Minimum monthly network cost threshold to raise issues (default: $50/month)
-NETWORK_COST_THRESHOLD_MONTHLY="${NETWORK_COST_THRESHOLD_MONTHLY:-50}"
+# Minimum monthly network cost threshold to raise issues (default: $200/month)
+NETWORK_COST_THRESHOLD_MONTHLY="${NETWORK_COST_THRESHOLD_MONTHLY:-200}"
 # Severity multipliers (applied to base threshold)
 # Severity 4 (Info): >= 1x threshold
 # Severity 3 (Medium): >= 5x threshold  

--- a/codebundles/gcp-project-cost-health/gcp_network_cost_analysis.sh
+++ b/codebundles/gcp-project-cost-health/gcp_network_cost_analysis.sh
@@ -31,15 +31,10 @@ CSV_FILE="${NETWORK_COST_CSV_FILE:-gcp_network_cost_report.csv}"
 ISSUES_FILE="${NETWORK_COST_ISSUES_FILE:-gcp_network_cost_issues.json}"
 OUTPUT_FORMAT="${OUTPUT_FORMAT:-all}"
 
-# Network cost thresholds and severity multipliers
+# Network cost threshold
 # Minimum monthly network cost threshold to raise issues (default: $200/month)
+# All SKUs exceeding this threshold will generate severity 3 (Medium) alerts
 NETWORK_COST_THRESHOLD_MONTHLY="${NETWORK_COST_THRESHOLD_MONTHLY:-200}"
-# Severity multipliers (applied to base threshold)
-# Severity 4 (Info): >= 1x threshold
-# Severity 3 (Medium): >= 5x threshold  
-# Severity 2 (High): >= 20x threshold
-NETWORK_COST_SEVERITY_MEDIUM_MULTIPLIER="${NETWORK_COST_SEVERITY_MEDIUM_MULTIPLIER:-5}"
-NETWORK_COST_SEVERITY_HIGH_MULTIPLIER="${NETWORK_COST_SEVERITY_HIGH_MULTIPLIER:-20}"
 
 # Validate NETWORK_COST_THRESHOLD_MONTHLY is a non-negative number
 if ! [[ "$NETWORK_COST_THRESHOLD_MONTHLY" =~ ^[0-9]+(\.[0-9]+)?$ ]] || (( $(echo "$NETWORK_COST_THRESHOLD_MONTHLY < 0" | bc -l 2>/dev/null || echo 1) )); then
@@ -614,10 +609,8 @@ detect_cost_anomalies() {
         fi
     done < <(echo "$aggregated_data" | jq -c '.[]')
     
-    # Generate informational issues for high-cost SKUs (above threshold)
-    # This alerts on consistently high costs, not just anomalies
-    log "Generating high-cost awareness alerts for SKUs above threshold..."
-    log "Severity levels: Info (>=${NETWORK_COST_THRESHOLD_MONTHLY}), Medium (>=$(echo "${NETWORK_COST_THRESHOLD_MONTHLY} * ${NETWORK_COST_SEVERITY_MEDIUM_MULTIPLIER}" | bc)), High (>=$(echo "${NETWORK_COST_THRESHOLD_MONTHLY} * ${NETWORK_COST_SEVERITY_HIGH_MULTIPLIER}" | bc))"
+    # Generate severity 3 issues for high-cost SKUs (above threshold)
+    log "Generating high-cost alerts for SKUs above threshold (\$${NETWORK_COST_THRESHOLD_MONTHLY}/month)..."
     
     while IFS= read -r sku_data; do
         local sku=$(echo "$sku_data" | jq -r '.sku')
@@ -625,52 +618,32 @@ detect_cost_anomalies() {
         local monthly_cost=$(echo "$sku_data" | jq -r '.monthly.cost')
         local total_cost=$(echo "$sku_data" | jq -r '.totalCost')
         
-        # Generate informational issue for any SKU above threshold
-        # This is not an anomaly - just awareness that this SKU is expensive
+        # Generate severity 3 issue for any SKU above threshold
         if (( $(echo "$monthly_cost >= ${NETWORK_COST_THRESHOLD_MONTHLY}" | bc -l) )); then
             # Calculate daily equivalent for better understanding
             local daily_cost=$(echo "scale=2; $monthly_cost / 30" | bc -l)
-            
-            # Determine severity based on configurable multipliers of base threshold
-            local severity=4  # Default: Info (1x threshold)
-            local severity_label="Info"
-            
-            local medium_threshold=$(echo "scale=2; ${NETWORK_COST_THRESHOLD_MONTHLY} * ${NETWORK_COST_SEVERITY_MEDIUM_MULTIPLIER}" | bc -l)
-            local high_threshold=$(echo "scale=2; ${NETWORK_COST_THRESHOLD_MONTHLY} * ${NETWORK_COST_SEVERITY_HIGH_MULTIPLIER}" | bc -l)
-            
-            if (( $(echo "$monthly_cost >= $high_threshold" | bc -l) )); then
-                severity=2
-                severity_label="High"
-            elif (( $(echo "$monthly_cost >= $medium_threshold" | bc -l) )); then
-                severity=3
-                severity_label="Medium"
-            fi
-            
-            # Calculate multiplier for context
-            local cost_multiplier=$(echo "scale=1; $monthly_cost / ${NETWORK_COST_THRESHOLD_MONTHLY}" | bc -l)
+            local threshold_daily=$(echo "scale=2; ${NETWORK_COST_THRESHOLD_MONTHLY} / 30" | bc -l)
             
             local issue=$(jq -n \
                 --arg title "High Network Cost: $sku" \
-                --argjson severity "$severity" \
-                --arg severity_label "$severity_label" \
                 --arg sku "$sku" \
                 --arg service "$service" \
                 --arg monthly "$monthly_cost" \
                 --arg daily "$daily_cost" \
                 --arg threshold "$NETWORK_COST_THRESHOLD_MONTHLY" \
-                --arg multiplier "$cost_multiplier" \
+                --arg threshold_daily "$threshold_daily" \
                 '{
                     title: $title,
-                    severity: $severity,
-                    expected: ("Network costs for individual SKUs should be reviewed when exceeding $" + $threshold + "/month (≈$" + (($threshold | tonumber) / 30 | tostring | split(".")[0]) + "/day)"),
-                    actual: ("Currently spending $" + $monthly + "/month (≈$" + $daily + "/day) on " + $sku + " - " + $multiplier + "x threshold"),
-                    details: ("Service: " + $service + "\nSKU: " + $sku + "\nMonthly Cost (30 days): $" + $monthly + "\nDaily Average: $" + $daily + "\nBase Threshold: $" + $threshold + "/month\nCost Multiplier: " + $multiplier + "x threshold\nSeverity: " + $severity_label + "\n\nThis is a high-cost network SKU that warrants review for potential optimization opportunities."),
+                    severity: 3,
+                    expected: ("Network costs for individual SKUs should be reviewed when exceeding $" + $threshold + "/month (~$" + $threshold_daily + "/day)"),
+                    actual: ("Currently spending $" + $monthly + "/month (~$" + $daily + "/day) on " + $sku),
+                    details: ("Service: " + $service + "\nSKU: " + $sku + "\nMonthly Cost (30 days): $" + $monthly + "\nDaily Average: $" + $daily + "\nThreshold: $" + $threshold + "/month\n\nThis network SKU exceeds the configured cost threshold and warrants review for potential optimization opportunities."),
                     reproduce_hint: "Review network traffic patterns and usage for this SKU in GCP Console",
                     next_steps: "1. Review if this network cost is expected and necessary\n2. Investigate optimization opportunities (CDN, Cloud Interconnect, compression)\n3. Check for inefficient data transfer patterns\n4. Consider architecture changes to reduce egress/transfer costs\n5. Review if workloads can be colocated to reduce inter-zone/region transfers"
                 }')
             
             issues=$(echo "$issues" | jq --argjson issue "$issue" '. + [$issue]')
-            log "ℹ️  [$severity_label] High-cost alert: $sku = \$$monthly_cost/month (~\$$daily_cost/day, ${cost_multiplier}x threshold)"
+            log "⚠️  High-cost alert: $sku = \$$monthly_cost/month (~\$$daily_cost/day, threshold: \$$NETWORK_COST_THRESHOLD_MONTHLY)"
         fi
     done < <(echo "$aggregated_data" | jq -c '.[]')
     

--- a/codebundles/gcp-project-cost-health/runbook.robot
+++ b/codebundles/gcp-project-cost-health/runbook.robot
@@ -72,7 +72,7 @@ Generate GCP Cost Report By Service and Project
     END
 
 Analyze GCP Network Costs By SKU
-    [Documentation]    Analyzes network-related costs broken down by SKU, showing daily spend for the last 7 days, weekly, monthly, and three-month spend. Detects cost anomalies and deviations.
+    [Documentation]    Analyzes network-related costs broken down by SKU, showing daily spend for the last 7 days, weekly, monthly, and three-month spend. Detects cost anomalies, deviations, and projects future costs based on recent spending trends to provide early warnings.
     [Tags]    GCP    Network    Cost Analysis    Egress    Ingress    access:read-only
     ${network_cost}=    RW.CLI.Run Bash File
     ...    bash_file=gcp_network_cost_analysis.sh
@@ -186,7 +186,7 @@ Suite Initialization
     ...    default=25
     ${NETWORK_COST_THRESHOLD_MONTHLY}=    RW.Core.Import User Variable    NETWORK_COST_THRESHOLD_MONTHLY
     ...    type=string
-    ...    description=Minimum monthly network cost (in USD) to trigger severity 3 alerts. SKUs below this threshold are excluded from analysis to reduce noise and BigQuery costs.
+    ...    description=Monthly network cost threshold (in USD) for severity 3 alerts. Triggers on SKUs that exceed this amount OR are projected to breach it based on recent spending trends (last 7 days).
     ...    pattern=\d+
     ...    default=200
     ${OS_PATH}=    Get Environment Variable    PATH

--- a/codebundles/gcp-project-cost-health/runbook.robot
+++ b/codebundles/gcp-project-cost-health/runbook.robot
@@ -186,19 +186,9 @@ Suite Initialization
     ...    default=25
     ${NETWORK_COST_THRESHOLD_MONTHLY}=    RW.Core.Import User Variable    NETWORK_COST_THRESHOLD_MONTHLY
     ...    type=string
-    ...    description=Minimum monthly network cost (in USD) to trigger alerts. SKUs below this threshold are excluded from analysis to reduce noise and BigQuery costs.
+    ...    description=Minimum monthly network cost (in USD) to trigger severity 3 alerts. SKUs below this threshold are excluded from analysis to reduce noise and BigQuery costs.
     ...    pattern=\d+
     ...    default=200
-    ${NETWORK_COST_SEVERITY_MEDIUM_MULTIPLIER}=    RW.Core.Import User Variable    NETWORK_COST_SEVERITY_MEDIUM_MULTIPLIER
-    ...    type=string
-    ...    description=Multiplier for Medium severity threshold. Medium alerts trigger at (base_threshold × multiplier). Default: 5 results in Medium at $1000/month with $200 base.
-    ...    pattern=\d+
-    ...    default=5
-    ${NETWORK_COST_SEVERITY_HIGH_MULTIPLIER}=    RW.Core.Import User Variable    NETWORK_COST_SEVERITY_HIGH_MULTIPLIER
-    ...    type=string
-    ...    description=Multiplier for High severity threshold. High alerts trigger at (base_threshold × multiplier). Default: 20 results in High at $4000/month with $200 base.
-    ...    pattern=\d+
-    ...    default=20
     ${OS_PATH}=    Get Environment Variable    PATH
     
     # Set suite variables
@@ -208,8 +198,6 @@ Suite Initialization
     Set Suite Variable    ${GCP_COST_BUDGET}    ${GCP_COST_BUDGET}
     Set Suite Variable    ${GCP_PROJECT_COST_THRESHOLD_PERCENT}    ${GCP_PROJECT_COST_THRESHOLD_PERCENT}
     Set Suite Variable    ${NETWORK_COST_THRESHOLD_MONTHLY}    ${NETWORK_COST_THRESHOLD_MONTHLY}
-    Set Suite Variable    ${NETWORK_COST_SEVERITY_MEDIUM_MULTIPLIER}    ${NETWORK_COST_SEVERITY_MEDIUM_MULTIPLIER}
-    Set Suite Variable    ${NETWORK_COST_SEVERITY_HIGH_MULTIPLIER}    ${NETWORK_COST_SEVERITY_HIGH_MULTIPLIER}
     Set Suite Variable    ${gcp_credentials}    ${gcp_credentials}
     
     # Create environment variables for the bash script
@@ -233,12 +221,6 @@ Suite Initialization
     END
     IF    $NETWORK_COST_THRESHOLD_MONTHLY != "" and $NETWORK_COST_THRESHOLD_MONTHLY != "0"
         Set To Dictionary    ${env_dict}    NETWORK_COST_THRESHOLD_MONTHLY    ${NETWORK_COST_THRESHOLD_MONTHLY}
-    END
-    IF    $NETWORK_COST_SEVERITY_MEDIUM_MULTIPLIER != "" and $NETWORK_COST_SEVERITY_MEDIUM_MULTIPLIER != "0"
-        Set To Dictionary    ${env_dict}    NETWORK_COST_SEVERITY_MEDIUM_MULTIPLIER    ${NETWORK_COST_SEVERITY_MEDIUM_MULTIPLIER}
-    END
-    IF    $NETWORK_COST_SEVERITY_HIGH_MULTIPLIER != "" and $NETWORK_COST_SEVERITY_HIGH_MULTIPLIER != "0"
-        Set To Dictionary    ${env_dict}    NETWORK_COST_SEVERITY_HIGH_MULTIPLIER    ${NETWORK_COST_SEVERITY_HIGH_MULTIPLIER}
     END
     Set Suite Variable    ${env}    ${env_dict}
     

--- a/codebundles/gcp-project-cost-health/runbook.robot
+++ b/codebundles/gcp-project-cost-health/runbook.robot
@@ -186,9 +186,19 @@ Suite Initialization
     ...    default=25
     ${NETWORK_COST_THRESHOLD_MONTHLY}=    RW.Core.Import User Variable    NETWORK_COST_THRESHOLD_MONTHLY
     ...    type=string
-    ...    description=Minimum monthly network cost (in USD) to trigger anomaly alerts. SKUs with monthly costs below this threshold will not generate alerts, reducing noise from low-cost items.
+    ...    description=Minimum monthly network cost (in USD) to trigger alerts. SKUs below this threshold are excluded from analysis to reduce noise and BigQuery costs.
     ...    pattern=\d+
-    ...    default=50
+    ...    default=200
+    ${NETWORK_COST_SEVERITY_MEDIUM_MULTIPLIER}=    RW.Core.Import User Variable    NETWORK_COST_SEVERITY_MEDIUM_MULTIPLIER
+    ...    type=string
+    ...    description=Multiplier for Medium severity threshold. Medium alerts trigger at (base_threshold × multiplier). Default: 5 results in Medium at $1000/month with $200 base.
+    ...    pattern=\d+
+    ...    default=5
+    ${NETWORK_COST_SEVERITY_HIGH_MULTIPLIER}=    RW.Core.Import User Variable    NETWORK_COST_SEVERITY_HIGH_MULTIPLIER
+    ...    type=string
+    ...    description=Multiplier for High severity threshold. High alerts trigger at (base_threshold × multiplier). Default: 20 results in High at $4000/month with $200 base.
+    ...    pattern=\d+
+    ...    default=20
     ${OS_PATH}=    Get Environment Variable    PATH
     
     # Set suite variables
@@ -198,6 +208,8 @@ Suite Initialization
     Set Suite Variable    ${GCP_COST_BUDGET}    ${GCP_COST_BUDGET}
     Set Suite Variable    ${GCP_PROJECT_COST_THRESHOLD_PERCENT}    ${GCP_PROJECT_COST_THRESHOLD_PERCENT}
     Set Suite Variable    ${NETWORK_COST_THRESHOLD_MONTHLY}    ${NETWORK_COST_THRESHOLD_MONTHLY}
+    Set Suite Variable    ${NETWORK_COST_SEVERITY_MEDIUM_MULTIPLIER}    ${NETWORK_COST_SEVERITY_MEDIUM_MULTIPLIER}
+    Set Suite Variable    ${NETWORK_COST_SEVERITY_HIGH_MULTIPLIER}    ${NETWORK_COST_SEVERITY_HIGH_MULTIPLIER}
     Set Suite Variable    ${gcp_credentials}    ${gcp_credentials}
     
     # Create environment variables for the bash script
@@ -221,6 +233,12 @@ Suite Initialization
     END
     IF    $NETWORK_COST_THRESHOLD_MONTHLY != "" and $NETWORK_COST_THRESHOLD_MONTHLY != "0"
         Set To Dictionary    ${env_dict}    NETWORK_COST_THRESHOLD_MONTHLY    ${NETWORK_COST_THRESHOLD_MONTHLY}
+    END
+    IF    $NETWORK_COST_SEVERITY_MEDIUM_MULTIPLIER != "" and $NETWORK_COST_SEVERITY_MEDIUM_MULTIPLIER != "0"
+        Set To Dictionary    ${env_dict}    NETWORK_COST_SEVERITY_MEDIUM_MULTIPLIER    ${NETWORK_COST_SEVERITY_MEDIUM_MULTIPLIER}
+    END
+    IF    $NETWORK_COST_SEVERITY_HIGH_MULTIPLIER != "" and $NETWORK_COST_SEVERITY_HIGH_MULTIPLIER != "0"
+        Set To Dictionary    ${env_dict}    NETWORK_COST_SEVERITY_HIGH_MULTIPLIER    ${NETWORK_COST_SEVERITY_HIGH_MULTIPLIER}
     END
     Set Suite Variable    ${env}    ${env_dict}
     


### PR DESCRIPTION
Implemented proactive alerting that projects future costs based on recent
spending trends, generating alerts BEFORE costs breach the threshold.

**How It Works:**

1. **Query Enhancement:**
   - Modified summary query to calculate both current monthly cost AND
     projected monthly cost (recent 7-day average × 30)
   - Includes SKUs where EITHER current >= threshold OR projected >= threshold
   - Uses CTE for efficient calculation of both metrics

2. **Alert Logic:**
   - **Current Breach**: "Currently spending $500/month" (already over threshold)
   - **Projected Breach**: "Current spend is $150/month, but recent daily rate
     of $10/day projects to $300/month" (early warning)

3. **Projection Calculation:**
   - Recent daily average = Last 7 days total / 7
   - Projected monthly = Recent daily average × 30
   - Only generates projection alert if weekly data exists (>0)

**Example Scenarios:**

| Current Monthly | Daily Rate (7d) | Projected Monthly | Threshold | Alert? |
|-----------------|-----------------|-------------------|-----------|--------|
| $50 | $2/day | $60 | $200 | ❌ No |
| $150 | $10/day | $300 | $200 | ✅ Projected breach |
| $250 | $8/day | $240 | $200 | ✅ Current breach |
| $180 | $5/day | $150 | $200 | ❌ No (declining) |

**Benefits:**

- Early warning system catches cost increases before they escalate
- Users can investigate and optimize BEFORE hitting the threshold
- Reduces surprise billing issues
- Maintains single configurable threshold (no complexity)

**Updated Files:**

- **gcp_network_cost_analysis.sh**:
  - Enhanced query with CTE for projection calculation
  - New projection-based alert generation
  - Clearer log messages about projection capability

- **README.md**:
  - Documented projection-based alerting
  - Added alert type examples
  - Explained early warning scenarios

- **runbook.robot**:
  - Updated task documentation
  - Enhanced variable description to mention projection

All alerts remain severity 3 (Medium) for consistency.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces proactive network cost alerting based on recent spend trends and aligns configuration/docs.
> 
> - Enhance `gcp_network_cost_analysis.sh` summary query to compute `monthly_cost` and `projected_monthly` (7-day avg × 30) using CTEs; include SKUs where either value meets/exceeds threshold
> - Generate severity 3 issues for both current breaches and projected breaches; improved logging and messaging
> - Change `NETWORK_COST_THRESHOLD_MONTHLY` default from `50` to `200`
> - Update `README.md` with behavior, examples, and alert types; clarify that threshold filters or projections drive inclusion
> - Update `runbook.robot` task docs and variable description/default to reflect projection-based alerts
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ecf34141f9930713287acfa7270e12a7c8cbc22a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->