### PR TITLE
Refactor Azure DevOps Health Monitoring Scripts to Enhance Error Handling and Authentication

### DIFF
--- a/codebundles/azure-devops-project-health/_az_helpers.sh
+++ b/codebundles/azure-devops-project-health/_az_helpers.sh
@@ -24,12 +24,14 @@ az_with_retry() {
         fi
 
         AZ_RESULT=""
-        if AZ_RESULT=$(timeout "$AZ_CMD_TIMEOUT" "$@" 2>_az_retry_err.log); then
+        AZ_RESULT=$(timeout "$AZ_CMD_TIMEOUT" "$@" 2>_az_retry_err.log)
+        exit_code=$?
+
+        if [ $exit_code -eq 0 ]; then
             rm -f _az_retry_err.log
             return 0
         fi
 
-        exit_code=$?
         local err_msg
         err_msg=$(cat _az_retry_err.log 2>/dev/null || echo "")
         rm -f _az_retry_err.log

--- a/codebundles/azure-devops-project-health/_az_helpers.sh
+++ b/codebundles/azure-devops-project-health/_az_helpers.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Shared helper functions for Azure DevOps shell scripts.
+# Source this file: source "$(dirname "$0")/_az_helpers.sh"
+
+: "${AZ_RETRY_COUNT:=3}"
+: "${AZ_RETRY_INITIAL_WAIT:=5}"
+: "${AZ_CMD_TIMEOUT:=60}"
+
+# Run an az CLI command with retry and per-call timeout.
+# Usage: az_with_retry az pipelines list --output json
+# Returns: sets AZ_RESULT with stdout, returns the exit code
+az_with_retry() {
+    local attempt=0
+    local wait_seconds="$AZ_RETRY_INITIAL_WAIT"
+    local exit_code=1
+
+    while [ $attempt -lt "$AZ_RETRY_COUNT" ]; do
+        attempt=$((attempt + 1))
+
+        if [ $attempt -gt 1 ]; then
+            echo "  Retry attempt $attempt/$AZ_RETRY_COUNT (waiting ${wait_seconds}s)..." >&2
+            sleep "$wait_seconds"
+            wait_seconds=$((wait_seconds * 2))
+        fi
+
+        AZ_RESULT=""
+        if AZ_RESULT=$(timeout "$AZ_CMD_TIMEOUT" "$@" 2>_az_retry_err.log); then
+            rm -f _az_retry_err.log
+            return 0
+        fi
+
+        exit_code=$?
+        local err_msg
+        err_msg=$(cat _az_retry_err.log 2>/dev/null || echo "")
+        rm -f _az_retry_err.log
+
+        if [ $exit_code -eq 124 ]; then
+            echo "  WARNING: Command timed out after ${AZ_CMD_TIMEOUT}s (attempt $attempt/$AZ_RETRY_COUNT)" >&2
+        else
+            echo "  WARNING: Command failed with exit code $exit_code (attempt $attempt/$AZ_RETRY_COUNT): $err_msg" >&2
+        fi
+    done
+
+    echo "  ERROR: Command failed after $AZ_RETRY_COUNT attempts: $*" >&2
+    return $exit_code
+}
+
+setup_azure_auth() {
+    local org_url="https://dev.azure.com/$AZURE_DEVOPS_ORG"
+
+    if ! az extension show --name azure-devops &>/dev/null; then
+        echo "Installing Azure DevOps CLI extension..."
+        az extension add --name azure-devops --output none
+    fi
+
+    az devops configure --defaults organization="$org_url" --output none
+
+    if [ "${AUTH_TYPE:-service_principal}" = "pat" ]; then
+        if [ -z "${AZURE_DEVOPS_PAT:-}" ]; then
+            echo "ERROR: AZURE_DEVOPS_PAT must be set when AUTH_TYPE=pat"
+            exit 1
+        fi
+        echo "Using PAT authentication..."
+        echo "$AZURE_DEVOPS_PAT" | az devops login --organization "$org_url"
+    else
+        echo "Using service principal authentication..."
+    fi
+}

--- a/codebundles/azure-devops-project-health/agent-pools.sh
+++ b/codebundles/azure-devops-project-health/agent-pools.sh
@@ -15,10 +15,12 @@
 # -----------------------------------------------------------------------------
 
 : "${AZURE_DEVOPS_ORG:?Must set AZURE_DEVOPS_ORG}"
-: "${HIGH_UTILIZATION_THRESHOLD:=80}"  # Default to 80% if not specified
+: "${HIGH_UTILIZATION_THRESHOLD:=80}"
 : "${AUTH_TYPE:=service_principal}"
 AZURE_DEVOPS_PAT="${AZURE_DEVOPS_PAT:-$azure_devops_pat}"
 export AZURE_DEVOPS_EXT_PAT="${AZURE_DEVOPS_PAT}"
+
+source "$(dirname "$0")/_az_helpers.sh"
 
 OUTPUT_FILE="agent_pools_issues.json"
 issues_json='[]'
@@ -28,43 +30,17 @@ echo "Analyzing Azure DevOps Agent Pools..."
 echo "Organization: $AZURE_DEVOPS_ORG"
 echo "High Utilization Threshold: ${HIGH_UTILIZATION_THRESHOLD}%"
 
-# Ensure Azure CLI is logged in and DevOps extension is installed
-if ! az extension show --name azure-devops &>/dev/null; then
-    echo "Installing Azure DevOps CLI extension..."
-    az extension add --name azure-devops --output none
-fi
-
-# Configure Azure DevOps CLI defaults
-az devops configure --defaults organization="$ORG_URL" --output none
-
-# Setup authentication
-if [ "$AUTH_TYPE" = "service_principal" ]; then
-    echo "Using service principal authentication..."
-    # Service principal authentication is handled by Azure CLI login
-elif [ "$AUTH_TYPE" = "pat" ]; then
-    if [ -z "${AZURE_DEVOPS_PAT:-}" ]; then
-        echo "ERROR: AZURE_DEVOPS_PAT must be set when AUTH_TYPE=pat"
-        exit 1
-    fi
-    echo "Using PAT authentication..."
-    echo "$AZURE_DEVOPS_PAT" | az devops login --organization "$ORG_URL"
-else
-    echo "ERROR: Invalid AUTH_TYPE. Must be 'service_principal' or 'pat'"
-    exit 1
-fi
+setup_azure_auth
 
 # Get list of agent pools
 echo "Retrieving agent pools in organization..."
-if ! pools=$(az pipelines pool list --org "$ORG_URL" --output json 2>pools_err.log); then
-    err_msg=$(cat pools_err.log)
-    rm -f pools_err.log
-    
+if ! az_with_retry az pipelines pool list --org "$ORG_URL" --output json; then
     echo "ERROR: Could not list agent pools."
     issues_json=$(echo "$issues_json" | jq \
         --arg title "Failed to List Agent Pools" \
-        --arg details "$err_msg" \
+        --arg details "Azure DevOps API was unreachable or returned an error after $AZ_RETRY_COUNT retry attempts." \
         --arg severity "3" \
-        --arg nextStep "Check if you have sufficient permissions to view agent pools." \
+        --arg nextStep "Check if you have sufficient permissions to view agent pools. Verify Azure DevOps API availability and network connectivity." \
         '. += [{
            "title": $title,
            "details": $details,
@@ -74,7 +50,7 @@ if ! pools=$(az pipelines pool list --org "$ORG_URL" --output json 2>pools_err.l
     echo "$issues_json" > "$OUTPUT_FILE"
     exit 1
 fi
-rm -f pools_err.log
+pools="$AZ_RESULT"
 
 # Save pools to a file to avoid subshell issues
 echo "$pools" > pools.json
@@ -101,16 +77,12 @@ for ((i=0; i<pool_count; i++)); do
     fi
     
     # Get agents in the pool
-    if ! agents=$(az pipelines agent list --pool-id "$pool_id" --org "$ORG_URL" --output json 2>agents_err.log); then
-        err_msg=$(cat agents_err.log)
-        rm -f agents_err.log
-        
-        # Failed to list agents in pool
+    if ! az_with_retry az pipelines agent list --pool-id "$pool_id" --org "$ORG_URL" --output json; then
         issues_json=$(echo "$issues_json" | jq \
             --arg title "Failed to List Agents in Pool \`$pool_name\`" \
-            --arg details "$err_msg" \
+            --arg details "Could not retrieve agents after $AZ_RETRY_COUNT attempts. API may be unreachable or permissions insufficient." \
             --arg severity "3" \
-            --arg nextStep "Check if you have sufficient permissions to view agents in this pool." \
+            --arg nextStep "Check if you have sufficient permissions to view agents in this pool. Verify Azure DevOps API availability." \
             '. += [{
                "title": $title,
                "details": $details,
@@ -119,7 +91,7 @@ for ((i=0; i<pool_count; i++)); do
              }]')
         continue
     fi
-    rm -f agents_err.log
+    agents="$AZ_RESULT"
     
     # Check if pool has no agents
     agent_count=$(echo "$agents" | jq '. | length')

--- a/codebundles/azure-devops-project-health/discover-projects.sh
+++ b/codebundles/azure-devops-project-health/discover-projects.sh
@@ -18,51 +18,24 @@ set -euo pipefail
 AZURE_DEVOPS_PAT="${AZURE_DEVOPS_PAT:-$azure_devops_pat}"
 export AZURE_DEVOPS_EXT_PAT="${AZURE_DEVOPS_PAT}"
 
+source "$(dirname "$0")/_az_helpers.sh"
+
 OUTPUT_FILE="discovered_projects.json"
 ORG_URL="https://dev.azure.com/$AZURE_DEVOPS_ORG"
 
 echo "Discovering Azure DevOps Projects..."
 echo "Organization: $AZURE_DEVOPS_ORG"
 
-# Ensure Azure CLI is logged in and DevOps extension is installed
-if ! az extension show --name azure-devops &>/dev/null; then
-    echo "Installing Azure DevOps CLI extension..."
-    az extension add --name azure-devops --output none
-fi
-
-# Configure Azure DevOps CLI defaults
-az devops configure --defaults organization="$ORG_URL" --output none
-
-# Setup authentication
-if [ "$AUTH_TYPE" = "service_principal" ]; then
-    echo "Using service principal authentication..."
-    # Service principal authentication is handled by Azure CLI login
-elif [ "$AUTH_TYPE" = "pat" ]; then
-    if [ -z "${AZURE_DEVOPS_PAT:-}" ]; then
-        echo "ERROR: AZURE_DEVOPS_PAT must be set when AUTH_TYPE=pat"
-        exit 1
-    fi
-    echo "Using PAT authentication..."
-    echo "$AZURE_DEVOPS_PAT" | az devops login --organization "$ORG_URL"
-else
-    echo "ERROR: Invalid AUTH_TYPE. Must be 'service_principal' or 'pat'"
-    exit 1
-fi
+setup_azure_auth
 
 # Get list of projects
 echo "Retrieving all projects in organization..."
-if ! projects_json=$(az devops project list --org "$ORG_URL" --output json 2>projects_err.log); then
-    err_msg=$(cat projects_err.log)
-    rm -f projects_err.log
-    
-    echo "ERROR: Could not list projects."
-    echo "Error details: $err_msg"
-    
-    # Create empty JSON array as fallback
+if ! az_with_retry az devops project list --org "$ORG_URL" --output json; then
+    echo "ERROR: Could not list projects after $AZ_RETRY_COUNT retry attempts."
     echo '[]' > "$OUTPUT_FILE"
     exit 1
 fi
-rm -f projects_err.log
+projects_json="$AZ_RESULT"
 
 # Extract the project data (Azure CLI returns {value: [projects]})
 projects_array=$(echo "$projects_json" | jq '.value // .')

--- a/codebundles/azure-devops-project-health/long-running-pipelines.sh
+++ b/codebundles/azure-devops-project-health/long-running-pipelines.sh
@@ -22,6 +22,8 @@ set -x
 AZURE_DEVOPS_PAT="${AZURE_DEVOPS_PAT:-$azure_devops_pat}"
 export AZURE_DEVOPS_EXT_PAT="${AZURE_DEVOPS_PAT}"
 
+source "$(dirname "$0")/_az_helpers.sh"
+
 OUTPUT_FILE="long_running_pipelines.json"
 issues_json='[]'
 
@@ -52,43 +54,18 @@ echo "Organization: $AZURE_DEVOPS_ORG"
 echo "Project:      $AZURE_DEVOPS_PROJECT"
 echo "Threshold:    $THRESHOLD_MINUTES minutes"
 
-# Ensure Azure CLI is logged in and DevOps extension is installed
-if ! az extension show --name azure-devops &>/dev/null; then
-    echo "Installing Azure DevOps CLI extension..."
-    az extension add --name azure-devops --output none
-fi
-
-# Configure Azure DevOps CLI defaults
-az devops configure --defaults organization="https://dev.azure.com/$AZURE_DEVOPS_ORG" project="$AZURE_DEVOPS_PROJECT" --output none
-
-# Setup authentication
-if [ "$AUTH_TYPE" = "service_principal" ]; then
-    echo "Using service principal authentication..."
-    # Service principal authentication is handled by Azure CLI login
-elif [ "$AUTH_TYPE" = "pat" ]; then
-    if [ -z "${AZURE_DEVOPS_PAT:-}" ]; then
-        echo "ERROR: AZURE_DEVOPS_PAT must be set when AUTH_TYPE=pat"
-        exit 1
-    fi
-    echo "Using PAT authentication..."
-    echo "$AZURE_DEVOPS_PAT" | az devops login --organization "https://dev.azure.com/$AZURE_DEVOPS_ORG"
-else
-    echo "ERROR: Invalid AUTH_TYPE. Must be 'service_principal' or 'pat'"
-    exit 1
-fi
+az devops configure --defaults project="$AZURE_DEVOPS_PROJECT" --output none
+setup_azure_auth
 
 # Get list of pipelines
 echo "Retrieving pipelines in project..."
-if ! pipelines=$(az pipelines list --output json 2>pipelines_err.log); then
-    err_msg=$(cat pipelines_err.log)
-    rm -f pipelines_err.log
-    
+if ! az_with_retry az pipelines list --output json; then
     echo "ERROR: Could not list pipelines."
     issues_json=$(echo "$issues_json" | jq \
         --arg title "Failed to List Pipelines" \
-        --arg details "$err_msg" \
+        --arg details "Azure DevOps API was unreachable or returned an error after $AZ_RETRY_COUNT retry attempts." \
         --arg severity "3" \
-        --arg nextStep "Check if the project exists and you have the right permissions." \
+        --arg nextStep "Check if the project exists and you have the right permissions. Verify Azure DevOps API availability." \
         '. += [{
            "title": $title,
            "details": $details,
@@ -98,7 +75,7 @@ if ! pipelines=$(az pipelines list --output json 2>pipelines_err.log); then
     echo "$issues_json" > "$OUTPUT_FILE"
     exit 1
 fi
-rm -f pipelines_err.log
+pipelines="$AZ_RESULT"
 
 # Save pipelines to a file to avoid subshell issues
 echo "$pipelines" > pipelines.json
@@ -120,15 +97,12 @@ for ((i=0; i<pipeline_count; i++)); do
     # from_date=$(date -d "$DAYS_TO_LOOK_BACK days ago" -u +"%Y-%m-%dT%H:%M:%SZ")
     
     # Get recent pipeline runs
-    if ! runs=$(az pipelines runs list --pipeline-id "$pipeline_id" --output json 2>runs_err.log); then
-        err_msg=$(cat runs_err.log)
-        rm -f runs_err.log
-        
+    if ! az_with_retry az pipelines runs list --pipeline-id "$pipeline_id" --output json; then
         issues_json=$(echo "$issues_json" | jq \
             --arg title "Failed to List Runs for Pipeline $pipeline_name" \
-            --arg details "$err_msg" \
+            --arg details "Could not retrieve runs after $AZ_RETRY_COUNT attempts." \
             --arg severity "3" \
-            --arg nextStep "Check if you have sufficient permissions to view pipeline runs." \
+            --arg nextStep "Check if you have sufficient permissions to view pipeline runs. Verify Azure DevOps API availability." \
             '. += [{
                "title": $title,
                "details": $details,
@@ -137,7 +111,7 @@ for ((i=0; i<pipeline_count; i++)); do
              }]')
         continue
     fi
-    rm -f runs_err.log
+    runs="$AZ_RESULT"
     
     # Save runs to a file to avoid subshell issues
     echo "$runs" > runs.json

--- a/codebundles/azure-devops-project-health/pipeline-failure-investigation.sh
+++ b/codebundles/azure-devops-project-health/pipeline-failure-investigation.sh
@@ -19,6 +19,8 @@ set -x
 AZURE_DEVOPS_PAT="${AZURE_DEVOPS_PAT:-$azure_devops_pat}"
 export AZURE_DEVOPS_EXT_PAT="${AZURE_DEVOPS_PAT}"
 
+source "$(dirname "$0")/_az_helpers.sh"
+
 OUTPUT_FILE="pipeline_failure_investigation.json"
 investigation_json='[]'
 
@@ -26,36 +28,18 @@ echo "Deep Pipeline Failure Investigation..."
 echo "Organization: $AZURE_DEVOPS_ORG"
 echo "Project:      $AZURE_DEVOPS_PROJECT"
 
-# Ensure Azure CLI is logged in and DevOps extension is installed
-if ! az extension show --name azure-devops &>/dev/null; then
-    echo "Installing Azure DevOps CLI extension..."
-    az extension add --name azure-devops --output none
-fi
-
-# Configure Azure DevOps CLI defaults
-az devops configure --defaults organization="https://dev.azure.com/$AZURE_DEVOPS_ORG" project="$AZURE_DEVOPS_PROJECT" --output none
-
-# Setup authentication for PAT if needed
-if [ "${AUTH_TYPE:-service_principal}" = "pat" ]; then
-    if [ -z "${AZURE_DEVOPS_PAT:-}" ]; then
-        echo "ERROR: AZURE_DEVOPS_PAT must be set when AUTH_TYPE=pat"
-        exit 1
-    fi
-    echo "$AZURE_DEVOPS_PAT" | az devops login --organization "https://dev.azure.com/$AZURE_DEVOPS_ORG"
-fi
+az devops configure --defaults project="$AZURE_DEVOPS_PROJECT" --output none
+setup_azure_auth
 
 # Get failed pipeline runs from last 24 hours
 echo "Getting failed pipeline runs from last 24 hours..."
 from_date=$(date -d "24 hours ago" -u +"%Y-%m-%dT%H:%M:%SZ")
 
-if ! failed_runs=$(az pipelines runs list --query "[?result=='failed' && finishTime >= '$from_date']" --output json 2>failed_runs_err.log); then
-    err_msg=$(cat failed_runs_err.log)
-    rm -f failed_runs_err.log
-    
+if ! az_with_retry az pipelines runs list --query "[?result=='failed' && finishTime >= '$from_date']" --output json; then
     echo "ERROR: Could not get failed pipeline runs."
     investigation_json=$(echo "$investigation_json" | jq \
         --arg title "Failed to Get Pipeline Runs" \
-        --arg details "$err_msg" \
+        --arg details "Azure DevOps API was unreachable or returned an error after $AZ_RETRY_COUNT retry attempts." \
         --arg severity "3" \
         '. += [{
            "title": $title,
@@ -65,7 +49,7 @@ if ! failed_runs=$(az pipelines runs list --query "[?result=='failed' && finishT
     echo "$investigation_json" > "$OUTPUT_FILE"
     exit 1
 fi
-rm -f failed_runs_err.log
+failed_runs="$AZ_RESULT"
 
 echo "$failed_runs" > failed_runs.json
 failed_count=$(jq '. | length' failed_runs.json)

--- a/codebundles/azure-devops-project-health/pipeline-logs.sh
+++ b/codebundles/azure-devops-project-health/pipeline-logs.sh
@@ -19,6 +19,8 @@ set -x
 AZURE_DEVOPS_PAT="${AZURE_DEVOPS_PAT:-$azure_devops_pat}"
 export AZURE_DEVOPS_EXT_PAT="${AZURE_DEVOPS_PAT}"
 
+source "$(dirname "$0")/_az_helpers.sh"
+
 OUTPUT_FILE="pipeline_logs_issues.json"
 TEMP_LOG_FILE="pipeline_log_temp.json"
 issues_json='[]'
@@ -27,43 +29,18 @@ echo "Analyzing Azure DevOps Pipeline Logs..."
 echo "Organization: $AZURE_DEVOPS_ORG"
 echo "Project:      $AZURE_DEVOPS_PROJECT"
 
-# Ensure Azure CLI is logged in and DevOps extension is installed
-if ! az extension show --name azure-devops &>/dev/null; then
-    echo "Installing Azure DevOps CLI extension..."
-    az extension add --name azure-devops --output none
-fi
-
-# Configure Azure DevOps CLI defaults
-az devops configure --defaults organization="https://dev.azure.com/$AZURE_DEVOPS_ORG" project="$AZURE_DEVOPS_PROJECT" --output none
-
-# Setup authentication
-if [ "$AUTH_TYPE" = "service_principal" ]; then
-    echo "Using service principal authentication..."
-    # Service principal authentication is handled by Azure CLI login
-elif [ "$AUTH_TYPE" = "pat" ]; then
-    if [ -z "${AZURE_DEVOPS_PAT:-}" ]; then
-        echo "ERROR: AZURE_DEVOPS_PAT must be set when AUTH_TYPE=pat"
-        exit 1
-    fi
-    echo "Using PAT authentication..."
-    echo "$AZURE_DEVOPS_PAT" | az devops login --organization "https://dev.azure.com/$AZURE_DEVOPS_ORG"
-else
-    echo "ERROR: Invalid AUTH_TYPE. Must be 'service_principal' or 'pat'"
-    exit 1
-fi
+az devops configure --defaults project="$AZURE_DEVOPS_PROJECT" --output none
+setup_azure_auth
 
 # Get list of pipelines
 echo "Retrieving pipelines in project..."
-if ! pipelines=$(az pipelines list --output json 2>pipelines_err.log); then
-    err_msg=$(cat pipelines_err.log)
-    rm -f pipelines_err.log
-    
+if ! az_with_retry az pipelines list --output json; then
     echo "ERROR: Could not list pipelines."
     issues_json=$(echo "$issues_json" | jq \
         --arg title "Failed to List Pipelines" \
-        --arg details "$err_msg" \
+        --arg details "Azure DevOps API was unreachable or returned an error after $AZ_RETRY_COUNT retry attempts." \
         --arg severity "3" \
-        --arg nextStep "Check if the project exists and you have the right permissions." \
+        --arg nextStep "Check if the project exists and you have the right permissions. Verify Azure DevOps API availability." \
         '. += [{
            "title": $title,
            "details": $details,
@@ -73,7 +50,7 @@ if ! pipelines=$(az pipelines list --output json 2>pipelines_err.log); then
     echo "$issues_json" > "$OUTPUT_FILE"
     exit 1
 fi
-rm -f pipelines_err.log
+pipelines="$AZ_RESULT"
 
 # Save pipelines to a file to avoid subshell issues
 echo "$pipelines" > pipelines.json
@@ -92,15 +69,12 @@ for ((i=0; i<pipeline_count; i++)); do
     echo "Processing Pipeline: $pipeline_name (ID: $pipeline_id)"
     
     # Get recent pipeline runs
-    if ! runs=$(az pipelines runs list --pipeline-id "$pipeline_id" --output json 2>runs_err.log); then
-        err_msg=$(cat runs_err.log)
-        rm -f runs_err.log
-        
+    if ! az_with_retry az pipelines runs list --pipeline-id "$pipeline_id" --output json; then
         issues_json=$(echo "$issues_json" | jq \
             --arg title "Failed to List Runs for Pipeline $pipeline_name" \
-            --arg details "$err_msg" \
+            --arg details "Could not retrieve runs after $AZ_RETRY_COUNT attempts." \
             --arg severity "3" \
-            --arg nextStep "Check if you have sufficient permissions to view pipeline runs." \
+            --arg nextStep "Check if you have sufficient permissions to view pipeline runs. Verify Azure DevOps API availability." \
             '. += [{
                "title": $title,
                "details": $details,
@@ -109,7 +83,7 @@ for ((i=0; i<pipeline_count; i++)); do
              }]')
         continue
     fi
-    rm -f runs_err.log
+    runs="$AZ_RESULT"
     
     # Save runs to a file to avoid subshell issues
     echo "$runs" > runs.json

--- a/codebundles/azure-devops-project-health/pipeline-performance-analysis.sh
+++ b/codebundles/azure-devops-project-health/pipeline-performance-analysis.sh
@@ -19,6 +19,8 @@ set -x
 AZURE_DEVOPS_PAT="${AZURE_DEVOPS_PAT:-$azure_devops_pat}"
 export AZURE_DEVOPS_EXT_PAT="${AZURE_DEVOPS_PAT}"
 
+source "$(dirname "$0")/_az_helpers.sh"
+
 OUTPUT_FILE="pipeline_performance_analysis.json"
 analysis_json='[]'
 
@@ -26,34 +28,16 @@ echo "Pipeline Performance Analysis..."
 echo "Organization: $AZURE_DEVOPS_ORG"
 echo "Project:      $AZURE_DEVOPS_PROJECT"
 
-# Ensure Azure CLI is logged in and DevOps extension is installed
-if ! az extension show --name azure-devops &>/dev/null; then
-    echo "Installing Azure DevOps CLI extension..."
-    az extension add --name azure-devops --output none
-fi
-
-# Configure Azure DevOps CLI defaults
-az devops configure --defaults organization="https://dev.azure.com/$AZURE_DEVOPS_ORG" project="$AZURE_DEVOPS_PROJECT" --output none
-
-# Setup authentication for PAT if needed
-if [ "${AUTH_TYPE:-service_principal}" = "pat" ]; then
-    if [ -z "${AZURE_DEVOPS_PAT:-}" ]; then
-        echo "ERROR: AZURE_DEVOPS_PAT must be set when AUTH_TYPE=pat"
-        exit 1
-    fi
-    echo "$AZURE_DEVOPS_PAT" | az devops login --organization "https://dev.azure.com/$AZURE_DEVOPS_ORG"
-fi
+az devops configure --defaults project="$AZURE_DEVOPS_PROJECT" --output none
+setup_azure_auth
 
 # Get list of pipelines
 echo "Getting pipelines in project..."
-if ! pipelines=$(az pipelines list --output json 2>pipelines_err.log); then
-    err_msg=$(cat pipelines_err.log)
-    rm -f pipelines_err.log
-    
+if ! az_with_retry az pipelines list --output json; then
     echo "ERROR: Could not list pipelines."
     analysis_json=$(echo "$analysis_json" | jq \
         --arg title "Failed to List Pipelines" \
-        --arg details "$err_msg" \
+        --arg details "Azure DevOps API was unreachable or returned an error after $AZ_RETRY_COUNT retry attempts." \
         --arg severity "3" \
         '. += [{
            "title": $title,
@@ -63,7 +47,7 @@ if ! pipelines=$(az pipelines list --output json 2>pipelines_err.log); then
     echo "$analysis_json" > "$OUTPUT_FILE"
     exit 1
 fi
-rm -f pipelines_err.log
+pipelines="$AZ_RESULT"
 
 echo "$pipelines" > pipelines.json
 pipeline_count=$(jq '. | length' pipelines.json)

--- a/codebundles/azure-devops-project-health/preflight-check.sh
+++ b/codebundles/azure-devops-project-health/preflight-check.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# Preflight check: validates identity, API connectivity, and per-scope access
+# for each project before the main health checks run.
+#
+# REQUIRED ENV VARS:
+#   AZURE_DEVOPS_ORG
+#   AZURE_DEVOPS_PROJECTS  - comma-separated project names to validate
+#
+# Outputs preflight_results.json with identity info and per-scope access results.
+
+: "${AZURE_DEVOPS_ORG:?Must set AZURE_DEVOPS_ORG}"
+: "${AZURE_DEVOPS_PROJECTS:?Must set AZURE_DEVOPS_PROJECTS}"
+: "${AUTH_TYPE:=service_principal}"
+AZURE_DEVOPS_PAT="${AZURE_DEVOPS_PAT:-$azure_devops_pat}"
+export AZURE_DEVOPS_EXT_PAT="${AZURE_DEVOPS_PAT}"
+
+source "$(dirname "$0")/_az_helpers.sh"
+
+OUTPUT_FILE="preflight_results.json"
+ORG_URL="https://dev.azure.com/$AZURE_DEVOPS_ORG"
+
+setup_azure_auth
+
+# --- Identity info ---
+echo "=== Identifying logged-in account ==="
+identity_json='{}'
+
+if account_info=$(az account show --output json 2>/dev/null); then
+    identity_name=$(echo "$account_info" | jq -r '.user.name // "unknown"')
+    identity_type=$(echo "$account_info" | jq -r '.user.type // "unknown"')
+    subscription=$(echo "$account_info" | jq -r '.name // "unknown"')
+    tenant_id=$(echo "$account_info" | jq -r '.tenantId // "unknown"')
+
+    identity_json=$(jq -n \
+        --arg name "$identity_name" \
+        --arg type "$identity_type" \
+        --arg subscription "$subscription" \
+        --arg tenant "$tenant_id" \
+        --arg auth_type "$AUTH_TYPE" \
+        '{name: $name, type: $type, subscription: $subscription, tenant: $tenant, auth_type: $auth_type}')
+
+    echo "  Identity: $identity_name ($identity_type)"
+    echo "  Auth:     $AUTH_TYPE"
+    echo "  Tenant:   $tenant_id"
+else
+    echo "  WARNING: Could not retrieve account info"
+    identity_json=$(jq -n --arg auth_type "$AUTH_TYPE" '{name: "unknown", type: "unknown", auth_type: $auth_type, error: "Could not retrieve account info"}')
+fi
+
+# --- Organization-level access ---
+echo ""
+echo "=== Testing organization-level access ==="
+org_access='{}'
+
+echo -n "  Agent pools: "
+if timeout 15 az pipelines pool list --org "$ORG_URL" --top 1 --output json &>/dev/null; then
+    echo "OK"
+    org_access=$(echo "$org_access" | jq '. + {agent_pools: "ok"}')
+else
+    echo "DENIED/FAILED"
+    org_access=$(echo "$org_access" | jq '. + {agent_pools: "denied_or_failed"}')
+fi
+
+# --- Per-project access checks ---
+echo ""
+echo "=== Testing per-project access ==="
+project_results='[]'
+
+IFS=',' read -ra PROJECTS <<< "$AZURE_DEVOPS_PROJECTS"
+for project in "${PROJECTS[@]}"; do
+    project=$(echo "$project" | xargs)  # trim whitespace
+    [ -z "$project" ] && continue
+
+    echo "  Project: $project"
+    proj_result=$(jq -n --arg name "$project" '{project: $name}')
+
+    # Project access
+    echo -n "    project show:         "
+    if timeout 15 az devops project show --project "$project" --org "$ORG_URL" --output json &>/dev/null; then
+        echo "OK"
+        proj_result=$(echo "$proj_result" | jq '. + {project_access: "ok"}')
+    else
+        echo "DENIED/FAILED"
+        proj_result=$(echo "$proj_result" | jq '. + {project_access: "denied_or_failed"}')
+    fi
+
+    # Pipelines read
+    echo -n "    pipelines list:       "
+    if timeout 15 az pipelines list --project "$project" --org "$ORG_URL" --top 1 --output json &>/dev/null; then
+        echo "OK"
+        proj_result=$(echo "$proj_result" | jq '. + {pipelines: "ok"}')
+    else
+        echo "DENIED/FAILED"
+        proj_result=$(echo "$proj_result" | jq '. + {pipelines: "denied_or_failed"}')
+    fi
+
+    # Pipeline runs read
+    echo -n "    pipeline runs list:   "
+    if timeout 15 az pipelines runs list --project "$project" --org "$ORG_URL" --top 1 --output json &>/dev/null; then
+        echo "OK"
+        proj_result=$(echo "$proj_result" | jq '. + {pipeline_runs: "ok"}')
+    else
+        echo "DENIED/FAILED"
+        proj_result=$(echo "$proj_result" | jq '. + {pipeline_runs: "denied_or_failed"}')
+    fi
+
+    # Repos read
+    echo -n "    repos list:           "
+    if timeout 15 az repos list --project "$project" --org "$ORG_URL" --top 1 --output json &>/dev/null; then
+        echo "OK"
+        proj_result=$(echo "$proj_result" | jq '. + {repos: "ok"}')
+    else
+        echo "DENIED/FAILED"
+        proj_result=$(echo "$proj_result" | jq '. + {repos: "denied_or_failed"}')
+    fi
+
+    # Service endpoints read
+    echo -n "    service endpoints:    "
+    if timeout 15 az devops service-endpoint list --project "$project" --org "$ORG_URL" --output json &>/dev/null; then
+        echo "OK"
+        proj_result=$(echo "$proj_result" | jq '. + {service_endpoints: "ok"}')
+    else
+        echo "DENIED/FAILED"
+        proj_result=$(echo "$proj_result" | jq '. + {service_endpoints: "denied_or_failed"}')
+    fi
+
+    # Repo policies read
+    echo -n "    repo policies:        "
+    if timeout 15 az repos policy list --project "$project" --org "$ORG_URL" --output json &>/dev/null; then
+        echo "OK"
+        proj_result=$(echo "$proj_result" | jq '. + {repo_policies: "ok"}')
+    else
+        echo "DENIED/FAILED"
+        proj_result=$(echo "$proj_result" | jq '. + {repo_policies: "denied_or_failed"}')
+    fi
+
+    project_results=$(echo "$project_results" | jq --argjson proj "$proj_result" '. += [$proj]')
+done
+
+# --- Build summary ---
+denied_count=$(echo "$project_results" | jq '[.[] | to_entries[] | select(.value == "denied_or_failed" and .key != "project")] | length')
+org_denied=$(echo "$org_access" | jq '[to_entries[] | select(.value == "denied_or_failed")] | length')
+total_denied=$((denied_count + org_denied))
+
+if [ "$total_denied" -gt 0 ]; then
+    summary="WARNING: $total_denied API scope(s) returned denied or failed. Some health checks may produce incomplete results."
+else
+    summary="All API scopes accessible. Preflight checks passed."
+fi
+
+# --- Write output ---
+result_json=$(jq -n \
+    --argjson identity "$identity_json" \
+    --argjson org_access "$org_access" \
+    --argjson projects "$project_results" \
+    --arg summary "$summary" \
+    --arg org "$AZURE_DEVOPS_ORG" \
+    '{
+        organization: $org,
+        identity: $identity,
+        org_level_access: $org_access,
+        project_access: $projects,
+        summary: $summary
+    }')
+
+echo "$result_json" > "$OUTPUT_FILE"
+
+echo ""
+echo "=== Preflight Summary ==="
+echo "$summary"
+echo "Results saved to $OUTPUT_FILE"

--- a/codebundles/azure-devops-project-health/queued-pipelines.sh
+++ b/codebundles/azure-devops-project-health/queued-pipelines.sh
@@ -21,6 +21,8 @@ set -x
 AZURE_DEVOPS_PAT="${AZURE_DEVOPS_PAT:-$azure_devops_pat}"
 export AZURE_DEVOPS_EXT_PAT="${AZURE_DEVOPS_PAT}"
 
+source "$(dirname "$0")/_az_helpers.sh"
+
 OUTPUT_FILE="queued_pipelines.json"
 issues_json='[]'
 
@@ -51,43 +53,18 @@ echo "Organization: $AZURE_DEVOPS_ORG"
 echo "Project:      $AZURE_DEVOPS_PROJECT"
 echo "Threshold:    $THRESHOLD_MINUTES minutes"
 
-# Ensure Azure CLI is logged in and DevOps extension is installed
-if ! az extension show --name azure-devops &>/dev/null; then
-    echo "Installing Azure DevOps CLI extension..."
-    az extension add --name azure-devops --output none
-fi
-
-# Configure Azure DevOps CLI defaults
-az devops configure --defaults organization="https://dev.azure.com/$AZURE_DEVOPS_ORG" project="$AZURE_DEVOPS_PROJECT" --output none
-
-# Setup authentication
-if [ "$AUTH_TYPE" = "service_principal" ]; then
-    echo "Using service principal authentication..."
-    # Service principal authentication is handled by Azure CLI login
-elif [ "$AUTH_TYPE" = "pat" ]; then
-    if [ -z "${AZURE_DEVOPS_PAT:-}" ]; then
-        echo "ERROR: AZURE_DEVOPS_PAT must be set when AUTH_TYPE=pat"
-        exit 1
-    fi
-    echo "Using PAT authentication..."
-    echo "$AZURE_DEVOPS_PAT" | az devops login --organization "https://dev.azure.com/$AZURE_DEVOPS_ORG"
-else
-    echo "ERROR: Invalid AUTH_TYPE. Must be 'service_principal' or 'pat'"
-    exit 1
-fi
+az devops configure --defaults project="$AZURE_DEVOPS_PROJECT" --output none
+setup_azure_auth
 
 # Get list of pipelines
 echo "Retrieving pipelines in project..."
-if ! pipelines=$(az pipelines list --output json 2>pipelines_err.log); then
-    err_msg=$(cat pipelines_err.log)
-    rm -f pipelines_err.log
-    
+if ! az_with_retry az pipelines list --output json; then
     echo "ERROR: Could not list pipelines."
     issues_json=$(echo "$issues_json" | jq \
         --arg title "Failed to List Pipelines" \
-        --arg details "$err_msg" \
+        --arg details "Azure DevOps API was unreachable or returned an error after $AZ_RETRY_COUNT retry attempts." \
         --arg severity "3" \
-        --arg nextStep "Check if the project exists and you have the right permissions." \
+        --arg nextStep "Check if the project exists and you have the right permissions. Verify Azure DevOps API availability." \
         '. += [{
            "title": $title,
            "details": $details,
@@ -97,7 +74,7 @@ if ! pipelines=$(az pipelines list --output json 2>pipelines_err.log); then
     echo "$issues_json" > "$OUTPUT_FILE"
     exit 1
 fi
-rm -f pipelines_err.log
+pipelines="$AZ_RESULT"
 
 # Save pipelines to a file to avoid subshell issues
 echo "$pipelines" > pipelines.json
@@ -116,15 +93,12 @@ for ((i=0; i<pipeline_count; i++)); do
     echo "Processing Pipeline: $pipeline_name (ID: $pipeline_id)"
     
     # Get queued runs for this pipeline
-    if ! runs=$(az pipelines runs list --pipeline-id "$pipeline_id" --output json 2>runs_err.log); then
-        err_msg=$(cat runs_err.log)
-        rm -f runs_err.log
-        
+    if ! az_with_retry az pipelines runs list --pipeline-id "$pipeline_id" --output json; then
         issues_json=$(echo "$issues_json" | jq \
             --arg title "Failed to List Runs for Pipeline $pipeline_name" \
-            --arg details "$err_msg" \
+            --arg details "Could not retrieve runs after $AZ_RETRY_COUNT attempts." \
             --arg severity "3" \
-            --arg nextStep "Check if you have sufficient permissions to view pipeline runs." \
+            --arg nextStep "Check if you have sufficient permissions to view pipeline runs. Verify Azure DevOps API availability." \
             '. += [{
                "title": $title,
                "details": $details,
@@ -133,7 +107,7 @@ for ((i=0; i<pipeline_count; i++)); do
              }]')
         continue
     fi
-    rm -f runs_err.log
+    runs="$AZ_RESULT"
     
     # Save runs to a file to avoid subshell issues
     echo "$runs" > runs.json

--- a/codebundles/azure-devops-project-health/repo-policies.sh
+++ b/codebundles/azure-devops-project-health/repo-policies.sh
@@ -18,6 +18,8 @@
 AZURE_DEVOPS_PAT="${AZURE_DEVOPS_PAT:-$azure_devops_pat}"
 export AZURE_DEVOPS_EXT_PAT="${AZURE_DEVOPS_PAT}"
 
+source "$(dirname "$0")/_az_helpers.sh"
+
 OUTPUT_FILE="repo_policies_issues.json"
 issues_json='[]'
 ORG_URL="https://dev.azure.com/$AZURE_DEVOPS_ORG"
@@ -38,30 +40,7 @@ if [[ -n "$AZURE_DEVOPS_PROJECT" ]]; then
     echo "Project: $AZURE_DEVOPS_PROJECT"
 fi
 
-# Ensure Azure CLI is logged in and DevOps extension is installed
-if ! az extension show --name azure-devops &>/dev/null; then
-    echo "Installing Azure DevOps CLI extension..."
-    az extension add --name azure-devops --output none
-fi
-
-# Configure Azure DevOps CLI defaults
-az devops configure --defaults organization="$ORG_URL" --output none
-
-# Setup authentication
-if [ "$AUTH_TYPE" = "service_principal" ]; then
-    echo "Using service principal authentication..."
-    # Service principal authentication is handled by Azure CLI login
-elif [ "$AUTH_TYPE" = "pat" ]; then
-    if [ -z "${AZURE_DEVOPS_PAT:-}" ]; then
-        echo "ERROR: AZURE_DEVOPS_PAT must be set when AUTH_TYPE=pat"
-        exit 1
-    fi
-    echo "Using PAT authentication..."
-    echo "$AZURE_DEVOPS_PAT" | az devops login --organization "$ORG_URL"
-else
-    echo "ERROR: Invalid AUTH_TYPE. Must be 'service_principal' or 'pat'"
-    exit 1
-fi
+setup_azure_auth
 
 # Load policy standards
 if [[ -f "policy-standards.json" ]]; then
@@ -106,16 +85,13 @@ if [[ -n "$AZURE_DEVOPS_PROJECT" ]]; then
     projects_json="[{\"name\": \"$AZURE_DEVOPS_PROJECT\"}]"
 else
     echo "Retrieving all projects in organization..."
-    if ! projects_json=$(az devops project list --org "$ORG_URL" --output json 2>projects_err.log); then
-        err_msg=$(cat projects_err.log)
-        rm -f projects_err.log
-        
+    if ! az_with_retry az devops project list --org "$ORG_URL" --output json; then
         echo "ERROR: Could not list projects."
         issues_json=$(echo "$issues_json" | jq \
             --arg title "Failed to List Projects in Organization \`${AZURE_DEVOPS_ORG}\`" \
-            --arg details "$err_msg" \
+            --arg details "Azure DevOps API was unreachable or returned an error after $AZ_RETRY_COUNT retry attempts." \
             --arg severity "3" \
-            --arg nextStep "Check if you have sufficient permissions to view projects." \
+            --arg nextStep "Check if you have sufficient permissions to view projects. Verify Azure DevOps API availability." \
             '. += [{
                "title": $title,
                "details": $details,
@@ -125,8 +101,7 @@ else
         echo "$issues_json" > "$OUTPUT_FILE"
         exit 1
     fi
-    projects_json=$(echo "$projects_json" | jq '.value')
-    rm -f projects_err.log
+    projects_json=$(echo "$AZ_RESULT" | jq '.value')
 fi
 
 # Save projects to a file to avoid subshell issues
@@ -142,14 +117,11 @@ for ((p=0; p<project_count; p++)); do
     echo "Processing Project: $project_name"
     
     # Get repositories in the project
-    if ! repos_json=$(az repos list --project "$project_name" --org "$ORG_URL" --output json 2>repos_err.log); then
-        err_msg=$(cat repos_err.log)
-        rm -f repos_err.log
-        
+    if ! az_with_retry az repos list --project "$project_name" --org "$ORG_URL" --output json; then
         access_denied_repos+=("$project_name")
         continue
     fi
-    rm -f repos_err.log
+    repos_json="$AZ_RESULT"
     
     # Save repos to a file to avoid subshell issues
     echo "$repos_json" > repos.json
@@ -186,14 +158,11 @@ for ((p=0; p<project_count; p++)); do
         
         # Get branch policies for the default branch
         default_branch_id="refs/heads/$repo_default_branch"
-        if ! policies_json=$(az repos policy list --repository-id "$repo_id" --branch "$default_branch_id" --project "$project_name" --org "$ORG_URL" --output json 2>policies_err.log); then
-            err_msg=$(cat policies_err.log)
-            rm -f policies_err.log
-            
+        if ! az_with_retry az repos policy list --repository-id "$repo_id" --branch "$default_branch_id" --project "$project_name" --org "$ORG_URL" --output json; then
             access_denied_repos+=("$project_name/$repo_name")
             continue
         fi
-        rm -f policies_err.log
+        policies_json="$AZ_RESULT"
         
         # Check if default branch is locked
         if [[ $(echo "$policy_standards" | jq -r '.branchPolicies.defaultBranch.isLocked') == "true" ]]; then

--- a/codebundles/azure-devops-project-health/repository-health-analysis.sh
+++ b/codebundles/azure-devops-project-health/repository-health-analysis.sh
@@ -19,6 +19,8 @@ set -x
 AZURE_DEVOPS_PAT="${AZURE_DEVOPS_PAT:-$azure_devops_pat}"
 export AZURE_DEVOPS_EXT_PAT="${AZURE_DEVOPS_PAT}"
 
+source "$(dirname "$0")/_az_helpers.sh"
+
 OUTPUT_FILE="repository_health_analysis.json"
 analysis_json='[]'
 
@@ -26,34 +28,16 @@ echo "Repository Health Analysis..."
 echo "Organization: $AZURE_DEVOPS_ORG"
 echo "Project:      $AZURE_DEVOPS_PROJECT"
 
-# Ensure Azure CLI is logged in and DevOps extension is installed
-if ! az extension show --name azure-devops &>/dev/null; then
-    echo "Installing Azure DevOps CLI extension..."
-    az extension add --name azure-devops --output none
-fi
-
-# Configure Azure DevOps CLI defaults
-az devops configure --defaults organization="https://dev.azure.com/$AZURE_DEVOPS_ORG" project="$AZURE_DEVOPS_PROJECT" --output none
-
-# Setup authentication for PAT if needed
-if [ "${AUTH_TYPE:-service_principal}" = "pat" ]; then
-    if [ -z "${AZURE_DEVOPS_PAT:-}" ]; then
-        echo "ERROR: AZURE_DEVOPS_PAT must be set when AUTH_TYPE=pat"
-        exit 1
-    fi
-    echo "$AZURE_DEVOPS_PAT" | az devops login --organization "https://dev.azure.com/$AZURE_DEVOPS_ORG"
-fi
+az devops configure --defaults project="$AZURE_DEVOPS_PROJECT" --output none
+setup_azure_auth
 
 # Get list of repositories
 echo "Getting repositories in project..."
-if ! repos=$(az repos list --output json 2>repos_err.log); then
-    err_msg=$(cat repos_err.log)
-    rm -f repos_err.log
-    
+if ! az_with_retry az repos list --output json; then
     echo "ERROR: Could not list repositories."
     analysis_json=$(echo "$analysis_json" | jq \
         --arg title "Failed to List Repositories" \
-        --arg details "$err_msg" \
+        --arg details "Azure DevOps API was unreachable or returned an error after $AZ_RETRY_COUNT retry attempts." \
         --arg severity "3" \
         '. += [{
            "title": $title,
@@ -63,7 +47,7 @@ if ! repos=$(az repos list --output json 2>repos_err.log); then
     echo "$analysis_json" > "$OUTPUT_FILE"
     exit 1
 fi
-rm -f repos_err.log
+repos="$AZ_RESULT"
 
 echo "$repos" > repos.json
 repo_count=$(jq '. | length' repos.json)

--- a/codebundles/azure-devops-project-health/runbook.robot
+++ b/codebundles/azure-devops-project-health/runbook.robot
@@ -39,6 +39,14 @@ Check Agent Pool Availability Across Projects in `${AZURE_DEVOPS_ORG}`
     EXCEPT
         Log    Failed to load agent pool JSON payload, defaulting to empty list.    WARN
         ${issue_list}=    Create List
+        RW.Core.Add Issue
+        ...    severity=3
+        ...    expected=Agent pool data should be collected successfully from Azure DevOps API
+        ...    actual=Failed to collect agent pool data — the script likely timed out or the Azure DevOps API was unreachable
+        ...    title=Agent Pool Data Collection Failed for `${AZURE_DEVOPS_ORG}`
+        ...    reproduce_hint=${agent_pool.cmd}
+        ...    details=The agent-pools.sh script did not produce valid JSON output. This typically indicates the Azure DevOps API was unresponsive or the script exceeded its ${{'180'}}s timeout.\n\nPreflight access check: ${PREFLIGHT_SUMMARY}\n\nStdout: ${agent_pool.stdout}
+        ...    next_steps=Review the preflight access check results in the report for identity and permission details. Check Azure DevOps API availability for organization `${AZURE_DEVOPS_ORG}`. Verify network connectivity from the runner to dev.azure.com. Review Azure DevOps service health at https://status.dev.azure.com.
     END
 
     IF    len(@{issue_list}) > 0
@@ -93,6 +101,14 @@ Check for Failed Pipelines Across Projects in `${AZURE_DEVOPS_ORG}`
         EXCEPT
             Log    Failed to load JSON payload for project ${project}, defaulting to empty list.    WARN
             ${issue_list}=    Create List
+            RW.Core.Add Issue
+            ...    severity=3
+            ...    expected=Pipeline failure data should be collected successfully from Azure DevOps API for project `${project}`
+            ...    actual=Failed to collect pipeline failure data — the script likely timed out or the Azure DevOps API was unreachable
+            ...    title=Pipeline Data Collection Failed for Project `${project}` in `${AZURE_DEVOPS_ORG}`
+            ...    reproduce_hint=${failed_pipelines.cmd}
+            ...    details=The pipeline-logs.sh script did not produce valid JSON output for project ${project}. This typically indicates the Azure DevOps API was unresponsive or the script exceeded its timeout.\n\nPreflight access check: ${PREFLIGHT_SUMMARY}\n\nStdout: ${failed_pipelines.stdout}
+            ...    next_steps=Review the preflight access check results in the report for identity and permission details. Check Azure DevOps API availability for organization `${AZURE_DEVOPS_ORG}`. Verify network connectivity from the runner to dev.azure.com.
         END
         
         IF    len(@{issue_list}) > 0
@@ -135,6 +151,14 @@ Check for Long-Running Pipelines Across Projects in `${AZURE_DEVOPS_ORG}` (Thres
         EXCEPT
             Log    Failed to load JSON payload for project ${project}, defaulting to empty list.    WARN
             ${issue_list}=    Create List
+            RW.Core.Add Issue
+            ...    severity=3
+            ...    expected=Long-running pipeline data should be collected successfully from Azure DevOps API for project `${project}`
+            ...    actual=Failed to collect long-running pipeline data — the script likely timed out or the Azure DevOps API was unreachable
+            ...    title=Long-Running Pipeline Data Collection Failed for Project `${project}` in `${AZURE_DEVOPS_ORG}`
+            ...    reproduce_hint=${long_running.cmd}
+            ...    details=The long-running-pipelines.sh script did not produce valid JSON output for project ${project}. This typically indicates the Azure DevOps API was unresponsive or the script exceeded its timeout.\n\nPreflight access check: ${PREFLIGHT_SUMMARY}\n\nStdout: ${long_running.stdout}
+            ...    next_steps=Review the preflight access check results in the report for identity and permission details. Check Azure DevOps API availability for organization `${AZURE_DEVOPS_ORG}`. Verify network connectivity from the runner to dev.azure.com.
         END
         
         IF    len(@{issue_list}) > 0
@@ -177,6 +201,14 @@ Check for Queued Pipelines Across Projects in `${AZURE_DEVOPS_ORG}` (Threshold: 
         EXCEPT
             Log    Failed to load JSON payload for project ${project}, defaulting to empty list.    WARN
             ${issue_list}=    Create List
+            RW.Core.Add Issue
+            ...    severity=3
+            ...    expected=Queued pipeline data should be collected successfully from Azure DevOps API for project `${project}`
+            ...    actual=Failed to collect queued pipeline data — the script likely timed out or the Azure DevOps API was unreachable
+            ...    title=Queued Pipeline Data Collection Failed for Project `${project}` in `${AZURE_DEVOPS_ORG}`
+            ...    reproduce_hint=${queued_pipelines.cmd}
+            ...    details=The queued-pipelines.sh script did not produce valid JSON output for project ${project}. This typically indicates the Azure DevOps API was unresponsive or the script exceeded its timeout.\n\nPreflight access check: ${PREFLIGHT_SUMMARY}\n\nStdout: ${queued_pipelines.stdout}
+            ...    next_steps=Review the preflight access check results in the report for identity and permission details. Check Azure DevOps API availability for organization `${AZURE_DEVOPS_ORG}`. Verify network connectivity from the runner to dev.azure.com.
         END
         
         IF    len(@{issue_list}) > 0
@@ -219,6 +251,14 @@ Check Repository Branch Policies Across Projects in `${AZURE_DEVOPS_ORG}`
         EXCEPT
             Log    Failed to load JSON payload for project ${project}, defaulting to empty list.    WARN
             ${issue_list}=    Create List
+            RW.Core.Add Issue
+            ...    severity=3
+            ...    expected=Repository policy data should be collected successfully from Azure DevOps API for project `${project}`
+            ...    actual=Failed to collect repository policy data — the script likely timed out or the Azure DevOps API was unreachable
+            ...    title=Repository Policy Data Collection Failed for Project `${project}` in `${AZURE_DEVOPS_ORG}`
+            ...    reproduce_hint=${repo_policies.cmd}
+            ...    details=The repo-policies.sh script did not produce valid JSON output for project ${project}. This typically indicates the Azure DevOps API was unresponsive or the script exceeded its timeout.\n\nPreflight access check: ${PREFLIGHT_SUMMARY}\n\nStdout: ${repo_policies.stdout}
+            ...    next_steps=Review the preflight access check results in the report for identity and permission details. Check Azure DevOps API availability for organization `${AZURE_DEVOPS_ORG}`. Verify network connectivity from the runner to dev.azure.com.
         END
         
         IF    len(@{issue_list}) > 0
@@ -260,6 +300,14 @@ Check Service Connection Health Across Projects in `${AZURE_DEVOPS_ORG}`
         EXCEPT
             Log    Failed to load JSON payload for project ${project}, defaulting to empty list.    WARN
             ${issue_list}=    Create List
+            RW.Core.Add Issue
+            ...    severity=3
+            ...    expected=Service connection data should be collected successfully from Azure DevOps API for project `${project}`
+            ...    actual=Failed to collect service connection data — the script likely timed out or the Azure DevOps API was unreachable
+            ...    title=Service Connection Data Collection Failed for Project `${project}` in `${AZURE_DEVOPS_ORG}`
+            ...    reproduce_hint=${service_connections.cmd}
+            ...    details=The service-connections.sh script did not produce valid JSON output for project ${project}. This typically indicates the Azure DevOps API was unresponsive or the script exceeded its timeout.\n\nPreflight access check: ${PREFLIGHT_SUMMARY}\n\nStdout: ${service_connections.stdout}
+            ...    next_steps=Review the preflight access check results in the report for identity and permission details. Check Azure DevOps API availability for organization `${AZURE_DEVOPS_ORG}`. Verify network connectivity from the runner to dev.azure.com.
         END
         
         IF    len(@{issue_list}) > 0
@@ -300,6 +348,14 @@ Investigate Pipeline Performance Issues Across Projects in `${AZURE_DEVOPS_ORG}`
         EXCEPT
             Log    Failed to load JSON payload for project ${project}, defaulting to empty list.    WARN
             ${issue_list}=    Create List
+            RW.Core.Add Issue
+            ...    severity=3
+            ...    expected=Pipeline performance data should be collected successfully from Azure DevOps API for project `${project}`
+            ...    actual=Failed to collect pipeline performance data — the script likely timed out or the Azure DevOps API was unreachable
+            ...    title=Pipeline Performance Data Collection Failed for Project `${project}` in `${AZURE_DEVOPS_ORG}`
+            ...    reproduce_hint=${performance_analysis.cmd}
+            ...    details=The pipeline-performance-analysis.sh script did not produce valid JSON output for project ${project}. This typically indicates the Azure DevOps API was unresponsive or the script exceeded its timeout.\n\nPreflight access check: ${PREFLIGHT_SUMMARY}\n\nStdout: ${performance_analysis.stdout}
+            ...    next_steps=Review the preflight access check results in the report for identity and permission details. Check Azure DevOps API availability for organization `${AZURE_DEVOPS_ORG}`. Verify network connectivity from the runner to dev.azure.com.
         END
         
         IF    len(@{issue_list}) > 0
@@ -343,6 +399,14 @@ Investigate Failed Pipeline Runs with Commit Correlation Across Projects in `${A
         EXCEPT
             Log    Failed to load JSON payload for project ${project}, defaulting to empty list.    WARN
             ${issue_list}=    Create List
+            RW.Core.Add Issue
+            ...    severity=3
+            ...    expected=Pipeline failure investigation data should be collected successfully from Azure DevOps API for project `${project}`
+            ...    actual=Failed to collect pipeline failure investigation data — the script likely timed out or the Azure DevOps API was unreachable
+            ...    title=Pipeline Failure Investigation Data Collection Failed for Project `${project}` in `${AZURE_DEVOPS_ORG}`
+            ...    reproduce_hint=${failure_investigation.cmd}
+            ...    details=The pipeline-failure-investigation.sh script did not produce valid JSON output for project ${project}. This typically indicates the Azure DevOps API was unresponsive or the script exceeded its timeout.\n\nPreflight access check: ${PREFLIGHT_SUMMARY}\n\nStdout: ${failure_investigation.stdout}
+            ...    next_steps=Review the preflight access check results in the report for identity and permission details. Check Azure DevOps API availability for organization `${AZURE_DEVOPS_ORG}`. Verify network connectivity from the runner to dev.azure.com.
         END
         
         IF    len(@{issue_list}) > 0
@@ -386,6 +450,14 @@ Analyze Recent Repository Activity Across Projects in `${AZURE_DEVOPS_ORG}`
         EXCEPT
             Log    Failed to load JSON payload for project ${project}, defaulting to empty list.    WARN
             ${issue_list}=    Create List
+            RW.Core.Add Issue
+            ...    severity=3
+            ...    expected=Repository health data should be collected successfully from Azure DevOps API for project `${project}`
+            ...    actual=Failed to collect repository health data — the script likely timed out or the Azure DevOps API was unreachable
+            ...    title=Repository Health Data Collection Failed for Project `${project}` in `${AZURE_DEVOPS_ORG}`
+            ...    reproduce_hint=${repo_activity.cmd}
+            ...    details=The repository-health-analysis.sh script did not produce valid JSON output for project ${project}. This typically indicates the Azure DevOps API was unresponsive or the script exceeded its timeout.\n\nPreflight access check: ${PREFLIGHT_SUMMARY}\n\nStdout: ${repo_activity.stdout}
+            ...    next_steps=Review the preflight access check results in the report for identity and permission details. Check Azure DevOps API availability for organization `${AZURE_DEVOPS_ORG}`. Verify network connectivity from the runner to dev.azure.com.
         END
         
         IF    len(@{issue_list}) > 0
@@ -516,6 +588,40 @@ Suite Initialization
     ...    AUTH_TYPE=${AUTH_TYPE}
     ...    AZURE_CONFIG_DIR=${AZURE_DEVOPS_CONFIG_DIR}
     Set Suite Variable    ${env}    ${env_dict}
+
+    # Preflight check: validate identity, API connectivity, and per-scope access
+    Log    Running preflight access checks...    INFO
+    ${projects_csv}=    Evaluate    ",".join($PROJECT_LIST)
+    ${preflight_env}=    Create Dictionary
+    ...    AZURE_DEVOPS_ORG=${AZURE_DEVOPS_ORG}
+    ...    AZURE_DEVOPS_PROJECTS=${projects_csv}
+    ...    AUTH_TYPE=${AUTH_TYPE}
+    ...    AZURE_CONFIG_DIR=${AZURE_DEVOPS_CONFIG_DIR}
+    ${preflight}=    RW.CLI.Run Bash File
+    ...    bash_file=preflight-check.sh
+    ...    env=${preflight_env}
+    ...    secret__azure_devops_pat=${AZURE_DEVOPS_PAT}
+    ...    timeout_seconds=120
+    ...    include_in_history=false
+
+    ${preflight_json_raw}=    RW.CLI.Run Cli
+    ...    cmd=cat preflight_results.json 2>/dev/null || echo '{"summary": "Preflight results not available", "identity": {"name": "unknown"}}'
+
+    TRY
+        ${preflight_data}=    Evaluate    json.loads(r'''${preflight_json_raw.stdout}''')    json
+        ${preflight_summary}=    Set Variable    ${preflight_data['summary']}
+        Log    Preflight result: ${preflight_summary}    INFO
+    EXCEPT
+        Log    WARNING: Could not parse preflight results. Raw output: ${preflight.stdout}    WARN
+        ${preflight_data}=    Evaluate    {"summary": "Preflight parse failed", "identity": {"name": "unknown"}}
+        ${preflight_summary}=    Set Variable    Preflight results unavailable
+    END
+
+    Set Suite Variable    ${PREFLIGHT_DATA}    ${preflight_data}
+    Set Suite Variable    ${PREFLIGHT_SUMMARY}    ${preflight_summary}
+
+    RW.Core.Add Pre To Report    Preflight Access Check:
+    RW.Core.Add Pre To Report    ${preflight.stdout}
     
     Log    Suite Initialization completed successfully!    INFO
 

--- a/codebundles/azure-devops-project-health/service-connections.sh
+++ b/codebundles/azure-devops-project-health/service-connections.sh
@@ -18,6 +18,8 @@ set -euo pipefail
 AZURE_DEVOPS_PAT="${AZURE_DEVOPS_PAT:-$azure_devops_pat}"
 export AZURE_DEVOPS_EXT_PAT="${AZURE_DEVOPS_PAT}"
 
+source "$(dirname "$0")/_az_helpers.sh"
+
 OUTPUT_FILE="service_connections_issues.json"
 issues_json='[]'
 
@@ -25,43 +27,18 @@ echo "Analyzing Azure DevOps Service Connections..."
 echo "Organization: $AZURE_DEVOPS_ORG"
 echo "Project:      $AZURE_DEVOPS_PROJECT"
 
-# Ensure Azure CLI is logged in and DevOps extension is installed
-if ! az extension show --name azure-devops &>/dev/null; then
-    echo "Installing Azure DevOps CLI extension..."
-    az extension add --name azure-devops --output none
-fi
-
-# Configure Azure DevOps CLI defaults
-az devops configure --defaults organization="https://dev.azure.com/$AZURE_DEVOPS_ORG" project="$AZURE_DEVOPS_PROJECT" --output none
-
-# Setup authentication
-if [ "$AUTH_TYPE" = "service_principal" ]; then
-    echo "Using service principal authentication..."
-    # Service principal authentication is handled by Azure CLI login
-elif [ "$AUTH_TYPE" = "pat" ]; then
-    if [ -z "${AZURE_DEVOPS_PAT:-}" ]; then
-        echo "ERROR: AZURE_DEVOPS_PAT must be set when AUTH_TYPE=pat"
-        exit 1
-    fi
-    echo "Using PAT authentication..."
-    echo "$AZURE_DEVOPS_PAT" | az devops login --organization "https://dev.azure.com/$AZURE_DEVOPS_ORG"
-else
-    echo "ERROR: Invalid AUTH_TYPE. Must be 'service_principal' or 'pat'"
-    exit 1
-fi
+az devops configure --defaults project="$AZURE_DEVOPS_PROJECT" --output none
+setup_azure_auth
 
 # Get list of service connections
 echo "Retrieving service connections in project..."
-if ! connections=$(az devops service-endpoint list --output json 2>connections_err.log); then
-    err_msg=$(cat connections_err.log)
-    rm -f connections_err.log
-    
+if ! az_with_retry az devops service-endpoint list --output json; then
     echo "ERROR: Could not list service connections."
     issues_json=$(echo "$issues_json" | jq \
         --arg title "Failed to List Service Connections" \
-        --arg details "$err_msg" \
+        --arg details "Azure DevOps API was unreachable or returned an error after $AZ_RETRY_COUNT retry attempts." \
         --arg severity "3" \
-        --arg nextStep "Check if you have sufficient permissions to view service connections." \
+        --arg nextStep "Check if you have sufficient permissions to view service connections. Verify Azure DevOps API availability." \
         '. += [{
            "title": $title,
            "details": $details,
@@ -71,7 +48,7 @@ if ! connections=$(az devops service-endpoint list --output json 2>connections_e
     echo "$issues_json" > "$OUTPUT_FILE"
     exit 1
 fi
-rm -f connections_err.log
+connections="$AZ_RESULT"
 
 # Save connections to a file to avoid subshell issues
 echo "$connections" > connections.json


### PR DESCRIPTION
- Consolidated authentication setup across multiple scripts by introducing a common `setup_azure_auth` function, improving code maintainability and clarity.
- Enhanced error handling for Azure DevOps API calls, providing clearer feedback on failures and next steps for users.
- Updated scripts to utilize a consistent method for retrieving data, ensuring better reliability and reducing the likelihood of errors during execution.
- Improved documentation and output messages to reflect changes in functionality and enhance user understanding of monitoring processes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches many runbook scripts and changes how all Azure DevOps API calls are executed (timeouts/retries and auth setup), which could alter behavior in edge cases or environments missing `timeout`/with different CLI auth state.
> 
> **Overview**
> **Improves reliability of Azure DevOps health checks** by introducing shared script helpers (`_az_helpers.sh`) that centralize Azure DevOps CLI extension setup + PAT/SP auth (`setup_azure_auth`) and wrap `az` calls with per-call timeouts, exponential-backoff retries, and standardized stdout capture (`az_with_retry`).
> 
> Updates the existing health scripts to use these helpers instead of ad-hoc `az` invocations and error-log parsing, and tweaks issue messages to explicitly call out API unavailability/timeouts and suggest network/service-health checks.
> 
> Adds a new `preflight-check.sh` and wires it into `runbook.robot` suite initialization to report identity + per-scope access results; the runbook also now emits explicit issues when downstream scripts fail to produce valid JSON, including the preflight summary for troubleshooting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit de8f2d77e7fbd489e6ddbeec9638b4c9b2fa44da. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->