### PR TITLE
Updates/020226-02

### DIFF
--- a/codebundles/azure-aks-triage/aks_cost_optimization.sh
+++ b/codebundles/azure-aks-triage/aks_cost_optimization.sh
@@ -224,7 +224,7 @@ if [[ "$CLUSTER_POWER_STATE" == "Stopped" ]]; then
     while read -r pool_data; do
         pool_name=$(echo "$pool_data" | jq -r '.name')
         pool_count=$(echo "$pool_data" | jq -r '.count // 0')
-        os_disk_size=$(echo "$pool_data" | jq -r '.osDiskSizeGb // 128')
+        os_disk_size=$(echo "$pool_data" | jq -r '.osDiskSizeGB // 128')
         os_disk_type=$(echo "$pool_data" | jq -r '.osDiskType // "Managed"')
         
         # Try to get OS disk storage account type from node pool or default to Premium for AKS

--- a/codebundles/azure-aks-triage/aks_cost_optimization.sh
+++ b/codebundles/azure-aks-triage/aks_cost_optimization.sh
@@ -235,6 +235,13 @@ if [[ "$CLUSTER_POWER_STATE" == "Stopped" ]]; then
         log "    OS Disk Size: ${os_disk_size}GB per node"
         log "    OS Disk Type: $os_disk_type ($os_storage_type)"
         
+        # Skip ephemeral OS disks - they use local VM storage and don't incur separate storage costs
+        # Ephemeral disks are deallocated when the cluster stops, so no ongoing storage charges
+        if [[ "$os_disk_type" == "Ephemeral" ]]; then
+            log "    ℹ️ Ephemeral OS disks - no storage cost (uses local VM storage)"
+            continue
+        fi
+        
         if [[ "$pool_count" -gt 0 ]]; then
             cost_per_gb=$(get_storage_cost_per_gb "$os_storage_type")
             pool_os_disk_total_gb=$((os_disk_size * pool_count))

--- a/codebundles/azure-aks-triage/runbook.robot
+++ b/codebundles/azure-aks-triage/runbook.robot
@@ -255,7 +255,7 @@ Analyze AKS Cluster Cost Optimization Opportunities for `${AKS_CLUSTER}` In Reso
     ${cost_optimization}=    RW.CLI.Run Bash File
     ...    bash_file=aks_cost_optimization.sh
     ...    env=${env}
-    ...    timeout_seconds=300
+    ...    timeout_seconds=${TIMEOUT_SECONDS}
     ...    include_in_history=false
     ...    show_in_rwl_cheatsheet=true
     
@@ -325,6 +325,11 @@ Suite Initialization
     ...    description=The time period, in minutes, to look back for activites/events. 
     ...    pattern=\w*
     ...    default=60
+    ${TIMEOUT_SECONDS}=    RW.Core.Import User Variable    TIMEOUT_SECONDS
+    ...    type=string
+    ...    description=Timeout in seconds for tasks (default: 900).
+    ...    pattern=\d+
+    ...    default=900
     ${AZURE_RESOURCE_SUBSCRIPTION_ID}=    RW.Core.Import User Variable    AZURE_RESOURCE_SUBSCRIPTION_ID
     ...    type=string
     ...    description=The Azure Subscription ID for the resource.  
@@ -360,6 +365,7 @@ Suite Initialization
     Set Suite Variable    ${AKS_CLUSTER}    ${AKS_CLUSTER}
     Set Suite Variable    ${AZ_RESOURCE_GROUP}    ${AZ_RESOURCE_GROUP}
     Set Suite Variable    ${RW_LOOKBACK_WINDOW}    ${RW_LOOKBACK_WINDOW}
+    Set Suite Variable    ${TIMEOUT_SECONDS}    ${TIMEOUT_SECONDS}
     Set Suite Variable
     ...    ${env}
     ...    {"AKS_CLUSTER":"${AKS_CLUSTER}", "AZ_RESOURCE_GROUP":"${AZ_RESOURCE_GROUP}", "RW_LOOKBACK_WINDOW": "${RW_LOOKBACK_WINDOW}", "AZURE_RESOURCE_SUBSCRIPTION_ID":"${AZURE_RESOURCE_SUBSCRIPTION_ID}"}

--- a/codebundles/azure-aks-triage/runbook.robot
+++ b/codebundles/azure-aks-triage/runbook.robot
@@ -264,10 +264,10 @@ Analyze AKS Cluster Cost Optimization Opportunities for `${AKS_CLUSTER}` In Reso
         RW.Core.Add Issue
         ...    severity=2
         ...    expected=AKS cost optimization analysis should complete within timeout for `${AKS_CLUSTER}` in `${AZ_RESOURCE_GROUP}`
-        ...    actual=AKS cost optimization analysis timed out after 300 seconds for `${AKS_CLUSTER}` in `${AZ_RESOURCE_GROUP}`
+        ...    actual=AKS cost optimization analysis timed out after ${TIMEOUT_SECONDS} seconds for `${AKS_CLUSTER}` in `${AZ_RESOURCE_GROUP}`
         ...    title=AKS Cost Optimization Analysis Timeout for Cluster `${AKS_CLUSTER}` in `${AZ_RESOURCE_GROUP}`
         ...    reproduce_hint=${cost_optimization.cmd}
