### PR TITLE
Enhance Azure App Service cost calculation logic in optimization script

### DIFF
--- a/codebundles/azure-appservice-cost-optimization/azure_appservice_cost_optimization.sh
+++ b/codebundles/azure-appservice-cost-optimization/azure_appservice_cost_optimization.sh
@@ -192,8 +192,12 @@ calculate_plan_cost() {
         "Free")
             base_cost=0
             ;;
-        "Shared"|"Dynamic")
+        "Shared")
             base_cost=10
+            ;;
+        "Dynamic")
+            # Consumption plan - pay per execution, no fixed monthly cost
+            base_cost=0
             ;;
         "Basic")
             case "$sku_upper" in
@@ -281,58 +285,44 @@ calculate_plan_cost() {
         *)
             # Try to determine by SKU name pattern if tier is unknown
             case "$sku_upper" in
-                B1|B2|B3) 
-                    case "$sku_upper" in
-                        "B1") base_cost=55 ;;
-                        "B2") base_cost=109 ;;
-                        "B3") base_cost=219 ;;
-                    esac
-                    ;;
-                S1|S2|S3)
-                    case "$sku_upper" in
-                        "S1") base_cost=73 ;;
-                        "S2") base_cost=146 ;;
-                        "S3") base_cost=292 ;;
-                    esac
-                    ;;
-                P1|P2|P3|P1V2|P2V2|P3V2|P0V3|P1V3|P2V3|P3V3)
-                    case "$sku_upper" in
-                        "P1"|"P1V2"|"P1V3") base_cost=146 ;;
-                        "P2"|"P2V2"|"P2V3") base_cost=292 ;;
-                        "P3"|"P3V2"|"P3V3") base_cost=584 ;;
-                        "P0V3") base_cost=78 ;;
-                    esac
-                    ;;
-                P1MV3|P2MV3|P3MV3|P4MV3|P5MV3)
-                    case "$sku_upper" in
-                        "P1MV3") base_cost=292 ;;
-                        "P2MV3") base_cost=584 ;;
-                        "P3MV3") base_cost=1168 ;;
-                        "P4MV3") base_cost=2336 ;;
-                        "P5MV3") base_cost=4672 ;;
-                    esac
-                    ;;
-                EP1|EP2|EP3)
-                    case "$sku_upper" in
-                        "EP1") base_cost=146 ;;
-                        "EP2") base_cost=292 ;;
-                        "EP3") base_cost=584 ;;
-                    esac
-                    ;;
-                I1|I2|I3|I1V2|I2V2|I3V2|I4V2|I5V2|I6V2)
-                    case "$sku_upper" in
-                        "I1"|"I1V2") base_cost=298 ;;
-                        "I2"|"I2V2") base_cost=595 ;;
-                        "I3"|"I3V2") base_cost=1190 ;;
-                        "I4V2") base_cost=2380 ;;
-                        "I5V2") base_cost=4760 ;;
-                        "I6V2") base_cost=9520 ;;
-                    esac
-                    ;;
-                Y1)
-                    # Consumption plan - charge per execution, estimate minimal base
-                    base_cost=0
-                    ;;
+                # Basic
+                "B1") base_cost=55 ;;
+                "B2") base_cost=109 ;;
+                "B3") base_cost=219 ;;
+                # Standard
+                "S1") base_cost=73 ;;
+                "S2") base_cost=146 ;;
+                "S3") base_cost=292 ;;
+                # Premium
+                "P1"|"P1V2"|"P1V3") base_cost=146 ;;
+                "P2"|"P2V2"|"P2V3") base_cost=292 ;;
+                "P3"|"P3V2"|"P3V3") base_cost=584 ;;
+                "P0V3") base_cost=78 ;;
+                # Premium Memory-optimized
+                "P1MV3") base_cost=292 ;;
+                "P2MV3") base_cost=584 ;;
+                "P3MV3") base_cost=1168 ;;
+                "P4MV3") base_cost=2336 ;;
+                "P5MV3") base_cost=4672 ;;
+                # Elastic Premium
+                "EP1") base_cost=146 ;;
+                "EP2") base_cost=292 ;;
+                "EP3") base_cost=584 ;;
+                # Flex Consumption
+                "FC1") base_cost=175 ;;
+                # Isolated
+                "I1"|"I1V2") base_cost=298 ;;
+                "I2"|"I2V2") base_cost=595 ;;
+                "I3"|"I3V2") base_cost=1190 ;;
+                "I4V2") base_cost=2380 ;;
+                "I5V2") base_cost=4760 ;;
+                "I6V2") base_cost=9520 ;;
+                # Workflow Standard (Logic Apps)
+                "WS1") base_cost=151 ;;
+                "WS2") base_cost=302 ;;
+                "WS3") base_cost=605 ;;
+                # Consumption/Dynamic
+                "Y1"|"F1"|"D1") base_cost=0 ;;
                 *)
                     # Unknown SKU - log warning and estimate based on capacity
                     log "  ⚠️  Unknown SKU '$sku_tier/$sku_name' - using estimate"

--- a/codebundles/azure-appservice-cost-optimization/azure_appservice_cost_optimization.sh
+++ b/codebundles/azure-appservice-cost-optimization/azure_appservice_cost_optimization.sh
@@ -321,8 +321,10 @@ calculate_plan_cost() {
                 "WS1") base_cost=151 ;;
                 "WS2") base_cost=302 ;;
                 "WS3") base_cost=605 ;;
-                # Consumption/Dynamic
-                "Y1"|"F1"|"D1") base_cost=0 ;;
+                # Free/Consumption
+                "Y1"|"F1") base_cost=0 ;;
+                # Shared
+                "D1") base_cost=10 ;;
                 *)
                     # Unknown SKU - log warning and estimate based on capacity
                     log "  ⚠️  Unknown SKU '$sku_tier/$sku_name' - using estimate"


### PR DESCRIPTION
- Expanded the cost calculation logic in the azure_appservice_cost_optimization.sh script to include additional SKU tiers and names, improving accuracy in estimating monthly costs for various Azure App Service plans.
- Normalized SKU names to uppercase for consistent matching and added handling for new tiers such as Free, Shared, Basic, Standard, Premium, ElasticPremium, Isolated, and WorkflowStandard.
- Implemented fallback logic for unknown SKUs to provide conservative cost estimates, enhancing the script's robustness in diverse scenarios.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes impact cost calculations and automated issue severity/wording; incorrect SKU mappings or metric parsing could misestimate savings or raise/lower alert severity for HPAs at max replicas.
> 
> **Overview**
> Improves Azure App Service Plan cost estimation by normalizing SKU names and greatly expanding tier/SKU coverage (including Free/Shared/Basic/Standard/Premium/Isolated/WorkflowStandard and more `PremiumV3` variants), plus adding a conservative fallback path that logs when an unknown SKU is encountered.
> 
> Enhances the Kubernetes deployment healthcheck HPA runbook: when an HPA is at `maxReplicas`, it now inspects current vs target CPU/memory utilization and escalates to a higher-severity issue when the HPA is *resource-constrained* (vs merely having no scaling headroom).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fdffa326237270519e4ed63ae806b249f7706208. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->