### PR TITLE
Fix Fetch Deployment Logs crash on JSON-heavy / >128 KB log payloads

### DIFF
--- a/codebundles/k8s-deployment-healthcheck/runbook.robot
+++ b/codebundles/k8s-deployment-healthcheck/runbook.robot
@@ -408,90 +408,54 @@ Fetch Deployment Logs for `${DEPLOYMENT_NAME}` in Namespace `${NAMESPACE}`
     ...    data:logs-bulk
     # Skip pod-related checks if deployment is scaled to 0
     IF    not ${SKIP_POD_CHECKS}
-        # Determine which container to fetch logs from
+        # Determine which containers to exclude from log collection.
+        # If CONTAINER_NAME is set, exclude every container EXCEPT that one;
+        # otherwise honor the user-configured EXCLUDED_CONTAINERS list.
         IF    "${CONTAINER_NAME}" != ""
-            ${target_container}=    Set Variable    ${CONTAINER_NAME}
-        ELSE
-            # Auto-detect primary container by listing containers and excluding known sidecars
             ${container_json}=    RW.CLI.Run Cli
             ...    cmd=${KUBERNETES_DISTRIBUTION_BINARY} get deployment/${DEPLOYMENT_NAME} --context ${CONTEXT} -n ${NAMESPACE} -o jsonpath='{.spec.template.spec.containers[*].name}'
             ...    env=${env}
             ...    secret_file__kubeconfig=${kubeconfig}
             ...    include_in_history=false
             @{all_containers}=    Split String    ${container_json.stdout}
-            ${container_count}=    Get Length    ${all_containers}
-            ${target_container}=    Set Variable    ${EMPTY}
-            IF    ${container_count} > 0
-                FOR    ${cname}    IN    @{all_containers}
-                    ${is_excluded}=    Evaluate    "${cname}" in ${EXCLUDED_CONTAINERS}
-                    IF    not ${is_excluded}
-                        ${target_container}=    Set Variable    ${cname}
-                        BREAK
-                    END
-                END
-                IF    "${target_container}" == ""
-                    ${target_container}=    Set Variable    ${all_containers}[0]
+            @{exclude_list}=    Create List
+            FOR    ${cname}    IN    @{all_containers}
+                IF    "${cname}" != "${CONTAINER_NAME}"
+                    Append To List    ${exclude_list}    ${cname}
                 END
             END
+        ELSE
+            @{exclude_list}=    Copy List    ${EXCLUDED_CONTAINERS}
         END
 
-        # Build the kubectl logs command with or without -c flag
-        IF    "${target_container}" != ""
-            ${logs_cmd}=    Set Variable    ${KUBERNETES_DISTRIBUTION_BINARY} logs deployment/${DEPLOYMENT_NAME} -c ${target_container} --context ${CONTEXT} -n ${NAMESPACE} --tail=${LOG_LINES} --since=${LOG_AGE}
-        ELSE
-            ${logs_cmd}=    Set Variable    ${KUBERNETES_DISTRIBUTION_BINARY} logs deployment/${DEPLOYMENT_NAME} --context ${CONTEXT} -n ${NAMESPACE} --tail=${LOG_LINES} --since=${LOG_AGE}
+        # Fetch logs to a temp directory via the K8sLog library.
+        # Replaces the previous bash+grep pipeline that crashed on JSON access
+        # logs (rc=2 syntax error) and on payloads >128KB (OSError E2BIG).
+        TRY
+            ${log_dir}=    RW.K8sLog.Fetch Workload Logs
+            ...    workload_type=deployment
+            ...    workload_name=${DEPLOYMENT_NAME}
+            ...    namespace=${NAMESPACE}
+            ...    context=${CONTEXT}
+            ...    kubeconfig=${kubeconfig}
+            ...    log_age=${LOG_AGE}
+            ...    max_log_lines=${LOG_LINES}
+            ...    excluded_containers=${exclude_list}
+        EXCEPT    AS    ${log_error}
+            Log    Warning: Log fetching encountered an error: ${log_error}
+            RW.Core.Add Pre To Report    **📋 Raw Deployment Logs for `${DEPLOYMENT_NAME}`**\n\n⚠️ Unable to fetch deployment logs: ${log_error}
+            ${log_dir}=    Set Variable    ${EMPTY}
         END
