### PR TITLE
Implement resource group filtering across Azure cost optimization scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ build
 **vm_mem_stdout**
 **vm_disk_stdout**
 **/.test/.gitconfig
+Runbook Log.html

--- a/codebundles/azure-appservice-cost-optimization/azure_appservice_cost_optimization.sh
+++ b/codebundles/azure-appservice-cost-optimization/azure_appservice_cost_optimization.sh
@@ -986,9 +986,10 @@ main() {
         local plans
         
         if is_resource_graph_available 2>/dev/null; then
-            # Use Resource Graph for faster query
-            local graph_result=$(query_appservice_plans_graph "$SUBSCRIPTION_ID")
-            plans=$(echo "$graph_result" | jq --arg rg "$rg" '[.data[] | select(.resourceGroup == $rg) | {
+            # Use Resource Graph for faster query with resource group filter
+            local rg_filter="resourceGroup in~ ('$rg')"
+            local graph_result=$(query_appservice_plans_graph "$SUBSCRIPTION_ID" "$rg_filter")
+            plans=$(echo "$graph_result" | jq '[.data[] | {
                 name: .name,
                 id: .id,
                 resourceGroup: .resourceGroup,

--- a/codebundles/azure-vm-cost-optimization/analyze_vm_optimization.sh
+++ b/codebundles/azure-vm-cost-optimization/analyze_vm_optimization.sh
@@ -330,49 +330,39 @@ main() {
         # Get VMs in subscription (filtered by resource group if specified)
         progress "Fetching VMs..."
         local vms
+        
+        # Build resource group filter (empty string when unset, which query_vms_graph handles as no-op)
+        local rg_graph_filter=""
         if [[ ${#RESOURCE_GROUP_FILTER[@]} -gt 0 ]]; then
-            # Resource group filter is specified - fetch only VMs in those resource groups
-            if is_resource_graph_available 2>/dev/null; then
-                # Build Resource Graph filter for resource groups (case-insensitive)
-                local rg_filter_parts=()
-                for rg in "${RESOURCE_GROUP_FILTER[@]}"; do
-                    rg_filter_parts+=("'$rg'")
-                done
-                local rg_filter_str=$(IFS=','; echo "${rg_filter_parts[*]}")
-                local rg_graph_filter="resourceGroup in~ (${rg_filter_str})"
-                local graph_result=$(query_vms_graph "$subscription_id" "$rg_graph_filter")
-                vms=$(echo "$graph_result" | jq '[.data[] | {
-                    name: .name,
-                    id: .id,
-                    location: .location,
-                    resourceGroup: .resourceGroup,
-                    hardwareProfile: {vmSize: .vmSize},
-                    _powerState: .powerState
-                }]')
-            else
-                # Fetch VMs from each specified resource group using az CLI
-                vms="[]"
-                for rg in "${RESOURCE_GROUP_FILTER[@]}"; do
-                    progress "  Fetching VMs from resource group: $rg"
-                    local rg_vms=$(az vm list --subscription "$subscription_id" --resource-group "$rg" -o json 2>/dev/null || echo '[]')
-                    vms=$(echo "$vms" "$rg_vms" | jq -s '.[0] + .[1]')
-                done
-            fi
+            local rg_filter_parts=()
+            for rg in "${RESOURCE_GROUP_FILTER[@]}"; do
+                rg_filter_parts+=("'$rg'")
+            done
+            rg_graph_filter="resourceGroup in~ ($(IFS=','; echo "${rg_filter_parts[*]}"))"
+        fi
+        
+        if is_resource_graph_available 2>/dev/null; then
+            # Resource Graph handles empty filter as no-op (fetches all)
+            local graph_result=$(query_vms_graph "$subscription_id" "$rg_graph_filter")
+            vms=$(echo "$graph_result" | jq '[.data[] | {
+                name: .name,
+                id: .id,
+                location: .location,
+                resourceGroup: .resourceGroup,
+                hardwareProfile: {vmSize: .vmSize},
+                _powerState: .powerState
+            }]')
+        elif [[ ${#RESOURCE_GROUP_FILTER[@]} -gt 0 ]]; then
+            # CLI fallback: fetch VMs from each specified resource group
+            vms="[]"
+            for rg in "${RESOURCE_GROUP_FILTER[@]}"; do
+                progress "  Fetching VMs from resource group: $rg"
+                local rg_vms=$(az vm list --subscription "$subscription_id" --resource-group "$rg" -o json 2>/dev/null || echo '[]')
+                vms=$(echo "$vms" "$rg_vms" | jq -s '.[0] + .[1]')
+            done
         else
-            # No resource group filter - fetch all VMs in the subscription
-            if is_resource_graph_available 2>/dev/null; then
-                local graph_result=$(query_vms_graph "$subscription_id")
-                vms=$(echo "$graph_result" | jq '[.data[] | {
-                    name: .name,
-                    id: .id,
-                    location: .location,
-                    resourceGroup: .resourceGroup,
-                    hardwareProfile: {vmSize: .vmSize},
-                    _powerState: .powerState
-                }]')
-            else
-                vms=$(az vm list --subscription "$subscription_id" -o json 2>/dev/null || echo '[]')
-            fi
+            # CLI fallback: no filter, fetch all VMs in subscription
+            vms=$(az vm list --subscription "$subscription_id" -o json 2>/dev/null || echo '[]')
         fi
         local vm_count=$(echo "$vms" | jq 'length')
         

--- a/codebundles/azure-vm-cost-optimization/runbook.robot
+++ b/codebundles/azure-vm-cost-optimization/runbook.robot
@@ -45,11 +45,12 @@ Analyze Virtual Machine Rightsizing and Deallocation Opportunities in Resource G
     RW.Core.Add Pre To Report    ${vm_details.stdout}
 
     ${vm_issues}=    RW.CLI.Run Cli
-    ...    cmd=cat vm_optimization_issues.json
+    ...    cmd=if [ -f "vm_optimization_issues.json" ] && [ -s "vm_optimization_issues.json" ]; then cat vm_optimization_issues.json; else echo "[]"; fi
     ...    env=${env}
     ...    timeout_seconds=60
     ...    include_in_history=false
-    ${vm_issue_list}=    Evaluate    json.loads(r'''${vm_issues.stdout}''')    json
+    ${issues_stdout}=    Set Variable If    "${vm_issues.stdout}" == ""    []    ${vm_issues.stdout}
+    ${vm_issue_list}=    Evaluate    json.loads(r'''${issues_stdout}''')    json
     IF    len(@{vm_issue_list}) > 0
         ${issue_count}=    Evaluate    len(@{vm_issue_list})
         


### PR DESCRIPTION
- Added functionality to filter resources by specified Azure resource groups in various optimization scripts, including those for AKS, App Service, Databricks, Storage, and VMs.
- Enhanced query performance by integrating resource group filters into Resource Graph queries, improving efficiency in resource discovery.
- Updated scripts to handle cases where no resource group is specified, ensuring comprehensive analysis across all resources when needed.
- Introduced utility functions for managing resource group filters and applied them consistently across scripts to streamline code and improve maintainability.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands query/filter logic across multiple Azure optimization scripts and shared Resource Graph utilities; mistakes could silently omit resources or change scan scope, but changes are largely additive and gated by optional env vars.
> 
> **Overview**
> Adds first-class `AZURE_RESOURCE_GROUPS` filtering across Azure cost optimization codebundles (AKS, App Service, Databricks, Storage, VMs) so analyses can target specific resource groups instead of always scanning entire subscriptions.
> 
> Resource Graph queries are updated to accept an optional Kusto `resourceGroup in~ (...)` clause (moved earlier in queries for efficiency), and CLI fallbacks are adjusted to either query per-resource-group or post-filter results. The storage analyzer also centralizes filter parsing/helpers (`init_resource_group_filter`, `filter_by_resource_groups`) and applies them consistently.
> 
> Improves runbook robustness by treating missing/empty `vm_optimization_issues.json` as `[]`, and updates `.gitignore` to exclude `Runbook Log.html`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 444ea37da06de71d55d1df0b5d8b00a558dd32b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->