-        ...    details=Command timed out after 300 seconds. This may indicate authentication issues, network connectivity problems, or Azure service delays.
+        ...    details=Command timed out after ${TIMEOUT_SECONDS} seconds. This may indicate authentication issues, network connectivity problems, or Azure service delays.
         ...    next_steps=Check Azure authentication with 'az account show'\nVerify network connectivity to Azure services\nCheck if Azure service principal credentials are expired\nTry running the command manually: ${cost_optimization.cmd}
         RETURN
     END

--- a/codebundles/azure-appservice-plan-health/runbook.robot
+++ b/codebundles/azure-appservice-plan-health/runbook.robot
@@ -148,7 +148,7 @@ Analyze App Service Plan Cost Optimization Opportunities in resource group `${AZ
     ${cost_optimization}=    RW.CLI.Run Bash File
     ...    bash_file=asp_cost_optimization.sh
     ...    env=${env}
-    ...    timeout_seconds=300
+    ...    timeout_seconds=${TIMEOUT_SECONDS}
     ...    include_in_history=false
     ...    show_in_rwl_cheatsheet=true
     RW.Core.Add Pre To Report    ${cost_optimization.stdout}
@@ -359,6 +359,11 @@ Suite Initialization
     ...    description=Metrics collection interval (e.g., PT1H, PT5M) (default: PT1H)
     ...    pattern=\w+
     ...    default=PT1H
+    ${TIMEOUT_SECONDS}=    RW.Core.Import User Variable    TIMEOUT_SECONDS
+    ...    type=string
+    ...    description=Timeout in seconds for tasks (default: 900).
+    ...    pattern=\d+
+    ...    default=900
     Set Suite Variable    ${AZURE_SUBSCRIPTION_ID}    ${AZURE_SUBSCRIPTION_ID}
     Set Suite Variable    ${AZURE_RESOURCE_GROUP}    ${AZURE_RESOURCE_GROUP}
     Set Suite Variable    ${AZURE_ACTIVITY_LOG_OFFSET}    ${AZURE_ACTIVITY_LOG_OFFSET}
@@ -372,6 +377,7 @@ Suite Initialization
     Set Suite Variable    ${METRICS_OFFSET}    ${METRICS_OFFSET}
     Set Suite Variable    ${METRICS_INTERVAL}    ${METRICS_INTERVAL}
     Set Suite Variable    ${AZURE_SUBSCRIPTION_NAME}    ${AZURE_SUBSCRIPTION_NAME}
+    Set Suite Variable    ${TIMEOUT_SECONDS}    ${TIMEOUT_SECONDS}
     Set Suite Variable
     ...    ${env}
     ...    {"AZURE_RESOURCE_GROUP":"${AZURE_RESOURCE_GROUP}", "AZURE_SUBSCRIPTION_ID":"${AZURE_SUBSCRIPTION_ID}", "CPU_THRESHOLD":"${CPU_THRESHOLD}", "MEMORY_THRESHOLD":"${MEMORY_THRESHOLD}", "DISK_QUEUE_THRESHOLD":"${DISK_QUEUE_THRESHOLD}", "SCALE_UP_CPU_THRESHOLD":"${SCALE_UP_CPU_THRESHOLD}", "SCALE_UP_MEMORY_THRESHOLD":"${SCALE_UP_MEMORY_THRESHOLD}", "SCALE_DOWN_CPU_THRESHOLD":"${SCALE_DOWN_CPU_THRESHOLD}", "SCALE_DOWN_MEMORY_THRESHOLD":"${SCALE_DOWN_MEMORY_THRESHOLD}", "METRICS_OFFSET":"${METRICS_OFFSET}", "METRICS_INTERVAL":"${METRICS_INTERVAL}", "AZURE_ACTIVITY_LOG_OFFSET": "${AZURE_ACTIVITY_LOG_OFFSET}"}

--- a/codebundles/azure-subscription-cost-health/runbook.robot
+++ b/codebundles/azure-subscription-cost-health/runbook.robot
@@ -21,7 +21,7 @@ Generate Azure Cost Report By Service and Resource Group
     ${cost_report}=    RW.CLI.Run Bash File
     ...    bash_file=azure_cost_historical_report.sh
     ...    env=${env}
-    ...    timeout_seconds=600
+    ...    timeout_seconds=${TIMEOUT_SECONDS}
     ...    include_in_history=false
     ...    show_in_rwl_cheatsheet=true
     RW.Core.Add Pre To Report    ${cost_report.stdout}
@@ -53,7 +53,7 @@ Analyze App Service Plan Cost Optimization
     ${cost_analysis}=    RW.CLI.Run Bash File
     ...    bash_file=azure_appservice_cost_optimization.sh
     ...    env=${env}
-    ...    timeout_seconds=600
+    ...    timeout_seconds=${TIMEOUT_SECONDS}
     ...    include_in_history=false
     ...    show_in_rwl_cheatsheet=true
     RW.Core.Add Pre To Report    ${cost_analysis.stdout}
@@ -103,7 +103,7 @@ Analyze AKS Node Pool Resizing Opportunities Based on Utilization Metrics
     ${aks_analysis}=    RW.CLI.Run Bash File
     ...    bash_file=analyze_aks_node_pool_optimization.sh
     ...    env=${env}
-    ...    timeout_seconds=900
+    ...    timeout_seconds=${TIMEOUT_SECONDS}
     ...    include_in_history=false
     ...    show_in_rwl_cheatsheet=true
     RW.Core.Add Pre To Report    ${aks_analysis.stdout}
@@ -153,7 +153,7 @@ Analyze Databricks Cluster Auto-Termination and Over-Provisioning Opportunities
     ${databricks_analysis}=    RW.CLI.Run Bash File
     ...    bash_file=analyze_databricks_cluster_optimization.sh
     ...    env=${env}
-    ...    timeout_seconds=900
+    ...    timeout_seconds=${TIMEOUT_SECONDS}
     ...    include_in_history=false
     ...    show_in_rwl_cheatsheet=true
     RW.Core.Add Pre To Report    ${databricks_analysis.stdout}
@@ -203,7 +203,7 @@ Analyze Virtual Machine Rightsizing and Deallocation Opportunities
     ${vm_analysis}=    RW.CLI.Run Bash File
     ...    bash_file=analyze_vm_optimization.sh
     ...    env=${env}
-    ...    timeout_seconds=900
+    ...    timeout_seconds=${TIMEOUT_SECONDS}
     ...    include_in_history=false
     ...    show_in_rwl_cheatsheet=true
     RW.Core.Add Pre To Report    ${vm_analysis.stdout}
@@ -290,7 +290,7 @@ Analyze Azure Storage Cost Optimization Opportunities
     ${storage_analysis}=    RW.CLI.Run Bash File
     ...    bash_file=analyze_storage_optimization.sh
     ...    env=${env}
-    ...    timeout_seconds=900
+    ...    timeout_seconds=${TIMEOUT_SECONDS}
     ...    include_in_history=false
     ...    show_in_rwl_cheatsheet=true
     RW.Core.Add Pre To Report    ${storage_analysis.stdout}
@@ -398,6 +398,12 @@ Suite Initialization
     ...    pattern=\d+
     ...    default=90
     
+    ${TIMEOUT_SECONDS}=    RW.Core.Import User Variable    TIMEOUT_SECONDS
+    ...    type=string
+    ...    description=Timeout in seconds for tasks (default: 900).
+    ...    pattern=\d+
+    ...    default=900
+    
     # Set suite variables
     Set Suite Variable    ${AZURE_SUBSCRIPTION_IDS}    ${AZURE_SUBSCRIPTION_IDS}
     Set Suite Variable    ${AZURE_RESOURCE_GROUPS}    ${AZURE_RESOURCE_GROUPS}
@@ -410,6 +416,7 @@ Suite Initialization
     Set Suite Variable    ${OPTIMIZATION_STRATEGY}    ${OPTIMIZATION_STRATEGY}
     Set Suite Variable    ${COST_INCREASE_THRESHOLD}    ${COST_INCREASE_THRESHOLD}
     Set Suite Variable    ${SNAPSHOT_AGE_THRESHOLD_DAYS}    ${SNAPSHOT_AGE_THRESHOLD_DAYS}
+    Set Suite Variable    ${TIMEOUT_SECONDS}    ${TIMEOUT_SECONDS}
     
     # Create environment variables for the bash script
     ${env}=    Create Dictionary


### PR DESCRIPTION
Updated the AKS cost optimization script to include comprehensive analysis of storage costs for stopped clusters. This enhancement introduces a function to determine cost per GB based on storage type, aggregates total storage and monthly costs from node pool configurations and standalone managed disks, and provides a detailed summary of estimated costs. The changes improve cost visibility and management for users with inactive clusters.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk: changes affect cost reporting logic for stopped AKS clusters (disk counting/cost estimation) and adjust execution timeouts across multiple runbooks, which could alter issue severity/output and job runtime behavior.
> 
> **Overview**
> Enhances stopped AKS cluster handling by replacing the simple `az disk list` tally with a **more comprehensive storage-cost estimate**: aggregates node pool OS disk costs (skipping *ephemeral* OS disks), adds separate accounting for standalone data/PVC managed disks (filtering out OS disks to avoid double-counting), and outputs a consolidated monthly/annual storage cost summary and issue payload.
> 
> Standardizes runbook execution timing by introducing a configurable `TIMEOUT_SECONDS` user variable (default `900`) and wiring it into multiple `RW.CLI.Run Bash File` tasks, updating timeout-related issue messages accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d591c9bb7e2dcc608aa9cd5d432fa7a328ad8931. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->