-        ${deployment_logs}=    RW.CLI.Run Cli
-        ...    cmd=${logs_cmd}
-        ...    env=${env}
-        ...    secret_file__kubeconfig=${kubeconfig}
-        ...    show_in_rwl_cheatsheet=true
-        ...    render_in_commandlist=true
-        
-        IF    ${deployment_logs.returncode} == 0
-            # Filter logs to remove repetitive health check messages and focus on meaningful content
-            ${filtered_logs}=    RW.CLI.Run Cli
-            ...    cmd=echo "${deployment_logs.stdout}" | grep -v -E "(Checking.*Health|Health.*Check|healthcheck|/health|GET /health|POST /health|probe|liveness|readiness)" | grep -E "(error|ERROR|warn|WARN|exception|Exception|fail|FAIL|fatal|FATAL|panic|stack|trace|timeout|connection.*refused|unable.*connect|authentication.*failed|denied|forbidden|unauthorized|500|502|503|504)" | tail -50 || echo "No significant errors or warnings found in recent logs"
-            ...    env=${env}
-            ...    include_in_history=false
-            
-            # Also get a sample of non-health-check logs for context
-            ${context_logs}=    RW.CLI.Run Cli
-            ...    cmd=echo "${deployment_logs.stdout}" | grep -v -E "(Checking.*Health|Health.*Check|healthcheck|/health|GET /health|POST /health|probe|liveness|readiness)" | head -20 | tail -10
-            ...    env=${env}
-            ...    include_in_history=false
-            
-            ${history}=    RW.CLI.Pop Shell History
-            
-            # Determine if logs are mostly health checks
-            ${total_lines}=    RW.CLI.Run Cli
-            ...    cmd=echo "${deployment_logs.stdout}" | wc -l
-            ...    env=${env}
-            ...    include_in_history=false
-            
-            ${health_check_lines}=    RW.CLI.Run Cli
-            ...    cmd=echo "${deployment_logs.stdout}" | grep -E "(Checking.*Health|Health.*Check|healthcheck|/health)" | wc -l
-            ...    env=${env}
-            ...    include_in_history=false
-            
-            # Handle empty output from wc -l by providing default values
-            ${total_lines_clean}=    Set Variable If    "${total_lines.stdout.strip()}" == ""    0    ${total_lines.stdout.strip()}
-            ${health_check_lines_clean}=    Set Variable If    "${health_check_lines.stdout.strip()}" == ""    0    ${health_check_lines.stdout.strip()}
-            
-            ${total_count}=    Convert To Integer    ${total_lines_clean}
-            ${health_count}=    Convert To Integer    ${health_check_lines_clean}
-            
-            # Create consolidated logs report
-            IF    ${health_count} > ${total_count} * 0.8
-                ${log_content}=    Set Variable If    "${context_logs.stdout.strip()}" != ""    **🔍 Filtered Error/Warning Logs:**\n${filtered_logs.stdout}\n\n**📝 Sample Application Logs (Non-Health Check):**\n${context_logs.stdout}    **🔍 Filtered Error/Warning Logs:**\n${filtered_logs.stdout}
-                RW.Core.Add Pre To Report    **📋 Raw Deployment Logs for `${DEPLOYMENT_NAME}`** (Last ${LOG_LINES} lines, ${LOG_AGE} age)\n**Total Log Lines:** ${total_count} | **Health Check Lines:** ${health_count}\n**ℹ️ Logs are mostly health check messages (${health_count}/${total_count} lines)**\n\n${log_content}\n\n**Commands Used:** ${history}\n\n**Note:** Automated issue detection is performed by the "Analyze Application Log Patterns" task.
+
+        IF    '''${log_dir}''' != '''${EMPTY}'''
+            ${parts}=    RW.K8sLog.Format Logs For Report    log_dir=${log_dir}
+
+            IF    ${parts}[mostly_health_checks]
+                ${log_content}=    Set Variable If    "${parts}[context]" != ""    **🔍 Filtered Error/Warning Logs:**\n${parts}[filtered]\n\n**📝 Sample Application Logs (Non-Health Check):**\n${parts}[context]    **🔍 Filtered Error/Warning Logs:**\n${parts}[filtered]
+                RW.Core.Add Pre To Report    **📋 Raw Deployment Logs for `${DEPLOYMENT_NAME}`** (Last ${LOG_LINES} lines, ${LOG_AGE} age)\n**Total Log Lines:** ${parts}[total_lines] | **Health Check Lines:** ${parts}[health_check_lines]\n**ℹ️ Logs are mostly health check messages (${parts}[health_check_lines]/${parts}[total_lines] lines)**\n\n${log_content}\n\n**Note:** Automated issue detection is performed by the "Analyze Application Log Patterns" task.
             ELSE
-                RW.Core.Add Pre To Report    **📋 Raw Deployment Logs for `${DEPLOYMENT_NAME}`** (Last ${LOG_LINES} lines, ${LOG_AGE} age)\n**Total Log Lines:** ${total_count} | **Health Check Lines:** ${health_count}\n\n**📝 Recent Application Logs:**\n${deployment_logs.stdout}\n\n**Commands Used:** ${history}\n\n**Note:** Automated issue detection is performed by the "Analyze Application Log Patterns" task.
+                RW.Core.Add Pre To Report    **📋 Raw Deployment Logs for `${DEPLOYMENT_NAME}`** (Last ${LOG_LINES} lines, ${LOG_AGE} age)\n**Total Log Lines:** ${parts}[total_lines] | **Health Check Lines:** ${parts}[health_check_lines]\n\n**📝 Recent Application Logs:**\n${parts}[raw]\n\n**Note:** Automated issue detection is performed by the "Analyze Application Log Patterns" task.
             END
-        ELSE
-            # Only add to report if fetch failed, don't create issue
-            ${history}=    RW.CLI.Pop Shell History
-            RW.Core.Add Pre To Report    **📋 Raw Deployment Logs for `${DEPLOYMENT_NAME}`**\n\n⚠️ Unable to fetch deployment logs (exit code ${deployment_logs.returncode}).\n\n**STDERR:** ${deployment_logs.stderr}\n\n**Commands Used:** ${history}
         END
     END
 

--- a/codebundles/k8s-deployment-healthcheck/runbook.robot
+++ b/codebundles/k8s-deployment-healthcheck/runbook.robot
@@ -409,8 +409,15 @@ Fetch Deployment Logs for `${DEPLOYMENT_NAME}` in Namespace `${NAMESPACE}`
     # Skip pod-related checks if deployment is scaled to 0
     IF    not ${SKIP_POD_CHECKS}
         # Determine which containers to exclude from log collection.
