### PR TITLE
Enhance Vercel integration in runbook and SLI scripts

### DIFF
--- a/codebundles/vercel-project-health/runbook.robot
+++ b/codebundles/vercel-project-health/runbook.robot
@@ -11,6 +11,7 @@ Library             Collections
 Library             RW.Core
 Library             RW.CLI
 Library             RW.platform
+Library             Vercel
 
 Suite Setup         Suite Initialization
 
@@ -124,17 +125,17 @@ Suite Initialization
     ...    type=string
     ...    description=Vercel team slug or ID; leave empty for hobby projects scoped to the token owner
     ...    pattern=^[\w-]*$
-    ...    default=${EMPTY}
+    ...    default=
     ${VERCEL_PROJECT_ID}=    RW.Core.Import User Variable    VERCEL_PROJECT_ID
     ...    type=string
     ...    description=Single Vercel project ID (prj_...); ignored when VERCEL_PROJECT_IDS is non-empty
     ...    pattern=^[\w-]*$
-    ...    default=${EMPTY}
+    ...    default=
     ${VERCEL_PROJECT_IDS}=    RW.Core.Import User Variable    VERCEL_PROJECT_IDS
     ...    type=string
     ...    description=Optional comma-separated project IDs for multi-project runs (overrides single ID when set)
     ...    pattern=^[\w,\s-]*$
-    ...    default=${EMPTY}
+    ...    default=
     ${VERCEL_ARTIFACT_ROOT}=    RW.Core.Import User Variable    VERCEL_ARTIFACT_ROOT
     ...    type=string
     ...    description=Parent directory for per-project JSON outputs when multiple projects are configured
@@ -184,7 +185,7 @@ Suite Initialization
     ...    type=string
     ...    description=Optional explicit base URL for the synthetic probe; auto-resolved from the latest READY production deployment when empty.
     ...    pattern=^.*$
-    ...    default=${EMPTY}
+    ...    default=
     ${VERCEL_PROBE_TIMEOUT_SECONDS}=    RW.Core.Import User Variable    VERCEL_PROBE_TIMEOUT_SECONDS
     ...    type=string
     ...    description=Per-request timeout for the synthetic probe (seconds).

--- a/codebundles/vercel-project-health/sli.robot
+++ b/codebundles/vercel-project-health/sli.robot
@@ -8,6 +8,7 @@ Library             BuiltIn
 Library             RW.Core
 Library             RW.CLI
 Library             RW.platform
+Library             Vercel
 
 Suite Setup         Suite Initialization
 
@@ -28,7 +29,7 @@ Suite Initialization
     ...    type=string
     ...    description=Vercel team slug or ID; leave empty for hobby projects
     ...    pattern=^[\w-]*$
-    ...    default=${EMPTY}
+    ...    default=
     ${VERCEL_PROJECT_ID}=    RW.Core.Import User Variable    VERCEL_PROJECT_ID
     ...    type=string
     ...    description=Vercel project ID (prj_...)
@@ -77,7 +78,7 @@ Suite Initialization
     ...    type=string
     ...    description=Optional expected production branch; when set, the production-branch SLI scores 0 if Vercel's link.productionBranch differs. Leave blank to skip the check.
     ...    pattern=^[\w./-]*$
-    ...    default=${EMPTY}
+    ...    default=
 
     ${env}=    Create Dictionary
     ...    VERCEL_TEAM_ID=${VERCEL_TEAM_ID}

--- a/codebundles/vercel-project-health/vercel-helpers.sh
+++ b/codebundles/vercel-project-health/vercel-helpers.sh
@@ -17,19 +17,40 @@
 # ---------------------------------------------------------------------------
 
 vercel_py() {
-  # Resolve PYTHONPATH so the Vercel package imports cleanly in dev tree and runner image.
-  local pp
-  if [[ -n "${RW_LIBRARIES_DIR:-}" ]] && [[ -d "${RW_LIBRARIES_DIR}/Vercel" ]]; then
-    pp="${RW_LIBRARIES_DIR}"
-  elif [[ -d "${SCRIPT_DIR:-}/../../libraries/Vercel" ]]; then
-    pp="${SCRIPT_DIR}/../../libraries"
-  elif [[ -d /home/runwhen/codecollection/libraries/Vercel ]]; then
-    pp="/home/runwhen/codecollection/libraries"
-  else
-    echo "[vercel] cannot locate codecollection/libraries/Vercel" >&2
-    return 1
+  # The codecollection's Python libraries (libraries/Vercel/) are auto-installed
+  # onto PYTHONPATH by the RunWhen runner image, AND surfaced into the Robot
+  # process by `Library    Vercel` in runbook.robot / sli.robot. Once Robot has
+  # loaded the library, every bash subprocess invoked via RW.CLI.Run Bash File
+  # can import it directly — `python3 -m Vercel <subcmd>` Just Works.
+  #
+  # In the dev tree (e.g. running `ro` from a codespace), the lib is also
+  # importable because task setup symlinks the codecollection into
+  # /home/runwhen/codecollection which is on the runner image's PYTHONPATH.
+  #
+  # If neither path is in effect, fall back to two well-known dev-tree
+  # locations and emit a one-line diagnostic so failures aren't opaque.
+  if python3 -c 'import Vercel' >/dev/null 2>&1; then
+    python3 -m Vercel "$@"
+    return $?
   fi
-  PYTHONPATH="${pp}${PYTHONPATH:+:${PYTHONPATH}}" python3 -m Vercel "$@"
+
+  local helpers_src script_src candidate
+  helpers_src="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+  script_src="${SCRIPT_DIR:-$helpers_src}"
+  for candidate in \
+      "${RW_LIBRARIES_DIR:-}" \
+      "${script_src}/../../libraries" \
+      "${helpers_src}/../../libraries" \
+      "/home/runwhen/codecollection/libraries"; do
+    [[ -z "$candidate" ]] && continue
+    if [[ -d "${candidate}/Vercel" ]]; then
+      PYTHONPATH="${candidate}${PYTHONPATH:+:${PYTHONPATH}}" python3 -m Vercel "$@"
+      return $?
+    fi
+  done
+
+  echo "[vercel] cannot import Vercel package: not on PYTHONPATH and no dev-tree fallback found. Ensure 'Library    Vercel' is declared in the calling .robot file." >&2
+  return 1
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
- Added the Vercel library to both runbook.robot and sli.robot for improved functionality.
- Updated default values for several user variables to be empty instead of using a placeholder, enhancing clarity and usability.
- Refactored vercel-helpers.sh to streamline the import process for the Vercel package, ensuring it is correctly included in the PYTHONPATH and providing clearer error messages when the package cannot be found.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily wiring/packaging changes (library import and PYTHONPATH fallback logic) with minimal behavioral impact beyond how the Vercel Python module is located and invoked.
> 
> **Overview**
> **Improves Vercel library availability for both Robot and bash tasks.** `runbook.robot` and `sli.robot` now explicitly import `Library    Vercel`, and several user variables switch from `default=${EMPTY}` to an empty `default=`.
> 
> **Refactors `vercel_py()` in `vercel-helpers.sh`** to first attempt a normal `import Vercel` (no manual PYTHONPATH) and only then fall back to a small set of known library locations, with a clearer diagnostic when the package cannot be found.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46adfd46196005b0e386040d61b44eb0188d5a0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->