### PR TITLE
feat: add SLI template to GCP project cost health generation rules

### DIFF
--- a/codebundles/gcp-project-cost-health/.runwhen/generation-rules/gcp-project-cost-health.yaml
+++ b/codebundles/gcp-project-cost-health/.runwhen/generation-rules/gcp-project-cost-health.yaml
@@ -19,4 +19,5 @@ spec:
             - type: slx
             - type: runbook
               templateName: gcp-project-cost-health-taskset.yaml
-
+            - type: sli
+              templateName: gcp-project-cost-health-sli.yaml

--- a/codebundles/gcp-project-cost-health/.runwhen/templates/gcp-project-cost-health-sli.yaml
+++ b/codebundles/gcp-project-cost-health/.runwhen/templates/gcp-project-cost-health-sli.yaml
@@ -1,0 +1,28 @@
+apiVersion: runwhen.com/v1
+kind: ServiceLevelIndicator
+metadata:
+  name: {{slx_name}}
+  labels:
+    {% include "common-labels.yaml" %}
+  annotations:
+    {% include "common-annotations.yaml" %}
+spec:
+  displayUnitsLong: Execution Status
+  displayUnitsShort: status
+  locations:
+    - {{default_location}}
+  description: Schedules daily execution of GCP cost health analysis runbook to monitor spending, network costs, and cost anomalies.
+  codeBundle:
+    repoUrl: https://github.com/runwhen-contrib/rw-workspace-utils.git
+    ref: main
+    pathToRobot: codebundles/cron-scheduler-sli/sli.robot
+  intervalStrategy: intermezzo
+  intervalSeconds: 300
+  configProvided:
+    - name: CRON_SCHEDULE
+      value: "0 8 * * *" 
+    - name: TARGET_SLX
+      value: ""
+    - name: DRY_RUN
+      value: "false"
+  secretsProvided: []


### PR DESCRIPTION
Included a new SLI type in the generation rules for GCP project cost health, enhancing the monitoring capabilities with the addition of the gcp-project-cost-health-sli.yaml template.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a scheduled SLI for GCP project cost health to automate daily runbook execution.
> 
> - Extends `gcp-project-cost-health` generation rules to output a new `sli` using `gcp-project-cost-health-sli.yaml`
> - Introduces `ServiceLevelIndicator` template that triggers the cost health runbook on a daily cron (`0 8 * * *`) via `rw-workspace-utils` cron scheduler; configurable via `CRON_SCHEDULE`, `TARGET_SLX`, `DRY_RUN`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6f57e6a9aea2cbdf0855f6f30ef7547c3cc3cfd2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->