-        # If CONTAINER_NAME is set, exclude every container EXCEPT that one;
-        # otherwise honor the user-configured EXCLUDED_CONTAINERS list.
+        #
+        # If CONTAINER_NAME is set AND it actually exists on the deployment,
+        # exclude every other container so only that container's logs are
+        # collected. If CONTAINER_NAME is set but NOT present on the deployment
+        # (typo, removed container, etc.), warn loudly and fall back to the
+        # user-configured EXCLUDED_CONTAINERS — an unknown CONTAINER_NAME would
+        # otherwise silently exclude every container and produce an empty
+        # report.
+        # If CONTAINER_NAME is unset, honor EXCLUDED_CONTAINERS as-is.
         IF    "${CONTAINER_NAME}" != ""
             ${container_json}=    RW.CLI.Run Cli
             ...    cmd=${KUBERNETES_DISTRIBUTION_BINARY} get deployment/${DEPLOYMENT_NAME} --context ${CONTEXT} -n ${NAMESPACE} -o jsonpath='{.spec.template.spec.containers[*].name}'
@@ -418,11 +425,17 @@ Fetch Deployment Logs for `${DEPLOYMENT_NAME}` in Namespace `${NAMESPACE}`
             ...    secret_file__kubeconfig=${kubeconfig}
             ...    include_in_history=false
             @{all_containers}=    Split String    ${container_json.stdout}
-            @{exclude_list}=    Create List
-            FOR    ${cname}    IN    @{all_containers}
-                IF    "${cname}" != "${CONTAINER_NAME}"
-                    Append To List    ${exclude_list}    ${cname}
+            ${container_name_present}=    Evaluate    "${CONTAINER_NAME}" in ${all_containers}
+            IF    ${container_name_present}
+                @{exclude_list}=    Create List
+                FOR    ${cname}    IN    @{all_containers}
+                    IF    "${cname}" != "${CONTAINER_NAME}"
+                        Append To List    ${exclude_list}    ${cname}
+                    END
                 END
+            ELSE
+                Log    Warning: CONTAINER_NAME='${CONTAINER_NAME}' not found on deployment ${DEPLOYMENT_NAME} (containers: ${all_containers}). Falling back to EXCLUDED_CONTAINERS.    WARN
+                @{exclude_list}=    Copy List    ${EXCLUDED_CONTAINERS}
             END
         ELSE
             @{exclude_list}=    Copy List    ${EXCLUDED_CONTAINERS}
@@ -431,6 +444,12 @@ Fetch Deployment Logs for `${DEPLOYMENT_NAME}` in Namespace `${NAMESPACE}`
         # Fetch logs to a temp directory via the K8sLog library.
         # Replaces the previous bash+grep pipeline that crashed on JSON access
         # logs (rc=2 syntax error) and on payloads >128KB (OSError E2BIG).
+        # NOTE: Fetch Workload Logs aggregates logs from EVERY pod x every
+        # non-excluded container. For a deployment with N replicas, the report
+        # below now spans all of them — the previous code's `kubectl logs
+        # deployment/X` only round-robined to one pod. Each container's slice
+        # is headed in the raw output by `=== <pod>_<container> ===` so it's
+        # easy to tell which lines came from where.
         TRY
             ${log_dir}=    RW.K8sLog.Fetch Workload Logs
             ...    workload_type=deployment
@@ -442,8 +461,8 @@ Fetch Deployment Logs for `${DEPLOYMENT_NAME}` in Namespace `${NAMESPACE}`
             ...    max_log_lines=${LOG_LINES}
             ...    excluded_containers=${exclude_list}
         EXCEPT    AS    ${log_error}
-            Log    Warning: Log fetching encountered an error: ${log_error}
-            RW.Core.Add Pre To Report    **📋 Raw Deployment Logs for `${DEPLOYMENT_NAME}`**\n\n⚠️ Unable to fetch deployment logs: ${log_error}
+            Log    Warning: Log fetching encountered an error: ${log_error}    WARN
+            RW.Core.Add Pre To Report    **📋 Raw Deployment Logs for `${DEPLOYMENT_NAME}`**\n\n⚠️ **Unable to fetch deployment logs.**\n\n**Error:**\n```\n${log_error}\n```\n\n**Reproduce manually:**\n```\n${KUBERNETES_DISTRIBUTION_BINARY} logs deployment/${DEPLOYMENT_NAME} --context ${CONTEXT} -n ${NAMESPACE} --tail=${LOG_LINES} --since=${LOG_AGE}\n```
             ${log_dir}=    Set Variable    ${EMPTY}
         END
 
@@ -452,9 +471,9 @@ Fetch Deployment Logs for `${DEPLOYMENT_NAME}` in Namespace `${NAMESPACE}`
 
             IF    ${parts}[mostly_health_checks]
                 ${log_content}=    Set Variable If    "${parts}[context]" != ""    **🔍 Filtered Error/Warning Logs:**\n${parts}[filtered]\n\n**📝 Sample Application Logs (Non-Health Check):**\n${parts}[context]    **🔍 Filtered Error/Warning Logs:**\n${parts}[filtered]
