### PR TITLE
Add statefulset and daemonset to k8s-stacktrace-health generation rules

### DIFF
--- a/codebundles/k8s-stacktrace-health/.runwhen/generation-rules/k8s-stacktrace-health.yaml
+++ b/codebundles/k8s-stacktrace-health/.runwhen/generation-rules/k8s-stacktrace-health.yaml
@@ -4,6 +4,8 @@ spec:
   generationRules:
     - resourceTypes:
         - deployment
+        - statefulset
+        - daemonset
       matchRules:
         - type: pattern
           pattern: ".+"


### PR DESCRIPTION
Extends the generation rule resourceTypes to match the workload kinds already supported by the codebundle (per the WORKLOAD_TYPE enum in runbook.robot and sli.robot). Jobs/CronJobs intentionally excluded - the codebundle does not yet support them.

Refs RW-903

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that expands generation coverage to additional Kubernetes workload kinds; main risk is creating additional SLXs/SLIs/runbooks for more resources than before.
> 
> **Overview**
> The `k8s-stacktrace-health` generation rules now match `statefulset` and `daemonset` resources in addition to `deployment`, causing the stacktrace health SLX/SLI/runbook artifacts to be generated for those workload kinds as well.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47f50cc5f169e866b592ad4b9df94bf654dcc143. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->