-                RW.Core.Add Pre To Report    **📋 Raw Deployment Logs for `${DEPLOYMENT_NAME}`** (Last ${LOG_LINES} lines, ${LOG_AGE} age)\n**Total Log Lines:** ${parts}[total_lines] | **Health Check Lines:** ${parts}[health_check_lines]\n**ℹ️ Logs are mostly health check messages (${parts}[health_check_lines]/${parts}[total_lines] lines)**\n\n${log_content}\n\n**Note:** Automated issue detection is performed by the "Analyze Application Log Patterns" task.
+                RW.Core.Add Pre To Report    **📋 Raw Deployment Logs for `${DEPLOYMENT_NAME}`** (Last ${LOG_LINES} lines per container, ${LOG_AGE} age)\n**Total Log Lines:** ${parts}[total_lines] | **Health Check Lines:** ${parts}[health_check_lines]\n**ℹ️ Logs are mostly health check messages (${parts}[health_check_lines]/${parts}[total_lines] lines)**\n\n${log_content}\n\n**Note:** Automated issue detection is performed by the "Analyze Application Log Patterns" task.
             ELSE
-                RW.Core.Add Pre To Report    **📋 Raw Deployment Logs for `${DEPLOYMENT_NAME}`** (Last ${LOG_LINES} lines, ${LOG_AGE} age)\n**Total Log Lines:** ${parts}[total_lines] | **Health Check Lines:** ${parts}[health_check_lines]\n\n**📝 Recent Application Logs:**\n${parts}[raw]\n\n**Note:** Automated issue detection is performed by the "Analyze Application Log Patterns" task.
+                RW.Core.Add Pre To Report    **📋 Raw Deployment Logs for `${DEPLOYMENT_NAME}`** (Last ${LOG_LINES} lines per container, ${LOG_AGE} age)\n**Total Log Lines:** ${parts}[total_lines] | **Health Check Lines:** ${parts}[health_check_lines]\n\n**📝 Recent Application Logs:**\n${parts}[raw]\n\n**Note:** Automated issue detection is performed by the "Analyze Application Log Patterns" task.
             END
         END
     END

--- a/libraries/RW/K8sLog/_test_log_filter.py
+++ b/libraries/RW/K8sLog/_test_log_filter.py
@@ -2,9 +2,9 @@
 
 Run via: ./test.sh   (or: pytest --log-cli-level=DEBUG _test_log_filter.py)
 
-The helper currently has a STUB implementation in k8s_log.py — these tests
-will mostly FAIL until the real implementation lands. That is intentional
-for review: the failures show exactly what each assertion is checking.
+Note: this file has a leading underscore so pytest's default `test_*.py`
+discovery does NOT pick it up automatically — `test.sh` invokes it by path.
+That convention is shared with libraries/RW/K8sApplications/_test_parsers.py.
 
 Each test builds a fake log_dir via pytest's tmp_path fixture, mirroring
 the directory layout produced by RW.K8sLog.Fetch Workload Logs:
@@ -93,10 +93,14 @@ def test_happy_path_filters_correctly(k8slog, tmp_path):
 
     # Raw should contain every line from the input — including health-check
     # noise — so callers that want to dump unfiltered logs can use it.
-    raw = result["raw"]
-    assert "Starting application" in raw
-    assert "GET /health 200" in raw            # noise — present in raw
-    assert "HTTP 503 from upstream" in raw     # signal — present in raw
+    raw_field = result["raw"]
+    assert "Starting application" in raw_field
+    assert "GET /health 200" in raw_field            # noise — present in raw
+    assert "HTTP 503 from upstream" in raw_field     # signal — present in raw
+
+    # Raw should be prefixed with a `=== <pod>_<container> ===` header so
+    # multi-pod / multi-container output stays readable.
+    assert "=== pod-abc_main ===" in raw_field
 
 
 def test_metacharacter_payload_does_not_crash(k8slog, tmp_path):
@@ -151,6 +155,49 @@ def test_empty_input(k8slog, tmp_path):
     assert result["filtered"] == ""
     assert result["context"] == ""
     assert result["mostly_health_checks"] is False
+
+
+def test_multi_file_aggregation(k8slog, tmp_path):
+    """When multiple *_logs.txt files exist (multiple pods/containers),
+    they must all be picked up and tagged with `=== <stem> ===` headers
+    so the raw output stays attributable.
+    """
+    logs_subdir = tmp_path / "deployment_test-app_logs"
+    logs_subdir.mkdir()
+    (logs_subdir / "pod-aaa_main_logs.txt").write_text("ERROR pod-aaa boom\n")
+    (logs_subdir / "pod-bbb_main_logs.txt").write_text("ERROR pod-bbb kaboom\n")
+
+    result = k8slog.format_logs_for_report(str(tmp_path))
+
+    assert result["total_lines"] == 2  # one line per file, headers do NOT count
+
+    raw_field = result["raw"]
+    assert "=== pod-aaa_main ===" in raw_field
+    assert "=== pod-bbb_main ===" in raw_field
+    assert "ERROR pod-aaa boom" in raw_field
+    assert "ERROR pod-bbb kaboom" in raw_field
+
+    # Filtered output keeps both signal lines, headers absent (sorted file order).
+    assert "ERROR pod-aaa boom" in result["filtered"]
+    assert "ERROR pod-bbb kaboom" in result["filtered"]
+    assert "===" not in result["filtered"]
+
+
+def test_nonexistent_log_dir(k8slog, tmp_path):
+    """Pointing at a path that doesn't exist must not raise — returns the
+    documented empty-zero dict so callers can branch on `total_lines == 0`.
+    """
+    missing = tmp_path / "does-not-exist"
+    result = k8slog.format_logs_for_report(str(missing))
+
+    assert result == {
+        "raw": "",
+        "filtered": "",
+        "context": "",
+        "total_lines": 0,
+        "health_check_lines": 0,
+        "mostly_health_checks": False,
+    }
 
 
 def test_shell_metacharacters_are_inert(k8slog, tmp_path):

--- a/libraries/RW/K8sLog/_test_log_filter.py
+++ b/libraries/RW/K8sLog/_test_log_filter.py
@@ -1,0 +1,174 @@
+"""Tests for K8sLog.format_logs_for_report.
+
+Run via: ./test.sh   (or: pytest --log-cli-level=DEBUG _test_log_filter.py)
+
+The helper currently has a STUB implementation in k8s_log.py — these tests
+will mostly FAIL until the real implementation lands. That is intentional
+for review: the failures show exactly what each assertion is checking.
+
+Each test builds a fake log_dir via pytest's tmp_path fixture, mirroring
+the directory layout produced by RW.K8sLog.Fetch Workload Logs:
+
+    <log_dir>/
+      <workload_type>_<workload_name>_logs/
+        <pod>_<container>_logs.txt
+"""
+
+import getpass
+import logging
+import os
+from pathlib import Path
+
+import pytest
+
+from RW.K8sLog import K8sLog
+
+logger = logging.getLogger(__name__)
+
+THIS_DIR = os.path.dirname(__file__)
+TEST_DATA_DIR = os.path.join(THIS_DIR, "test_data")
+
+
+def _read(name: str) -> str:
+    with open(os.path.join(TEST_DATA_DIR, name)) as f:
+        return f.read()
+
+
+def _make_log_dir(tmp_path: Path, content: str,
+                  workload: str = "deployment_test-app",
+                  pod_container: str = "pod-abc_main") -> str:
+    """Create a log_dir under tmp_path that mirrors the layout produced
+    by RW.K8sLog.Fetch Workload Logs, and write `content` to a single
+    pod/container log file inside it.
+    """
+    logs_subdir = tmp_path / f"{workload}_logs"
+    logs_subdir.mkdir()
+    log_file = logs_subdir / f"{pod_container}_logs.txt"
+    log_file.write_text(content)
+    return str(tmp_path)
+
+
+@pytest.fixture
+def k8slog():
+    return K8sLog()
+
+
+def test_happy_path_filters_correctly(k8slog, tmp_path):
+    """Plain-text log: noise filter drops health-check lines, signal filter keeps errors/warnings."""
+    raw = _read("plain_text.log")
+    log_dir = _make_log_dir(tmp_path, raw)
+    result = k8slog.format_logs_for_report(log_dir)
+
+    assert result["total_lines"] == 13
+    # health_check_lines uses the NARROWER counter regex (matching
+    # runbook.robot:473) — only /health, healthcheck, Checking.*Health,
+    # Health.*Check. Lines like "probe completed" / "liveness check" /
+    # "readiness probe" are dropped by the noise filter but NOT counted
+    # here — that asymmetry is preserved from the original bash pipeline.
+    # In our fixture: GET /health (×2), POST /health (×1), healthcheck (×1) = 4
+    assert result["health_check_lines"] == 4
+    assert result["mostly_health_checks"] is False
+
+    filtered = result["filtered"]
+    # Signal lines must be preserved
+    assert "Database connection refused" in filtered
+    assert "Slow query detected" in filtered
+    assert "authentication failed" in filtered
+    assert "HTTP 503 from upstream" in filtered
+
+    # Health-check noise must be excluded (using the broader noise filter)
+    assert "GET /health 200" not in filtered
+    assert "POST /health 200" not in filtered
+    assert "readiness probe ok" not in filtered
+
+    # Non-signal informational lines must be excluded
+    assert "Starting application" not in filtered
+    assert "Processing request" not in filtered
+
+    # Context (head 20 | tail 10 of non-noise) — 6 non-noise lines in this
+    # fixture, so context contains all of them. Pin the boundary lines.
+    context = result["context"]
+    assert "Starting application" in context
+    assert "HTTP 503 from upstream" in context
+
+    # Raw should contain every line from the input — including health-check
+    # noise — so callers that want to dump unfiltered logs can use it.
+    raw = result["raw"]
+    assert "Starting application" in raw
+    assert "GET /health 200" in raw            # noise — present in raw
+    assert "HTTP 503 from upstream" in raw     # signal — present in raw
+
+
+def test_metacharacter_payload_does_not_crash(k8slog, tmp_path):
+    """JSON access logs containing (, ', ;, $(...), backticks — content that broke bash.
+
+    The old shell pipeline died on this with `syntax error near unexpected token '('`.
+    The Python helper must process it without raising.
+    """
+    raw = _read("json_with_metachars.log")
+    log_dir = _make_log_dir(tmp_path, raw)
+    result = k8slog.format_logs_for_report(log_dir)
+
+    assert isinstance(result, dict)
+    assert isinstance(result["filtered"], str)
+    assert result["total_lines"] == 3
+    assert result["health_check_lines"] == 0
+    # The single ERROR line should survive the filter
+    assert "connection refused" in result["filtered"]
+
+
+def test_oversized_payload_does_not_crash(k8slog, tmp_path):
+    """JSON access logs at production volume — pushed past the 128 KB
+    MAX_ARG_STRLEN that crashed the old shell version with
+    OSError [Errno 7] Argument list too long.
+
+    Uses the same JSON fixture as test_metacharacter_payload_does_not_crash
+    so this test exercises both stressors (size + metacharacters) together —
+    which is exactly how the original prod failure manifested.
+    """
+    base = _read("json_with_metachars.log")          # 3 lines, ~1.4 KB
+    multiplier = (200_000 // len(base)) + 1           # push past 128 KB MAX_ARG_STRLEN
+    raw = base * multiplier
+
+    assert len(raw) > 200_000  # sanity check on the constructed payload
+
+    log_dir = _make_log_dir(tmp_path, raw)
+    result = k8slog.format_logs_for_report(log_dir)
+
+    assert result["total_lines"] == 3 * multiplier
+    assert result["health_check_lines"] == 0
+    assert result["mostly_health_checks"] is False
+    assert "connection refused" in result["filtered"]
+
+
+def test_empty_input(k8slog, tmp_path):
+    """A log file that exists but is empty must return zero counts and empty fields, not raise."""
+    log_dir = _make_log_dir(tmp_path, "")
+    result = k8slog.format_logs_for_report(log_dir)
+
+    assert result["total_lines"] == 0
+    assert result["health_check_lines"] == 0
+    assert result["filtered"] == ""
+    assert result["context"] == ""
+    assert result["mostly_health_checks"] is False
+
+
+def test_shell_metacharacters_are_inert(k8slog, tmp_path):
+    """Regression: $(...) and backticks must appear literally in returned output.
+
+    Proves that no shell is invoked anywhere in the pipeline. If a shell
+    were involved, $(whoami) would be replaced by the running user's name
+    and `id` would be replaced by the output of id(1).
+    """
+    raw = "ERROR command failed: $(whoami) and `id` should be literal\n"
+    log_dir = _make_log_dir(tmp_path, raw)
+    result = k8slog.format_logs_for_report(log_dir)
+
+    assert "$(whoami)" in result["filtered"]
+    assert "`id`" in result["filtered"]
+
+    current_user = getpass.getuser()
+    assert current_user not in result["filtered"], (
+        f"Username {current_user!r} appeared in filtered output — "
+        "a shell expanded $(whoami) somewhere in the pipeline."
+    )

--- a/libraries/RW/K8sLog/k8s_log.py
+++ b/libraries/RW/K8sLog/k8s_log.py
@@ -1893,3 +1893,100 @@ class K8sLog:
                 if timestamp:
                     return timestamp
         return datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z')
+
+    def format_logs_for_report(self, log_dir: str) -> dict:
+        """Read all *_logs.txt files under log_dir and return a filtered
+        summary suitable for embedding in a runbook report.
+
+        Replaces the bash+grep pipeline previously used by the
+        "Fetch Deployment Logs" task in
+        codebundles/k8s-deployment-healthcheck/runbook.robot (lines 451-495).
+        Doing this in pure Python eliminates two failure classes that the
+        shell version suffered from:
+
+        - OSError [Errno 7] Argument list too long, when the kubectl-logs
+          payload exceeded Linux's MAX_ARG_STRLEN (~128 KB) once interpolated
+          into the bash -c command string.
+        - bash syntax errors, when the log content contained shell
+          metacharacters (e.g. '(' inside JSON User-Agent strings) that
+          broke bash's quoting once the JSON's '"' chars toggled state.
+
+        Returns:
+            dict with keys:
+              raw                 (str)  full concatenated content of all log
+                                         files (used by callers that want to
+                                         dump unfiltered logs to a report)
+              filtered            (str)  last 50 lines that match the signal
+                                         regex, after dropping noise
+              context             (str)  10-line sample of non-noise lines
+                                         (matches `head -20 | tail -10`)
+              total_lines         (int)  total lines across all log files
+              health_check_lines  (int)  lines matching the narrower counter
+                                         regex (see note below)
+              mostly_health_checks (bool) health_check_lines > total_lines * 0.8
+
+        Note on regex parity with the original:
+            The original bash pipeline used TWO different noise patterns —
+            a broader one for `grep -v` filtering (runbook.robot:454) and a
+            narrower one for the health-check counter (runbook.robot:473).
+            That asymmetry is preserved here verbatim so behavior is
+            unchanged. To unify them, drop the _HEALTH_CHECK_COUNTER pattern
+            and use _NOISE_PATTERN for both — but that's a behavior change.
+        """
+        # Broader pattern: drop these lines before showing them
+        _NOISE_PATTERN = (
+            r"Checking.*Health|Health.*Check|healthcheck|/health|"
+            r"GET /health|POST /health|probe|liveness|readiness"
+        )
+        # Narrower pattern: matches the original counter at runbook.robot:473
+        _HEALTH_CHECK_COUNTER = (
+            r"Checking.*Health|Health.*Check|healthcheck|/health"
+        )
+        # Signal pattern: keep only these lines in `filtered`
+        _SIGNAL_PATTERN = (
+            r"error|ERROR|warn|WARN|exception|Exception|fail|FAIL|"
+            r"fatal|FATAL|panic|stack|trace|timeout|"
+            r"connection.*refused|unable.*connect|authentication.*failed|"
+            r"denied|forbidden|unauthorized|500|502|503|504"
+        )
+
+        log_path = Path(log_dir)
+        if not log_path.is_dir():
+            return {
+                "raw": "",
+                "filtered": "",
+                "context": "",
+                "total_lines": 0,
+                "health_check_lines": 0,
+                "mostly_health_checks": False,
+            }
+
+        raw_lines: List[str] = []
+        for log_file in sorted(log_path.rglob("*_logs.txt")):
+            try:
+                content = log_file.read_text(errors="replace")
+            except OSError as e:
+                logger.warn(f"Could not read log file {log_file}: {e}")
+                continue
+            raw_lines.extend(content.splitlines())
+
+        total_lines = len(raw_lines)
+        health_check_lines = sum(
+            1 for line in raw_lines if re.search(_HEALTH_CHECK_COUNTER, line)
+        )
+
+        non_noise = [line for line in raw_lines if not re.search(_NOISE_PATTERN, line)]
+        signal_lines = [line for line in non_noise if re.search(_SIGNAL_PATTERN, line)]
+
+        # Mirror `head -20 | tail -10`: take first 20 non-noise lines, then
+        # last 10 of those. For inputs <= 10 lines, this returns all of them.
+        context_lines = non_noise[:20][-10:]
+
+        return {
+            "raw": "\n".join(raw_lines),
+            "filtered": "\n".join(signal_lines[-50:]),
+            "context": "\n".join(context_lines),
+            "total_lines": total_lines,
+            "health_check_lines": health_check_lines,
+            "mostly_health_checks": health_check_lines > total_lines * 0.8,
+        }

--- a/libraries/RW/K8sLog/k8s_log.py
+++ b/libraries/RW/K8sLog/k8s_log.py
@@ -1914,13 +1914,17 @@ class K8sLog:
         Returns:
             dict with keys:
               raw                 (str)  full concatenated content of all log
-                                         files (used by callers that want to
-                                         dump unfiltered logs to a report)
+                                         files. Each file's slice is preceded
+                                         by a `=== <pod>_<container> ===`
+                                         header so multi-pod / multi-container
+                                         output is readable.
               filtered            (str)  last 50 lines that match the signal
                                          regex, after dropping noise
               context             (str)  10-line sample of non-noise lines
                                          (matches `head -20 | tail -10`)
-              total_lines         (int)  total lines across all log files
+              total_lines         (int)  total LOG lines across all files
+                                         (the `=== ... ===` headers and blank
+                                         separators in `raw` are NOT counted)
               health_check_lines  (int)  lines matching the narrower counter
                                          regex (see note below)
               mostly_health_checks (bool) health_check_lines > total_lines * 0.8
@@ -1961,14 +1965,26 @@ class K8sLog:
                 "mostly_health_checks": False,
             }
 
-        raw_lines: List[str] = []
+        raw_lines: List[str] = []        # actual log lines, no headers — used for counts/filtering
+        raw_segments: List[str] = []     # rendered output, includes per-file headers
         for log_file in sorted(log_path.rglob("*_logs.txt")):
             try:
                 content = log_file.read_text(errors="replace")
             except OSError as e:
                 logger.warn(f"Could not read log file {log_file}: {e}")
                 continue
-            raw_lines.extend(content.splitlines())
+            file_lines = content.splitlines()
+
+            # Header so concatenated multi-pod / multi-container output is
+            # readable. Strip the `_logs.txt` suffix; what remains is the
+            # `<pod>_<container>` stem produced by Fetch Workload Logs.
+            file_label = log_file.name.removesuffix("_logs.txt") or log_file.name
+            if raw_segments:
+                raw_segments.append("")  # blank separator between files
+            raw_segments.append(f"=== {file_label} ===")
+            raw_segments.extend(file_lines)
+
+            raw_lines.extend(file_lines)
 
         total_lines = len(raw_lines)
         health_check_lines = sum(
@@ -1983,7 +1999,7 @@ class K8sLog:
         context_lines = non_noise[:20][-10:]
 
         return {
-            "raw": "\n".join(raw_lines),
+            "raw": "\n".join(raw_segments),
             "filtered": "\n".join(signal_lines[-50:]),
             "context": "\n".join(context_lines),
             "total_lines": total_lines,

--- a/libraries/RW/K8sLog/test.sh
+++ b/libraries/RW/K8sLog/test.sh
@@ -1,2 +1,5 @@
 #!/bin/bash
+# The test file is named with a leading underscore (`_test_log_filter.py`)
+# so pytest's default `test_*.py` discovery skips it; we invoke it by path.
+# Same convention as libraries/RW/K8sApplications/test.sh.
 pytest --log-cli-level=DEBUG _test_log_filter.py

--- a/libraries/RW/K8sLog/test.sh
+++ b/libraries/RW/K8sLog/test.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+pytest --log-cli-level=DEBUG _test_log_filter.py

--- a/libraries/RW/K8sLog/test_data/json_with_metachars.log
+++ b/libraries/RW/K8sLog/test_data/json_with_metachars.log
@@ -1,0 +1,3 @@
+{"level":"INFO","time":"2026-05-06T19:16:28.847Z","msg":"GET /api","headers":{"user-agent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36","content-security-policy":"script-src https://cdn.jsdelivr.net;default-src 'self';base-uri 'self';font-src 'self' https: data:","sec-ch-ua":"\"Chromium\";v=\"147\", \"Not.A/Brand\";v=\"8\""}}
+{"level":"INFO","time":"2026-05-06T19:16:28.919Z","msg":"GET /api","headers":{"x-injection-attempt":"$(rm -rf /tmp/foo)","backtick-test":"`whoami`","csp":"frame-ancestors 'self';upgrade-insecure-requests"}}
+{"level":"ERROR","time":"2026-05-06T19:16:30.000Z","msg":"connection refused","stack":"at handler (file.js:123:45) (called by main)"}

--- a/libraries/RW/K8sLog/test_data/plain_text.log
+++ b/libraries/RW/K8sLog/test_data/plain_text.log
@@ -1,0 +1,13 @@
+2026-05-06T18:40:00 INFO Starting application
+2026-05-06T18:40:01 INFO GET /health 200
+2026-05-06T18:40:02 INFO probe completed successfully
+2026-05-06T18:40:03 INFO liveness check ok
+2026-05-06T18:40:04 INFO healthcheck pass
+2026-05-06T18:40:05 INFO Processing request id=abc
+2026-05-06T18:40:06 ERROR Database connection refused
+2026-05-06T18:40:07 WARN Slow query detected: 2400ms
+2026-05-06T18:40:08 INFO GET /health 200
+2026-05-06T18:40:09 ERROR authentication failed for user x
+2026-05-06T18:40:10 INFO POST /health 200
+2026-05-06T18:40:11 ERROR HTTP 503 from upstream
+2026-05-06T18:40:12 INFO readiness probe ok


### PR DESCRIPTION
## Summary

- Replaces a buggy `bash + grep` filter pipeline in the `Fetch Deployment Logs`
task with a pure-Python helper. 
- The old pipeline crashed two ways against JSON-emitting deployments: 
  - `OSError [Errno 7] Argument list too long` for payloads >128 KB: [Task-output-log](https://papi.beta.runwhen.com/api/v3/workspaces/dev/slxs/cc-s-sdc-depl-health-158ef31c/files/695834/1052335/log.html?raw=True) containing the exception, [Runsession](https://app.beta.runwhen.com/workspace/dev/chat?runSessionId=695834&view=tasks).
  - `bash: syntax error near unexpected token '('` when JSON content contained shell metacharacters.[Runsession](https://app.beta.runwhen.com/workspace/dev/chat?runSessionId=695859&view=tasks), [Task-output-logs](https://papi.beta.runwhen.com/api/v3/workspaces/dev/slxs/cc-s-sdc-depl-health-158ef31c/files/695859/1052363/log.html?raw=True) : Fetch Deployment Logs task > `IF 
not ${SKIP_POD_CHECKS}` > `IF ${deployment_logs.returncode} == 0` > **Search for `syntax error`**
- Both classes are structurally impossible in the new code path because no shell is invoked on log content.

## Changes

- **`libraries/RW/K8sLog/k8s_log.py`** — new keyword `format_logs_for_report(log_dir)`. Pure Python: `rglob`s `*_logs.txt` under `log_dir`, classifies each line via two regex passes (broader noise filter for the old `grep -v` step, narrower health-check counter, signal pattern), and returns a dict containing `raw`, `filtered`, `context`, `total_lines`, `health_check_lines`, `mostly_health_checks`.
- **`codebundles/k8s-deployment-healthcheck/runbook.robot`** — task body rewritten. The four `RW.CLI.Run Cli` filter calls (`echo | grep | grep | tail`, `head | tail`, two `wc -l`) and the manual count arithmetic are deleted. Kubectl ingest moved to the existing `RW.K8sLog.Fetch Workload Logs` keyword, matching the pattern already used by `Analyze Application Log Patterns` in the same file. The `CONTAINER_NAME` user variable is preserved via dynamic `excluded_containers` computation.
- **`libraries/RW/K8sLog/_test_log_filter.py`** — 5 pytest tests for the new keyword.
- **`libraries/RW/K8sLog/test_data/{plain_text,json_with_metachars}.log`** — new fixtures; the JSON one carries `(`, `'`, `;`, `$()`, backticks (the exact content that broke the old bash pipeline).
- **`libraries/RW/K8sLog/test.sh`** — runner, matches the existing `K8sApplications/test.sh` convention.

## Testing

- **Pytest**: 5/5 passing locally. Coverage: happy-path noise/signal classification + counts, JSON-metachar payload doesn't crash, ~200 KB payload (well past Linux's 128 KB `MAX_ARG_STRLEN`) doesn't crash, empty input handled, and a regression test asserting `$(whoami)` and backticks appear *literally* in returned output (proves no shell expansion).
- **Manual end-to-end**: ran the patched runbook against a test cluster with two captured prod-failure payloads (149 KB and 72 KB) staged via a temporary `${log_dir}` override. Both processed cleanly, task `PASS`, no `Exception while running` or `bash: syntax error` lines anywhere in the run log. The test override has been reverted; only the actual fix is in this PR.

## Notes for Reviewers

- The original signal regex includes `trace`, which matches `trace_id` / `traceparent` / `tracestate` in JSON Datadog headers — produces false positives in `filtered`. Same behavior as the old `grep`, preserved for parity. Worth tightening separately.
- The original bash code used **two slightly different noise patterns**: a broader one for `grep -v` filtering (runbook.robot:454) and a narrower one for the health-check counter (runbook.robot:473). The narrower one is preserved verbatim in the Python port for behavior parity; could be unified in a follow-up.
- Suggest reviewing `libraries/RW/K8sLog/k8s_log.py` (the new keyword + docstring) first, then the runbook diff.