### PR TITLE
Enhance Azure DevOps scripts for improved agent pool management and u…

### DIFF
--- a/codebundles/azure-devops-organization-health/_az_helpers.sh
+++ b/codebundles/azure-devops-organization-health/_az_helpers.sh
@@ -101,6 +101,44 @@ ado_auth_header() {
     fi
 }
 
+# Best-effort resolution of the authenticated identity. Echoes a JSON object:
+#   {name, id, email, auth_type, confirmed}
+# Tries `az devops invoke` FIRST so it shares the exact auth + proxy path as the
+# tasks/probes (a raw curl often fails behind a corporate proxy even when `az`
+# succeeds, which is why PAT runs previously reported identity "unknown"). Falls
+# back to a direct connectionData REST call. Never fails the caller.
+ado_identity_json() {
+    local org_url="https://dev.azure.com/$AZURE_DEVOPS_ORG"
+    local auth="${AUTH_TYPE:-service_principal}"
+    local resp=""
+
+    resp=$(az devops invoke --area Location --resource ConnectionData \
+        --org "$org_url" --api-version 7.1 --output json 2>/dev/null || echo "")
+
+    if ! echo "$resp" | jq -e '(.authenticatedUser.id // .authorizedUser.id)' >/dev/null 2>&1; then
+        local hdr; hdr=$(ado_auth_header)
+        if [ -n "$hdr" ]; then
+            resp=$(curl -s --max-time 15 -H "Authorization: $hdr" \
+                "$org_url/_apis/connectionData?api-version=7.1" 2>/dev/null || echo "")
+        fi
+    fi
+
+    if echo "$resp" | jq -e '(.authenticatedUser.id // .authorizedUser.id)' >/dev/null 2>&1; then
+        echo "$resp" | jq --arg a "$auth" '
+            (.authenticatedUser // .authorizedUser) as $u
+            | ($u.properties.Account."$value" // $u.emailAddress // "") as $email
+            | {
+                name:      ($u.providerDisplayName // $u.customDisplayName // $email // "unknown"),
+                id:        ($u.id // "unknown"),
+                email:     $email,
+                auth_type: $a,
+                confirmed: true
+              }'
+    else
+        jq -n --arg a "$auth" '{name:"unknown", id:"unknown", email:"", auth_type:$a, confirmed:false}'
+    fi
+}
+
 # Newline-separated list of elastic (VMSS / scale-set / agent-cloud) pool IDs.
 # Populated by load_elastic_pool_ids; empty until then or on failure.
 AZ_ELASTIC_POOL_IDS=""
@@ -169,9 +207,39 @@ pool_is_elastic() {
 # linger as "offline" registrations, so a raw offline count is misleading. The
 # meaningful signal for these pools is ONLINE capacity, not offline backlog.
 #
-# Args: $1 = agents JSON array, $2 = is_elastic ("true"/"false")
+# Heuristic: does this pool look like a self-managed ephemeral farm (Kubernetes/
+# KEDA, AKS, VMSS/scale-set, container agents) based on its NAME and its AGENT
+# NAMES? Such pools auto-generate agents with sequential/templated names and
+# leave stale "offline" registrations behind, so a raw offline count (or a
+# scaled-to-zero state) is expected churn, not an outage. This is the signal the
+# elastic-pools API and the online>0 ratio test miss when a pool is scaled to 0.
+# Args: $1 = agents JSON array, $2 = pool name
+pool_looks_ephemeral() {
+    local agents="$1" pool_name="${2:-}"
+    # Pool-name patterns.
+    if printf '%s' "$pool_name" \
+        | grep -Eiq 'k8s|aks|kube|keda|vmss|scale.?set|ephemeral|autoscale|elastic|container|-agents?$|aci'; then
+        return 0
+    fi
+    # Agent-name patterns: a majority named like generated/scaled instances, e.g.
+    # "azp-...", "...agents-0", "<base>-<N>" (trailing numeric suffix).
+    echo "$agents" | jq -e '
+        ([.[] | .name // ""]) as $n
+        | ($n | length) as $tot
+        | if $tot == 0 then false
+          else
+            ([ $n[] | select(
+                test("^azp-"; "i")
+                or test("agents?-[0-9]+$"; "i")
+                or test("-[0-9]+$")
+            )] | length) as $gen
+            | ($gen * 2) >= $tot
+          end' >/dev/null 2>&1
+}
+
+# Args: $1 = agents JSON array, $2 = is_elastic ("true"/"false"), $3 = pool name (optional)
 classify_pool_agents() {
-    local agents="$1" is_elastic="${2:-false}"
+    local agents="$1" is_elastic="${2:-false}" pool_name="${3:-}"
     local ephemeral_ratio="${EPHEMERAL_OFFLINE_RATIO:-60}"
 
     local counts total online offline busy
@@ -190,14 +258,20 @@ classify_pool_agents() {
     if [ "$is_elastic" = "true" ]; then
         kind="elastic"
         expected_offline=$offline
-    elif [ "$online" -gt 0 ] && [ "$total" -gt 0 ]; then
-        local off_ratio=$(( offline * 100 / total ))
-        if [ "$off_ratio" -ge "$ephemeral_ratio" ]; then
-            # Online capacity exists but offline dominates: classic signature of
-            # a self-managed VMSS/AKS/container pool leaving stale registrations.
-            kind="ephemeral"
-            expected_offline=$offline
-        fi
+    elif [ "$online" -gt 0 ] && [ "$total" -gt 0 ] \
+            && [ "$(( offline * 100 / total ))" -ge "$ephemeral_ratio" ]; then
+        # Online capacity exists but offline dominates: classic signature of a
+        # self-managed VMSS/AKS/container pool leaving stale registrations.
+        kind="ephemeral"
+        expected_offline=$offline
+    elif [ "$total" -gt 0 ] && [ "$offline" -eq "$total" ] \
+            && pool_looks_ephemeral "$agents" "$pool_name"; then
+        # Scaled-to-zero ephemeral farm: every agent offline AND the pool/agent
+        # naming matches a Kubernetes/VMSS/container pattern. This is the case the
+        # ratio test cannot catch (no online agents to take a ratio of), and is
+        # exactly the "very high offline count" false positive to suppress.
+        kind="ephemeral"
+        expected_offline=$offline
     fi
 
     echo "AGENT_COUNT=$total"
@@ -264,39 +338,62 @@ get_all_users() (
 
 # Fetch agents for every non-hosted pool concurrently, writing one JSON file per
 # pool to <out_dir>/agents_<poolId>.json. This turns what was an O(pools)
-# sequential wall of `az` calls into a bounded-parallel pass, which is the
-# dominant cost for organisations with hundreds of pools.
+# sequential wall of calls into a bounded-parallel pass, the dominant cost for
+# organisations with hundreds of pools.
+#
+# Agents are fetched via a direct REST call (curl) rather than `az pipelines
+# agent list`. The az CLI pays a ~1s Python startup PER pool, so for ~200 pools
+# that alone is several minutes and was causing the 180s task timeouts. The PAT/
+# bearer header is resolved once and passed to the workers via the environment
+# (not argv) so it never appears in `ps`. When no credential is available we
+# fall back to the az CLI.
 #
 # On a fetch FAILURE the file is written as {"__fetch_error__": true} (and the
-# stderr is preserved in agents_<poolId>.err) so callers can distinguish a
+# error is preserved in agents_<poolId>.err) so callers can distinguish a
 # permission/timeout/throttling error from a genuinely empty pool. Use the
 # agents_fetch_failed helper below to test for this.
-# Args: $1 = pools JSON array, $2 = output dir, $3 = max parallelism (default 8)
+# Args: $1 = pools JSON array, $2 = output dir, $3 = max parallelism (default 20)
 fetch_pool_agents_parallel() {
     local pools_json="$1" out_dir="$2"
-    local max_par="${3:-${AGENT_FETCH_PARALLELISM:-8}}"
+    local max_par="${3:-${AGENT_FETCH_PARALLELISM:-20}}"
     local org_url="https://dev.azure.com/$AZURE_DEVOPS_ORG"
     # Validate/clamp parallelism. xargs -P 0 means UNLIMITED concurrency, which
-    # would spawn one `az` per pool and overwhelm the runner/API.
+    # would spawn one worker per pool and overwhelm the runner/API.
     case "$max_par" in
-        ''|*[!0-9]*) max_par=8 ;;
+        ''|*[!0-9]*) max_par=20 ;;
     esac
     [ "$max_par" -lt 1 ] && max_par=1
     [ "$max_par" -gt 32 ] && max_par=32
     mkdir -p "$out_dir"
+
+    # Resolve auth once; pass via env to the parallel workers (keeps PAT out of argv).
+    export ADO_AUTH_HDR; ADO_AUTH_HDR=$(ado_auth_header)
+
     echo "$pools_json" \
         | jq -r '.[] | select((.isHosted // false) == false) | .id' \
         | xargs -r -P "$max_par" -I {} bash -c '
-            out="$1/agents_$2.json"
-            err="$1/agents_$2.err"
-            if az pipelines agent list --pool-id "$2" --org "$3" --output json >"$out" 2>"$err"; then
-                rm -f "$err"
+            pool="$2"; out="$1/agents_$2.json"; err="$1/agents_$2.err"; raw="$1/agents_$2.raw"
+            if [ -n "${ADO_AUTH_HDR:-}" ]; then
+                url="$3/_apis/distributedtask/pools/$pool/agents?includeAssignedRequest=true&api-version=7.1"
+                if curl -fsS --max-time 60 -H "Authorization: $ADO_AUTH_HDR" "$url" -o "$raw" 2>"$err"; then
+                    if jq -e "type == \"object\" and has(\"value\")" "$raw" >/dev/null 2>&1; then
+                        jq ".value // []" "$raw" >"$out" && rm -f "$raw" "$err"
+                    else
+                        echo "{\"__fetch_error__\": true}" >"$out"; mv -f "$raw" "$err" 2>/dev/null || true
+                    fi
+                else
+                    echo "{\"__fetch_error__\": true}" >"$out"; rm -f "$raw"
+                fi
             else
-                # Preserve the error; write a marker so callers report a real
-                # per-pool access/availability failure instead of "no agents".
-                echo "{\"__fetch_error__\": true}" >"$out"
+                # No credential header available: fall back to the az CLI.
+                if az pipelines agent list --pool-id "$pool" --org "$3" --output json >"$out" 2>"$err"; then
+                    rm -f "$err"
+                else
+                    echo "{\"__fetch_error__\": true}" >"$out"
+                fi
             fi
           ' _ "$out_dir" {} "$org_url"
+    unset ADO_AUTH_HDR
 }
 
 # Return 0 if the agents file for a pool indicates a fetch failure (marker), and

--- a/codebundles/azure-devops-organization-health/_az_helpers.sh
+++ b/codebundles/azure-devops-organization-health/_az_helpers.sh
@@ -207,23 +207,10 @@ pool_is_elastic() {
 # linger as "offline" registrations, so a raw offline count is misleading. The
 # meaningful signal for these pools is ONLINE capacity, not offline backlog.
 #
-# Heuristic: does this pool look like a self-managed ephemeral farm (Kubernetes/
-# KEDA, AKS, VMSS/scale-set, container agents) based on its NAME and its AGENT
-# NAMES? Such pools auto-generate agents with sequential/templated names and
-# leave stale "offline" registrations behind, so a raw offline count (or a
-# scaled-to-zero state) is expected churn, not an outage. This is the signal the
-# elastic-pools API and the online>0 ratio test miss when a pool is scaled to 0.
-# Args: $1 = agents JSON array, $2 = pool name
-pool_looks_ephemeral() {
-    local agents="$1" pool_name="${2:-}"
-    # Pool-name patterns.
-    if printf '%s' "$pool_name" \
-        | grep -Eiq 'k8s|aks|kube|keda|vmss|scale.?set|ephemeral|autoscale|elastic|container|-agents?$|aci'; then
-        return 0
-    fi
-    # Agent-name patterns: a majority named like generated/scaled instances, e.g.
-    # "azp-...", "...agents-0", "<base>-<N>" (trailing numeric suffix).
-    echo "$agents" | jq -e '
+# True when a majority of agent names look auto-generated (VMSS/K8s/container).
+# Args: $1 = agents JSON array
+agents_look_generated() {
+    echo "$1" | jq -e '
         ([.[] | .name // ""]) as $n
         | ($n | length) as $tot
         | if $tot == 0 then false
@@ -235,6 +222,22 @@ pool_looks_ephemeral() {
             )] | length) as $gen
             | ($gen * 2) >= $tot
           end' >/dev/null 2>&1
+}
+
+# Heuristic: self-managed ephemeral farm (Kubernetes/KEDA/AKS/VMSS/container).
+# Requires generated-looking agent names so static pools named "*-agent" or
+# containing "elastic" are not misclassified when every agent is offline.
+# Args: $1 = agents JSON array, $2 = pool name
+pool_looks_ephemeral() {
+    local agents="$1" pool_name="${2:-}"
+    agents_look_generated "$agents" || return 1
+    # Strong infra signals in the pool name reinforce the agent-name signal.
+    if printf '%s' "$pool_name" \
+        | grep -Eiq 'k8s|aks|kube|keda|vmss|scale.?set|ephemeral'; then
+        return 0
+    fi
+    # Agent-name majority alone is sufficient (e.g. cts-pool + azp-maven-agent-N).
+    return 0
 }
 
 # Args: $1 = agents JSON array, $2 = is_elastic ("true"/"false"), $3 = pool name (optional)
@@ -336,6 +339,59 @@ get_all_users() (
             '{items: ., totalCount: (. | length), partial: $partial}'
 )
 
+# Load agents JSON from a per-pool cache file. Returns 1 on fetch_error marker.
+# Always echoes a JSON array (never a non-array body that would break jq).
+# Args: $1 = path to agents_<poolId>.json
+load_pool_agents_json() {
+    local f="$1"
+    if agents_fetch_failed "$f"; then
+        return 1
+    fi
+    if [ ! -s "$f" ]; then
+        echo "[]"
+        return 0
+    fi
+    if jq -e 'type == "array"' "$f" >/dev/null 2>&1; then
+        cat "$f"
+    else
+        echo "[]"
+    fi
+}
+
+# Rich issue_details text for agent-pool findings (RunWhen agents consume the
+# JSON "details" field as issue_details).
+# Args: summary, pool_name, pool_id, pool_type, pool_kind, total, online, offline,
+#       busy, expected_offline, [extra paragraph], [sample offline agent names]
+ado_pool_issue_details() {
+    local summary="$1" pool_name="$2" pool_id="$3" pool_type="$4" pool_kind="$5"
+    local total="$6" online="$7" offline="$8" busy="$9" expected_offline="${10:-0}"
+    local extra="${11:-}" sample="${12:-}"
+    local org="${AZURE_DEVOPS_ORG:-unknown}"
+    printf '%s\n\n' "$summary"
+    printf 'Organization: %s\n' "$org"
+    printf 'Pool: %s (id=%s, poolType=%s, classified_as=%s)\n' "$pool_name" "$pool_id" "$pool_type" "$pool_kind"
+    printf 'Agent counts: total=%s online=%s offline=%s busy_assigned=%s expected_offline_churn=%s\n' \
+        "$total" "$online" "$offline" "$busy" "$expected_offline"
+    printf '\nInterpretation:\n'
+    printf '- classified_as elastic/ephemeral: most offline rows are torn-down VMSS/Kubernetes/container registrations, not necessarily failed machines.\n'
+    printf '- busy_assigned: agents with a non-null assignedRequest (work bound to a registered agent). This does NOT count pipeline jobs waiting in the pool queue when no agent is online.\n'
+    printf '- If builds are queued in Azure DevOps while online=0, open Organization Settings > Agent pools > %s and verify autoscale/VMSS/KEDA and service connections.\n' "$pool_name"
+    [ -n "$extra" ] && printf '\n%s\n' "$extra"
+    [ -n "$sample" ] && printf '\nSample offline agents: %s\n' "$sample"
+    printf '\nAPI probed: GET .../distributedtask/pools/%s/agents?includeAssignedRequest=true\n' "$pool_id"
+}
+
+# Generic structured issue_details for non-pool scripts.
+# Args: summary line, then zero or more "Key: value" lines
+ado_issue_details() {
+    local summary="$1"; shift
+    printf '%s\n\n--- Context ---\n' "$summary"
+    printf 'Organization: %s\n' "${AZURE_DEVOPS_ORG:-unknown}"
+    for line in "$@"; do
+        [ -n "$line" ] && printf '%s\n' "$line"
+    done
+}
+
 # Fetch agents for every non-hosted pool concurrently, writing one JSON file per
 # pool to <out_dir>/agents_<poolId>.json. This turns what was an O(pools)
 # sequential wall of calls into a bounded-parallel pass, the dominant cost for
@@ -373,23 +429,28 @@ fetch_pool_agents_parallel() {
         | jq -r '.[] | select((.isHosted // false) == false) | .id' \
         | xargs -r -P "$max_par" -I {} bash -c '
             pool="$2"; out="$1/agents_$2.json"; err="$1/agents_$2.err"; raw="$1/agents_$2.raw"
+            org="$3"
+            mark_err() { echo "{\"__fetch_error__\": true}" >"$out"; }
+            az_fetch() {
+                az pipelines agent list --pool-id "$pool" --org "$org" \
+                    --include-assigned-request --output json >"$out" 2>"$err"
+            }
+            wrote=false
             if [ -n "${ADO_AUTH_HDR:-}" ]; then
-                url="$3/_apis/distributedtask/pools/$pool/agents?includeAssignedRequest=true&api-version=7.1"
+                url="$org/_apis/distributedtask/pools/$pool/agents?includeAssignedRequest=true&api-version=7.1"
                 if curl -fsS --max-time 60 -H "Authorization: $ADO_AUTH_HDR" "$url" -o "$raw" 2>"$err"; then
-                    if jq -e "type == \"object\" and has(\"value\")" "$raw" >/dev/null 2>&1; then
-                        jq ".value // []" "$raw" >"$out" && rm -f "$raw" "$err"
-                    else
-                        echo "{\"__fetch_error__\": true}" >"$out"; mv -f "$raw" "$err" 2>/dev/null || true
+                    if jq -e "type == \"object\" and (.value | type) == \"array\"" "$raw" >/dev/null 2>&1 \
+                            && jq -c ".value" "$raw" >"$out" 2>/dev/null && [ -s "$out" ]; then
+                        rm -f "$raw" "$err"; wrote=true
                     fi
-                else
-                    echo "{\"__fetch_error__\": true}" >"$out"; rm -f "$raw"
                 fi
-            else
-                # No credential header available: fall back to the az CLI.
-                if az pipelines agent list --pool-id "$pool" --org "$3" --output json >"$out" 2>"$err"; then
+                rm -f "$raw"
+            fi
+            if [ "$wrote" = false ]; then
+                if az_fetch; then
                     rm -f "$err"
                 else
-                    echo "{\"__fetch_error__\": true}" >"$out"
+                    mark_err
                 fi
             fi
           ' _ "$out_dir" {} "$org_url"

--- a/codebundles/azure-devops-organization-health/agent-pool-capacity.sh
+++ b/codebundles/azure-devops-organization-health/agent-pool-capacity.sh
@@ -85,7 +85,7 @@ echo "Found $pool_count agent pools. Analyzing capacity..."
 
 # Fetch agents for all non-hosted pools in parallel (major speedup for orgs
 # with hundreds of pools that previously ran one sequential call per pool).
-echo "Fetching agents for all self-hosted pools (parallelism: ${AGENT_FETCH_PARALLELISM:-8})..."
+echo "Fetching agents for all self-hosted pools (parallelism: ${AGENT_FETCH_PARALLELISM:-20})..."
 fetch_pool_agents_parallel "$agent_pools" "$AGENT_CACHE_DIR"
 
 # Initialize counters
@@ -137,7 +137,7 @@ for ((i=0; i<pool_count; i++)); do
     agents=$(cat "$agents_file")
 
     # VMSS-aware classification.
-    eval "$(classify_pool_agents "$agents" "$is_elastic")"
+    eval "$(classify_pool_agents "$agents" "$is_elastic" "$pool_name")"
     agent_count=$AGENT_COUNT
     online_count=$ONLINE_COUNT
     offline_count=$OFFLINE_COUNT
@@ -182,15 +182,22 @@ for ((i=0; i<pool_count; i++)); do
         fi
     fi
 
-    # No online capacity. For elastic/ephemeral pools this is the meaningful
-    # signal (cannot service jobs); transient offline backlog is ignored.
+    # No online capacity. For elastic/ephemeral pools this is only a problem when
+    # work is actually waiting; a pool scaled to zero while idle is normal and the
+    # offline backlog is expected churn. Static pools with all agents offline are
+    # always a real problem.
     if [ "$agent_count" -gt 0 ] && [ "$online_count" -eq 0 ]; then
         if [ "$pool_kind" = "elastic" ] || [ "$pool_kind" = "ephemeral" ]; then
-            pool_issues+=("No online agents available (pool cannot currently service jobs)")
+            if [ "$busy_count" -gt 0 ]; then
+                pool_issues+=("No online agents but $busy_count assigned request(s) waiting (pool cannot service queued work)")
+                if [ "$severity" -gt 2 ]; then severity=2; fi
+            else
+                echo "  $pool_kind pool scaled to zero (idle): 0 online, $offline_count expected offline, no queued work. Not flagged."
+            fi
         else
             pool_issues+=("All agents offline")
+            if [ "$severity" -gt 2 ]; then severity=2; fi
         fi
-        if [ "$severity" -gt 2 ]; then severity=2; fi
     fi
 
     # High utilization (only meaningful when there is online capacity)

--- a/codebundles/azure-devops-organization-health/agent-pool-capacity.sh
+++ b/codebundles/azure-devops-organization-health/agent-pool-capacity.sh
@@ -122,19 +122,20 @@ for ((i=0; i<pool_count; i++)); do
     # Distinguish a real fetch failure (permission/timeout/throttle) from an
     # empty pool so inaccessible pools are reported rather than counted as empty.
     if fetch_err=$(agents_fetch_failed "$agents_file"); then
+        pool_details=$(ado_pool_issue_details \
+            "Failed to list agents for pool \`$pool_name\` (id=$pool_id). Access/availability error, not an empty pool." \
+            "$pool_name" "$pool_id" "$pool_type" "unknown" "0" "0" "0" "0" "0" \
+            "Fetch error: ${fetch_err:-unknown}. REST was attempted first, then az pipelines agent list." "")
         capacity_json=$(echo "$capacity_json" | jq \
             --arg title "Unable To Retrieve Agents For Pool \`$pool_name\`" \
-            --arg details "Failed to list agents for pool \`$pool_name\` (ID: $pool_id). This is an access/availability error, not an empty pool. Error: ${fetch_err:-unknown}" \
+            --arg details "$pool_details" \
             --arg severity "3" \
             --arg nextStep "Verify the identity has the Agent Pools (Read) scope and 'Reader' on this pool, then re-run. Transient throttling/timeouts may also cause this." \
             '. += [{"title": $title, "details": $details, "next_steps": $nextStep, "severity": ($severity | tonumber)}]')
         echo "  WARNING: could not fetch agents for pool $pool_name ($pool_id): ${fetch_err:-unknown}"
         continue
     fi
-    if [ ! -s "$agents_file" ]; then
-        echo "[]" > "$agents_file"
-    fi
-    agents=$(cat "$agents_file")
+    agents=$(load_pool_agents_json "$agents_file")
 
     # VMSS-aware classification.
     eval "$(classify_pool_agents "$agents" "$is_elastic" "$pool_name")"
@@ -189,10 +190,21 @@ for ((i=0; i<pool_count; i++)); do
     if [ "$agent_count" -gt 0 ] && [ "$online_count" -eq 0 ]; then
         if [ "$pool_kind" = "elastic" ] || [ "$pool_kind" = "ephemeral" ]; then
             if [ "$busy_count" -gt 0 ]; then
-                pool_issues+=("No online agents but $busy_count assigned request(s) waiting (pool cannot service queued work)")
+                pool_issues+=("No online agents but $busy_count assigned request(s) on registered agents (pool cannot service work)")
                 if [ "$severity" -gt 2 ]; then severity=2; fi
             else
-                echo "  $pool_kind pool scaled to zero (idle): 0 online, $offline_count expected offline, no queued work. Not flagged."
+                pool_details=$(ado_pool_issue_details \
+                    "Pool scaled to zero: 0 online, $offline_count expected offline churn, no assignedRequest on agents." \
+                    "$pool_name" "$pool_id" "$pool_type" "$pool_kind" "$agent_count" "$online_count" \
+                    "$offline_count" "$busy_count" "$expected_offline" \
+                    "Advisory only: verify in Azure DevOps whether pipeline runs are queued for this pool." "")
+                capacity_json=$(echo "$capacity_json" | jq \
+                    --arg title "Agent Pool \`$pool_name\` Scaled To Zero (Verify Queue)" \
+                    --arg details "$pool_details" \
+                    --arg severity "4" \
+                    --arg nextStep "No action if pipelines are not waiting. If builds are queued, investigate autoscale/VMSS/KEDA and service connections for this pool." \
+                    '. += [{"title": $title, "details": $details, "next_steps": $nextStep, "severity": ($severity | tonumber)}]')
+                echo "  $pool_kind pool $pool_name scaled to zero: advisory issue raised."
             fi
         else
             pool_issues+=("All agents offline")
@@ -232,6 +244,11 @@ for ((i=0; i<pool_count; i++)); do
         pools_with_issues=$((pools_with_issues + 1))
         issues_summary=$(IFS='; '; echo "${pool_issues[*]}")
         title="Agent Pool Capacity Issue: $pool_name"
+        pool_details=$(ado_pool_issue_details \
+            "Capacity issues: $issues_summary" \
+            "$pool_name" "$pool_id" "$pool_type" "$pool_kind" "$agent_count" "$online_count" \
+            "$offline_count" "$busy_count" "$expected_offline" \
+            "Utilization (online agents only): ${utilization}%" "")
         
         capacity_json=$(echo "$capacity_json" | jq \
             --arg title "$title" \
@@ -246,6 +263,7 @@ for ((i=0; i<pool_count; i++)); do
             --arg busy_count "$busy_count" \
             --arg utilization "$utilization" \
             --arg issues_summary "$issues_summary" \
+            --arg details "$pool_details" \
             --arg severity "$severity" \
             '. += [{
                "title": $title,
@@ -261,7 +279,7 @@ for ((i=0; i<pool_count; i++)); do
                "utilization_percent": $utilization,
                "issues_summary": $issues_summary,
                "severity": ($severity | tonumber),
-               "details": "Pool \($pool_name) [\($pool_kind)]: \($agent_count) agents (\($online_count) online, \($busy_count) busy, \($offline_count) offline of which \($expected_offline) are expected scale-set/ephemeral churn). Utilization: \($utilization)%. Issues: \($issues_summary)",
+               "details": $details,
                "next_steps": "Review agent pool \($pool_name) online capacity. For elastic/VMSS pools, verify the scale-set can provision agents; for static pools, investigate the offline agents and add capacity if utilization is high."
              }]')
     else

--- a/codebundles/azure-devops-organization-health/cross-project-dependencies.sh
+++ b/codebundles/azure-devops-organization-health/cross-project-dependencies.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
-set -x
+# NOTE: `set -x` is intentionally NOT used (it leaks AZURE_DEVOPS_PAT into logs
+# and bloats output). Set AZ_DEBUG=1 to opt in to tracing for local debugging.
+[ "${AZ_DEBUG:-0}" = "1" ] && set -x
 # -----------------------------------------------------------------------------
 # REQUIRED ENV VARS:
 #   AZURE_DEVOPS_ORG

--- a/codebundles/azure-devops-organization-health/license-utilization.sh
+++ b/codebundles/azure-devops-organization-health/license-utilization.sh
@@ -82,25 +82,47 @@ fi
 
 echo "Found $user_count users. Analyzing license distribution..."
 
-# Analyze license types and usage
-basic_users=$(jq '[.items[] | select(.accessLevel.accountLicenseType == "basic")] | length' users.json)
-stakeholder_users=$(jq '[.items[] | select(.accessLevel.accountLicenseType == "stakeholder")] | length' users.json)
-visual_studio_users=$(jq '[.items[] | select(.accessLevel.accountLicenseType == "msdn")] | length' users.json)
-express_users=$(jq '[.items[] | select(.accessLevel.accountLicenseType == "express")] | length' users.json)
-advanced_users=$(jq '[.items[] | select(.accessLevel.accountLicenseType == "advanced")] | length' users.json)
+# Analyze license types and usage.
+#
+# Azure DevOps accountLicenseType enum maps to the marketed license names as:
+#   express / professional -> "Basic"            (billed, ~$6/user/month)
+#   advanced               -> "Basic + Test Plans" (billed, ~$52/user/month)
+#   stakeholder            -> "Stakeholder"        (free)
+# Visual Studio subscribers are NOT a distinct accountLicenseType; they carry an
+# msdnLicenseType (or licensingSource == "msdn") and their access is covered by
+# the VS subscription, so they are not separately billed. Counting only the
+# literal "basic"/"msdn" enum values (the old logic) under-reported paid seats
+# badly (e.g. 1384 "express" users showed as 0 Basic and $0 cost).
+license_counts=$(jq -c '
+    def lvl:    (.accessLevel.accountLicenseType // "none");
+    def msdn:   (.accessLevel.msdnLicenseType   // "none");
+    def licsrc: (.accessLevel.licensingSource    // "none");
+    def is_vs:  ((msdn != "none") or (licsrc == "msdn"));
+    reduce .items[] as $x ({basic:0, advanced:0, stakeholder:0, vs:0, other:0};
+        ($x | is_vs) as $v | ($x | lvl) as $l |
+        if   $l == "stakeholder"                       then .stakeholder += 1
+        elif $v                                        then .vs += 1
+        elif ($l == "express" or $l == "professional") then .basic += 1
+        elif $l == "advanced"                          then .advanced += 1
+        else .other += 1 end)
+    ' users.json)
+basic_users=$(echo "$license_counts" | jq -r '.basic')
+advanced_users=$(echo "$license_counts" | jq -r '.advanced')
+stakeholder_users=$(echo "$license_counts" | jq -r '.stakeholder')
+visual_studio_users=$(echo "$license_counts" | jq -r '.vs')
+other_users=$(echo "$license_counts" | jq -r '.other')
 
 echo "License Distribution:"
-echo "  Basic: $basic_users"
-echo "  Stakeholder: $stakeholder_users"
-echo "  Visual Studio Subscriber: $visual_studio_users"
-echo "  Express: $express_users"
-echo "  Advanced: $advanced_users"
+echo "  Basic (express/professional): $basic_users"
+echo "  Basic + Test Plans (advanced): $advanced_users"
+echo "  Stakeholder (free): $stakeholder_users"
+echo "  Visual Studio Subscriber (covered): $visual_studio_users"
+echo "  Other/None: $other_users"
 
-# Calculate license costs (approximate based on typical pricing)
-# Note: These are rough estimates and actual costs may vary
-basic_cost_per_user=6  # USD per month
-visual_studio_cost_per_user=0  # Usually included with VS subscription
-advanced_cost_per_user=10  # USD per month
+# Calculate license costs (approximate list pricing; actual contract pricing varies).
+basic_cost_per_user=6       # USD per month (Basic)
+advanced_cost_per_user=52   # USD per month (Basic + Test Plans)
+# Stakeholder and VS-subscriber seats are not separately billed.
 
 estimated_monthly_cost=$(( (basic_users * basic_cost_per_user) + (advanced_users * advanced_cost_per_user) ))
 
@@ -194,7 +216,6 @@ if [ ${#license_issues[@]} -gt 0 ]; then
         --arg basic_users "$basic_users" \
         --arg stakeholder_users "$stakeholder_users" \
         --arg visual_studio_users "$visual_studio_users" \
-        --arg express_users "$express_users" \
         --arg advanced_users "$advanced_users" \
         --arg inactive_users "$inactive_users" \
         --arg estimated_monthly_cost "$estimated_monthly_cost" \
@@ -206,13 +227,12 @@ if [ ${#license_issues[@]} -gt 0 ]; then
            "basic_users": ($basic_users | tonumber),
            "stakeholder_users": ($stakeholder_users | tonumber),
            "visual_studio_users": ($visual_studio_users | tonumber),
-           "express_users": ($express_users | tonumber),
            "advanced_users": ($advanced_users | tonumber),
            "inactive_users": ($inactive_users | tonumber),
            "estimated_monthly_cost_usd": ($estimated_monthly_cost | tonumber),
            "issues_summary": $issues_summary,
            "severity": ($severity | tonumber),
-           "details": "Organization has \($total_users) users: \($basic_users) Basic, \($stakeholder_users) Stakeholder, \($visual_studio_users) VS Subscriber. Estimated cost: $\($estimated_monthly_cost)/month. Issues: \($issues_summary)",
+           "details": "Organization has \($total_users) users: \($basic_users) Basic, \($advanced_users) Basic+Test Plans, \($stakeholder_users) Stakeholder, \($visual_studio_users) VS Subscriber. Estimated cost: $\($estimated_monthly_cost)/month. Issues: \($issues_summary)",
            "next_steps": "Review license allocation and consider optimizing user access levels. Remove inactive users and ensure appropriate license types are assigned."
          }]')
 else
@@ -257,7 +277,7 @@ echo "License utilization analysis completed. Results saved to $OUTPUT_FILE"
 echo ""
 echo "=== LICENSE UTILIZATION SUMMARY ==="
 echo "Total Users: $user_count"
-echo "Basic: $basic_users, Stakeholder: $stakeholder_users, VS Subscriber: $visual_studio_users"
+echo "Basic: $basic_users, Basic+Test Plans: $advanced_users, Stakeholder: $stakeholder_users, VS Subscriber: $visual_studio_users, Other: $other_users"
 echo "Estimated Monthly Cost: \$${estimated_monthly_cost} USD"
 echo "Inactive Users: $inactive_users"
 echo ""

--- a/codebundles/azure-devops-organization-health/license-utilization.sh
+++ b/codebundles/azure-devops-organization-health/license-utilization.sh
@@ -65,9 +65,15 @@ user_count=$(jq '.items | length' users.json)
 users_partial=$(jq -r '.partial // false' users.json)
 if [ "$users_partial" = "true" ]; then
     echo "WARNING: user list is incomplete (pagination stopped early); license figures are a lower bound."
+    lic_details=$(ado_issue_details \
+        "User pagination did not complete; license figures are a lower bound." \
+        "Users analyzed (partial): $user_count" \
+        "Cause: a page failed mid-pagination or the 100000-row safety cap was reached" \
+        "Impact: inactive-user counts and cost estimates may be understated" \
+        "API: az devops user list with USER_PAGE_SIZE=${USER_PAGE_SIZE:-1000}")
     license_json=$(echo "$license_json" | jq \
         --arg title "User List Incomplete For License Analysis" \
-        --arg details "User pagination did not complete (a page failed or the safety cap was reached). License counts and inactive-user figures below are based on a partial set of $user_count users and should be treated as a lower bound." \
+        --arg details "$lic_details" \
         --arg severity "3" \
         --arg next_steps "Re-run when the Member Entitlement Management API is healthy. If the org exceeds 100000 users, raise the pagination safety cap. Check for throttling." \
         '. += [{"title": $title, "details": $details, "severity": ($severity | tonumber), "next_steps": $next_steps}]')
@@ -102,7 +108,7 @@ license_counts=$(jq -c '
         ($x | is_vs) as $v | ($x | lvl) as $l |
         if   $l == "stakeholder"                       then .stakeholder += 1
         elif $v                                        then .vs += 1
-        elif ($l == "express" or $l == "professional") then .basic += 1
+        elif ($l == "express" or $l == "professional" or $l == "basic") then .basic += 1
         elif $l == "advanced"                          then .advanced += 1
         else .other += 1 end)
     ' users.json)
@@ -188,8 +194,10 @@ if [ "$stakeholder_users" -eq 0 ] && [ "$user_count" -gt 5 ]; then
     license_issues+=("No stakeholder users - consider using stakeholder licenses for view-only users")
 fi
 
-if [ "$visual_studio_users" -eq 0 ] && [ "$basic_users" -gt 10 ]; then
-    license_issues+=("No Visual Studio subscribers detected - verify if developers have VS subscriptions")
+# VS subscribers are detected via msdnLicenseType/licensingSource, not accountLicenseType.
+# Do not warn based on Basic seat count alone — many orgs use express/professional only.
+if [ "$visual_studio_users" -eq 0 ] && [ "$other_users" -gt 50 ]; then
+    license_issues+=("Many entitlements ($other_users) have unrecognized license types — verify accountLicenseType mapping")
 fi
 
 if [ "$user_count" -gt 100 ]; then
@@ -210,6 +218,18 @@ if [ ${#license_issues[@]} -gt 0 ]; then
     issues_summary=$(IFS='; '; echo "${license_issues[*]}")
     title="License Utilization: Optimization Opportunities"
     
+    lic_details=$(ado_issue_details \
+        "License optimization opportunities detected." \
+        "Total users: $user_count" \
+        "Basic (express/professional/basic): $basic_users" \
+        "Basic+Test Plans (advanced): $advanced_users" \
+        "Stakeholder (free): $stakeholder_users" \
+        "VS Subscriber (msdn-covered): $visual_studio_users" \
+        "Other/unmapped: $other_users" \
+        "Inactive 90+ days: $inactive_users (of $users_with_access_info tracked)" \
+        "Estimated monthly cost (list pricing): \$${estimated_monthly_cost} USD" \
+        "Findings: $issues_summary" \
+        "Note: express and professional accountLicenseType values are billed as Basic (~\$6/mo); advanced is Basic+Test Plans (~\$52/mo).")
     license_json=$(echo "$license_json" | jq \
         --arg title "$title" \
         --arg total_users "$user_count" \
@@ -220,6 +240,7 @@ if [ ${#license_issues[@]} -gt 0 ]; then
         --arg inactive_users "$inactive_users" \
         --arg estimated_monthly_cost "$estimated_monthly_cost" \
         --arg issues_summary "$issues_summary" \
+        --arg details "$lic_details" \
         --arg severity "$severity" \
         '. += [{
            "title": $title,
@@ -232,7 +253,7 @@ if [ ${#license_issues[@]} -gt 0 ]; then
            "estimated_monthly_cost_usd": ($estimated_monthly_cost | tonumber),
            "issues_summary": $issues_summary,
            "severity": ($severity | tonumber),
-           "details": "Organization has \($total_users) users: \($basic_users) Basic, \($advanced_users) Basic+Test Plans, \($stakeholder_users) Stakeholder, \($visual_studio_users) VS Subscriber. Estimated cost: $\($estimated_monthly_cost)/month. Issues: \($issues_summary)",
+           "details": $details,
            "next_steps": "Review license allocation and consider optimizing user access levels. Remove inactive users and ensure appropriate license types are assigned."
          }]')
 else
@@ -241,9 +262,16 @@ fi
 
 # Add specific recommendations based on findings
 if [ "$inactive_users" -gt 0 ]; then
+    inactive_details=$(ado_issue_details \
+        "$inactive_users users inactive for 90+ days (includes never-accessed ADO epoch dates)." \
+        "Inactive users: $inactive_users" \
+        "Users with lastAccessedDate tracked: $users_with_access_info" \
+        "Cutoff: 90 days before run (UTC)" \
+        "Reclamation: review Member Entitlement Management in Azure DevOps > Organization Settings > Users" \
+        "Cost impact: each inactive Basic seat ~\$6/mo; Basic+Test Plans ~\$52/mo")
     license_json=$(echo "$license_json" | jq \
         --arg title "Inactive User Cleanup Recommended" \
-        --arg details "$inactive_users users have been inactive for 90+ days" \
+        --arg details "$inactive_details" \
         --arg severity "2" \
         '. += [{
            "title": $title,

--- a/codebundles/azure-devops-organization-health/meta.yaml
+++ b/codebundles/azure-devops-organization-health/meta.yaml
@@ -56,10 +56,10 @@ spec:
       default: "60"
       example: "70"
     - name: AGENT_FETCH_PARALLELISM
-      description: "Number of agent-pool agent lists to fetch concurrently (performance tuning for organizations with many pools)"
+      description: "Number of agent-pool agent lists to fetch concurrently (performance tuning for organizations with many pools). Clamped to 1-32; agents are fetched via REST to avoid per-pool CLI startup cost."
       required: false
-      default: "8"
-      example: "12"
+      default: "20"
+      example: "24"
     - name: USER_PAGE_SIZE
       description: "Page size used when paginating organization users for licensing/policy analysis (max 10000)"
       required: false

--- a/codebundles/azure-devops-organization-health/organization-policies.sh
+++ b/codebundles/azure-devops-organization-health/organization-policies.sh
@@ -95,7 +95,7 @@ else
             ($x | is_vs) as $v | ($x | lvl) as $l |
             if   $l == "stakeholder"                       then .stakeholder += 1
             elif $v                                        then .vs += 1
-            elif ($l == "express" or $l == "professional") then .basic += 1
+            elif ($l == "express" or $l == "professional" or $l == "basic") then .basic += 1
             elif $l == "advanced"                          then .advanced += 1
             else .other += 1 end)')
     basic_users=$(echo "$license_counts" | jq -r '.basic')

--- a/codebundles/azure-devops-organization-health/organization-policies.sh
+++ b/codebundles/azure-devops-organization-health/organization-policies.sh
@@ -82,12 +82,29 @@ else
         access_denied_areas+=("User Information: pagination incomplete - analyzed only $user_count users (a page failed or the safety cap was reached); user-based policy findings may be understated.")
     fi
     
-    # Analyze user access levels
-    basic_users=$(echo "$users" | jq '[.items[] | select(.accessLevel.accountLicenseType == "express" or .accessLevel.accountLicenseType == "basic")] | length')
-    stakeholder_users=$(echo "$users" | jq '[.items[] | select(.accessLevel.accountLicenseType == "stakeholder")] | length')
-    visual_studio_users=$(echo "$users" | jq '[.items[] | select(.accessLevel.accountLicenseType == "professional" or .accessLevel.accountLicenseType == "advanced")] | length')
+    # Analyze user access levels. Keep this categorisation consistent with
+    # license-utilization.sh: express/professional -> Basic, advanced -> Basic +
+    # Test Plans, stakeholder -> free, and Visual Studio subscribers are detected
+    # via msdnLicenseType / licensingSource (not a distinct accountLicenseType).
+    license_counts=$(echo "$users" | jq -c '
+        def lvl:    (.accessLevel.accountLicenseType // "none");
+        def msdn:   (.accessLevel.msdnLicenseType   // "none");
+        def licsrc: (.accessLevel.licensingSource    // "none");
+        def is_vs:  ((msdn != "none") or (licsrc == "msdn"));
+        reduce .items[] as $x ({basic:0, advanced:0, stakeholder:0, vs:0, other:0};
+            ($x | is_vs) as $v | ($x | lvl) as $l |
+            if   $l == "stakeholder"                       then .stakeholder += 1
+            elif $v                                        then .vs += 1
+            elif ($l == "express" or $l == "professional") then .basic += 1
+            elif $l == "advanced"                          then .advanced += 1
+            else .other += 1 end)')
+    basic_users=$(echo "$license_counts" | jq -r '.basic')
+    advanced_users=$(echo "$license_counts" | jq -r '.advanced')
+    stakeholder_users=$(echo "$license_counts" | jq -r '.stakeholder')
+    visual_studio_users=$(echo "$license_counts" | jq -r '.vs')
     
-    echo "  Basic users: $basic_users"
+    echo "  Basic users (express/professional): $basic_users"
+    echo "  Basic + Test Plans (advanced): $advanced_users"
     echo "  Stakeholder users: $stakeholder_users"
     echo "  Visual Studio subscribers: $visual_studio_users"
     

--- a/codebundles/azure-devops-organization-health/organization-service-health.sh
+++ b/codebundles/azure-devops-organization-health/organization-service-health.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
-set -x
+# NOTE: `set -x` is intentionally NOT used (it leaks AZURE_DEVOPS_PAT into logs
+# and bloats output). Set AZ_DEBUG=1 to opt in to tracing for local debugging.
+[ "${AZ_DEBUG:-0}" = "1" ] && set -x
 # -----------------------------------------------------------------------------
 # REQUIRED ENV VARS:
 #   AZURE_DEVOPS_ORG

--- a/codebundles/azure-devops-organization-health/platform-issue-investigation.sh
+++ b/codebundles/azure-devops-organization-health/platform-issue-investigation.sh
@@ -49,7 +49,7 @@ if agent_pools=$(az pipelines pool list --output json 2>/dev/null); then
     pool_count=$(echo "$agent_pools" | jq '. | length')
 
     # Fetch all pool agents in parallel rather than one slow call per pool.
-    echo "  Fetching agents for $pool_count pools (parallelism: ${AGENT_FETCH_PARALLELISM:-8})..."
+    echo "  Fetching agents for $pool_count pools (parallelism: ${AGENT_FETCH_PARALLELISM:-20})..."
     fetch_pool_agents_parallel "$agent_pools" "$AGENT_CACHE_DIR"
 
     for ((i=0; i<pool_count; i++)); do
@@ -85,25 +85,28 @@ if agent_pools=$(az pipelines pool list --output json 2>/dev/null); then
         [ -s "$agents_file" ] || echo "[]" > "$agents_file"
         agents=$(cat "$agents_file")
 
-        eval "$(classify_pool_agents "$agents" "$is_elastic")"
+        eval "$(classify_pool_agents "$agents" "$is_elastic" "$pool_name")"
         agent_count=$AGENT_COUNT
         online_count=$ONLINE_COUNT
         offline_count=$OFFLINE_COUNT
+        busy_count=$BUSY_COUNT
         pool_kind=$POOL_KIND
 
         echo "  Investigating pool: $pool_name [$pool_kind] ($online_count online / $offline_count offline / $agent_count total)"
 
         if [ "$pool_kind" = "elastic" ] || [ "$pool_kind" = "ephemeral" ]; then
             # Offline agents in elastic/ephemeral pools are torn-down scale-set
-            # instances, not failures. Only a complete lack of online capacity is
-            # actionable.
-            if [ "$agent_count" -gt 0 ] && [ "$online_count" -eq 0 ]; then
+            # instances, not failures. A complete lack of online capacity is only
+            # actionable when work is actually queued; idle scaled-to-zero is normal.
+            if [ "$agent_count" -gt 0 ] && [ "$online_count" -eq 0 ] && [ "${busy_count:-0}" -gt 0 ]; then
                 investigation_json=$(echo "$investigation_json" | jq \
-                    --arg title "Elastic Pool Has No Online Agents: $pool_name" \
-                    --arg details "Elastic/ephemeral pool $pool_name ($pool_kind) currently has 0 online agents ($offline_count offline registrations are expected scale-set churn). The pool cannot service jobs until it provisions agents." \
+                    --arg title "Elastic Pool Has No Online Agents While Work Is Queued: $pool_name" \
+                    --arg details "Elastic/ephemeral pool $pool_name ($pool_kind) has 0 online agents but $busy_count assigned request(s) ($offline_count offline registrations are expected scale-set churn). The pool cannot service queued work until it provisions agents." \
                     --arg severity "2" \
-                    --arg next_steps "Verify the VMSS/scale-set can provision agents: check the elastic pool configuration, the backing Azure scale set health, the service connection, and any sizing errors in Azure DevOps > Organization Settings > Agent pools." \
+                    --arg next_steps "Verify the VMSS/scale-set/Kubernetes scaler can provision agents: check the elastic pool configuration, the backing Azure scale set / KEDA health, the service connection, and any sizing errors in Azure DevOps > Organization Settings > Agent pools." \
                     '. += [{"title": $title, "details": $details, "severity": ($severity | tonumber), "next_steps": $next_steps}]')
+            elif [ "$agent_count" -gt 0 ] && [ "$online_count" -eq 0 ]; then
+                echo "  $pool_kind pool $pool_name scaled to zero (idle): 0 online, $offline_count expected offline, no queued work. Not flagged."
             fi
         elif [ "$offline_count" -gt 0 ]; then
             # Static pool: offline agents are genuine lost capacity. Cap the

--- a/codebundles/azure-devops-organization-health/platform-issue-investigation.sh
+++ b/codebundles/azure-devops-organization-health/platform-issue-investigation.sh
@@ -56,6 +56,7 @@ if agent_pools=$(az pipelines pool list --output json 2>/dev/null); then
         pool_json=$(jq -c ".[${i}]" <<< "$agent_pools")
         pool_name=$(echo "$pool_json" | jq -r '.name')
         pool_id=$(echo "$pool_json" | jq -r '.id')
+        pool_type=$(echo "$pool_json" | jq -r '.poolType // "Unknown"')
         is_hosted=$(echo "$pool_json" | jq -r '.isHosted // false')
         
         # Skip Microsoft-hosted pools
@@ -73,17 +74,20 @@ if agent_pools=$(az pipelines pool list --output json 2>/dev/null); then
         # A fetch failure (permission/timeout/throttle) is reported as an
         # access issue rather than being treated as an empty pool.
         if fetch_err=$(agents_fetch_failed "$agents_file"); then
+            pool_details=$(ado_pool_issue_details \
+                "Failed to list agents for pool $pool_name (id=$pool_id). Access/availability error." \
+                "$pool_name" "$pool_id" "$pool_type" "unknown" "0" "0" "0" "0" "0" \
+                "Fetch error: ${fetch_err:-unknown}" "")
             investigation_json=$(echo "$investigation_json" | jq \
                 --arg title "Unable To Retrieve Agents For Pool: $pool_name" \
-                --arg details "Failed to list agents for pool $pool_name (ID: $pool_id). This is an access/availability error, not an empty pool. Error: ${fetch_err:-unknown}" \
+                --arg details "$pool_details" \
                 --arg severity "3" \
                 --arg next_steps "Verify the identity has the Agent Pools (Read) scope and 'Reader' on this pool, then re-run. Transient throttling/timeouts may also cause this." \
                 '. += [{"title": $title, "details": $details, "severity": ($severity | tonumber), "next_steps": $next_steps}]')
             echo "  WARNING: could not fetch agents for pool $pool_name ($pool_id): ${fetch_err:-unknown}"
             continue
         fi
-        [ -s "$agents_file" ] || echo "[]" > "$agents_file"
-        agents=$(cat "$agents_file")
+        agents=$(load_pool_agents_json "$agents_file")
 
         eval "$(classify_pool_agents "$agents" "$is_elastic" "$pool_name")"
         agent_count=$AGENT_COUNT
@@ -99,14 +103,28 @@ if agent_pools=$(az pipelines pool list --output json 2>/dev/null); then
             # instances, not failures. A complete lack of online capacity is only
             # actionable when work is actually queued; idle scaled-to-zero is normal.
             if [ "$agent_count" -gt 0 ] && [ "$online_count" -eq 0 ] && [ "${busy_count:-0}" -gt 0 ]; then
+                pool_details=$(ado_pool_issue_details \
+                    "Elastic/ephemeral pool has 0 online agents but active assignedRequest on $busy_count agent(s)." \
+                    "$pool_name" "$pool_id" "$pool_type" "$pool_kind" "$agent_count" "$online_count" \
+                    "$offline_count" "$busy_count" "$offline_count" "" "")
                 investigation_json=$(echo "$investigation_json" | jq \
-                    --arg title "Elastic Pool Has No Online Agents While Work Is Queued: $pool_name" \
-                    --arg details "Elastic/ephemeral pool $pool_name ($pool_kind) has 0 online agents but $busy_count assigned request(s) ($offline_count offline registrations are expected scale-set churn). The pool cannot service queued work until it provisions agents." \
+                    --arg title "Elastic Pool Has No Online Agents While Work Is Assigned: $pool_name" \
+                    --arg details "$pool_details" \
                     --arg severity "2" \
                     --arg next_steps "Verify the VMSS/scale-set/Kubernetes scaler can provision agents: check the elastic pool configuration, the backing Azure scale set / KEDA health, the service connection, and any sizing errors in Azure DevOps > Organization Settings > Agent pools." \
                     '. += [{"title": $title, "details": $details, "severity": ($severity | tonumber), "next_steps": $next_steps}]')
             elif [ "$agent_count" -gt 0 ] && [ "$online_count" -eq 0 ]; then
-                echo "  $pool_kind pool $pool_name scaled to zero (idle): 0 online, $offline_count expected offline, no queued work. Not flagged."
+                pool_details=$(ado_pool_issue_details \
+                    "Pool scaled to zero with $offline_count expected offline registrations; no assignedRequest detected." \
+                    "$pool_name" "$pool_id" "$pool_type" "$pool_kind" "$agent_count" "$online_count" \
+                    "$offline_count" "$busy_count" "$offline_count" \
+                    "Advisory: verify whether pipeline runs are queued for this pool in Azure DevOps." "")
+                investigation_json=$(echo "$investigation_json" | jq \
+                    --arg title "Elastic Pool Scaled To Zero (Verify Queue): $pool_name" \
+                    --arg details "$pool_details" \
+                    --arg severity "4" \
+                    --arg next_steps "No action if no pipelines are waiting. If builds are queued, investigate autoscale/VMSS/KEDA." \
+                    '. += [{"title": $title, "details": $details, "severity": ($severity | tonumber), "next_steps": $next_steps}]')
             fi
         elif [ "$offline_count" -gt 0 ]; then
             # Static pool: offline agents are genuine lost capacity. Cap the
@@ -118,9 +136,13 @@ if agent_pools=$(az pipelines pool list --output json 2>/dev/null); then
                 offline_details="$offline_details; ... and $((offline_count - MAX_OFFLINE_DETAIL)) more"
             fi
 
+            pool_details=$(ado_pool_issue_details \
+                "Static pool has $offline_count offline agents out of $agent_count total." \
+                "$pool_name" "$pool_id" "${pool_type:-unknown}" "$pool_kind" "$agent_count" "$online_count" \
+                "$offline_count" "$busy_count" "0" "" "$offline_details")
             investigation_json=$(echo "$investigation_json" | jq \
                 --arg title "Offline Agents in Pool: $pool_name" \
-                --arg details "Static pool $pool_name has $offline_count offline agents out of $agent_count total. Sample: $offline_details" \
+                --arg details "$pool_details" \
                 --arg severity "3" \
                 --arg next_steps "Check agent connectivity, restart agent services, and verify network connectivity for offline agents" \
                 '. += [{"title": $title, "details": $details, "severity": ($severity | tonumber), "next_steps": $next_steps}]')

--- a/codebundles/azure-devops-organization-health/preflight-check.sh
+++ b/codebundles/azure-devops-organization-health/preflight-check.sh
@@ -65,23 +65,15 @@ probe() {
 # 1. Identity (best effort, non-blocking)
 # =========================================================================
 echo "=== Authenticated Identity ==="
-identity_json='{"name":"unknown","id":"unknown","auth_type":"'"$AUTH_TYPE"'","confirmed":false}'
-conn_hdr=$(ado_auth_header)
-if [ -n "$conn_hdr" ]; then
-    conn_data=$(curl -s --max-time 15 -H "Authorization: $conn_hdr" \
-        "$ORG_URL/_apis/connectionData?api-version=7.1" 2>/dev/null || echo "")
-    if echo "$conn_data" | jq -e '.authenticatedUser.id' >/dev/null 2>&1; then
-        uname=$(echo "$conn_data" | jq -r '.authenticatedUser.providerDisplayName // .authenticatedUser.customDisplayName // "unknown"')
-        uid=$(echo "$conn_data" | jq -r '.authenticatedUser.id // "unknown"')
-        echo "  Display Name: $uname"
-        echo "  User ID:      $uid"
-        identity_json=$(jq -n --arg n "$uname" --arg i "$uid" --arg a "$AUTH_TYPE" \
-            '{name:$n, id:$i, auth_type:$a, confirmed:true}')
-    else
-        echo "  NOTE: connectionData did not return an identity (often blocked by a proxy or"
-        echo "        a PAT without the Graph scope). Non-blocking; capability probes below"
-        echo "        are the authoritative access signal."
-    fi
+identity_json=$(ado_identity_json)
+if [ "$(echo "$identity_json" | jq -r '.confirmed')" = "true" ]; then
+    echo "  Display Name: $(echo "$identity_json" | jq -r '.name')"
+    echo "  User ID:      $(echo "$identity_json" | jq -r '.id')"
+    [ -n "$(echo "$identity_json" | jq -r '.email')" ] && echo "  Account:      $(echo "$identity_json" | jq -r '.email')"
+else
+    echo "  NOTE: could not resolve the authenticated identity (connectionData blocked"
+    echo "        by a proxy, or a PAT without Graph scope). Non-blocking; the capability"
+    echo "        probes below are the authoritative access signal."
 fi
 
 # =========================================================================

--- a/codebundles/azure-devops-organization-health/runbook.robot
+++ b/codebundles/azure-devops-organization-health/runbook.robot
@@ -81,7 +81,7 @@ Check Agent Pool Capacity and Utilization for Organization `${AZURE_DEVOPS_ORG}`
     ...    bash_file=agent-pool-capacity.sh
     ...    env=${env}
     ...    secret__azure_devops_pat=${AZURE_DEVOPS_PAT}
-    ...    timeout_seconds=180
+    ...    timeout_seconds=300
     ...    include_in_history=false
     ...    show_in_rwl_cheatsheet=true
     
@@ -91,8 +91,16 @@ Check Agent Pool Capacity and Utilization for Organization `${AZURE_DEVOPS_ORG}`
     TRY
         ${issue_list}=    Evaluate    json.loads(r'''${issues.stdout}''')    json
     EXCEPT
-        Log    Failed to load agent capacity JSON payload, defaulting to empty list.    WARN
+        Log    Failed to load agent capacity JSON payload — the script likely timed out or the API was unreachable.    WARN
         ${issue_list}=    Create List
+        RW.Core.Add Issue
+        ...    severity=3
+        ...    expected=Agent pool capacity data should be collected for organization `${AZURE_DEVOPS_ORG}`
+        ...    actual=Agent pool capacity collection produced no output (likely a timeout while enumerating agents across all pools, or the API was unreachable)
+        ...    title=Agent Pool Capacity Collection Failed for `${AZURE_DEVOPS_ORG}`
+        ...    reproduce_hint=${agent_capacity.cmd}
+        ...    details=agent-pool-capacity.sh did not produce valid JSON. For organizations with many pools, raise AGENT_FETCH_PARALLELISM and/or the task timeout. Preflight: ${PREFLIGHT_SUMMARY}
+        ...    next_steps=Increase AGENT_FETCH_PARALLELISM (default 20), confirm Agent Pools (Read) access, and verify dev.azure.com connectivity from the runner.
     END
     
     IF    len(@{issue_list}) > 0

--- a/codebundles/azure-devops-organization-health/service-incident-check.sh
+++ b/codebundles/azure-devops-organization-health/service-incident-check.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
-set -x
+# NOTE: `set -x` is intentionally NOT used (it leaks AZURE_DEVOPS_PAT into logs
+# and bloats output). Set AZ_DEBUG=1 to opt in to tracing for local debugging.
+[ "${AZ_DEBUG:-0}" = "1" ] && set -x
 # -----------------------------------------------------------------------------
 # REQUIRED ENV VARS:
 #   AZURE_DEVOPS_ORG

--- a/codebundles/azure-devops-project-health/_az_helpers.sh
+++ b/codebundles/azure-devops-project-health/_az_helpers.sh
@@ -101,6 +101,44 @@ ado_auth_header() {
     fi
 }
 
+# Best-effort resolution of the authenticated identity. Echoes a JSON object:
+#   {name, id, email, auth_type, confirmed}
+# Tries `az devops invoke` FIRST so it shares the exact auth + proxy path as the
+# tasks/probes (a raw curl often fails behind a corporate proxy even when `az`
+# succeeds, which is why PAT runs previously reported identity "unknown"). Falls
+# back to a direct connectionData REST call. Never fails the caller.
+ado_identity_json() {
+    local org_url="https://dev.azure.com/$AZURE_DEVOPS_ORG"
+    local auth="${AUTH_TYPE:-service_principal}"
+    local resp=""
+
+    resp=$(az devops invoke --area Location --resource ConnectionData \
+        --org "$org_url" --api-version 7.1 --output json 2>/dev/null || echo "")
+
+    if ! echo "$resp" | jq -e '(.authenticatedUser.id // .authorizedUser.id)' >/dev/null 2>&1; then
+        local hdr; hdr=$(ado_auth_header)
+        if [ -n "$hdr" ]; then
+            resp=$(curl -s --max-time 15 -H "Authorization: $hdr" \
+                "$org_url/_apis/connectionData?api-version=7.1" 2>/dev/null || echo "")
+        fi
+    fi
+
+    if echo "$resp" | jq -e '(.authenticatedUser.id // .authorizedUser.id)' >/dev/null 2>&1; then
+        echo "$resp" | jq --arg a "$auth" '
+            (.authenticatedUser // .authorizedUser) as $u
+            | ($u.properties.Account."$value" // $u.emailAddress // "") as $email
+            | {
+                name:      ($u.providerDisplayName // $u.customDisplayName // $email // "unknown"),
+                id:        ($u.id // "unknown"),
+                email:     $email,
+                auth_type: $a,
+                confirmed: true
+              }'
+    else
+        jq -n --arg a "$auth" '{name:"unknown", id:"unknown", email:"", auth_type:$a, confirmed:false}'
+    fi
+}
+
 # Newline-separated list of elastic (VMSS / scale-set / agent-cloud) pool IDs.
 # Populated by load_elastic_pool_ids; empty until then or on failure.
 AZ_ELASTIC_POOL_IDS=""
@@ -169,9 +207,39 @@ pool_is_elastic() {
 # linger as "offline" registrations, so a raw offline count is misleading. The
 # meaningful signal for these pools is ONLINE capacity, not offline backlog.
 #
-# Args: $1 = agents JSON array, $2 = is_elastic ("true"/"false")
+# Heuristic: does this pool look like a self-managed ephemeral farm (Kubernetes/
+# KEDA, AKS, VMSS/scale-set, container agents) based on its NAME and its AGENT
+# NAMES? Such pools auto-generate agents with sequential/templated names and
+# leave stale "offline" registrations behind, so a raw offline count (or a
+# scaled-to-zero state) is expected churn, not an outage. This is the signal the
+# elastic-pools API and the online>0 ratio test miss when a pool is scaled to 0.
+# Args: $1 = agents JSON array, $2 = pool name
+pool_looks_ephemeral() {
+    local agents="$1" pool_name="${2:-}"
+    # Pool-name patterns.
+    if printf '%s' "$pool_name" \
+        | grep -Eiq 'k8s|aks|kube|keda|vmss|scale.?set|ephemeral|autoscale|elastic|container|-agents?$|aci'; then
+        return 0
+    fi
+    # Agent-name patterns: a majority named like generated/scaled instances, e.g.
+    # "azp-...", "...agents-0", "<base>-<N>" (trailing numeric suffix).
+    echo "$agents" | jq -e '
+        ([.[] | .name // ""]) as $n
+        | ($n | length) as $tot
+        | if $tot == 0 then false
+          else
+            ([ $n[] | select(
+                test("^azp-"; "i")
+                or test("agents?-[0-9]+$"; "i")
+                or test("-[0-9]+$")
+            )] | length) as $gen
+            | ($gen * 2) >= $tot
+          end' >/dev/null 2>&1
+}
+
+# Args: $1 = agents JSON array, $2 = is_elastic ("true"/"false"), $3 = pool name (optional)
 classify_pool_agents() {
-    local agents="$1" is_elastic="${2:-false}"
+    local agents="$1" is_elastic="${2:-false}" pool_name="${3:-}"
     local ephemeral_ratio="${EPHEMERAL_OFFLINE_RATIO:-60}"
 
     local counts total online offline busy
@@ -190,14 +258,20 @@ classify_pool_agents() {
     if [ "$is_elastic" = "true" ]; then
         kind="elastic"
         expected_offline=$offline
-    elif [ "$online" -gt 0 ] && [ "$total" -gt 0 ]; then
-        local off_ratio=$(( offline * 100 / total ))
-        if [ "$off_ratio" -ge "$ephemeral_ratio" ]; then
-            # Online capacity exists but offline dominates: classic signature of
-            # a self-managed VMSS/AKS/container pool leaving stale registrations.
-            kind="ephemeral"
-            expected_offline=$offline
-        fi
+    elif [ "$online" -gt 0 ] && [ "$total" -gt 0 ] \
+            && [ "$(( offline * 100 / total ))" -ge "$ephemeral_ratio" ]; then
+        # Online capacity exists but offline dominates: classic signature of a
+        # self-managed VMSS/AKS/container pool leaving stale registrations.
+        kind="ephemeral"
+        expected_offline=$offline
+    elif [ "$total" -gt 0 ] && [ "$offline" -eq "$total" ] \
+            && pool_looks_ephemeral "$agents" "$pool_name"; then
+        # Scaled-to-zero ephemeral farm: every agent offline AND the pool/agent
+        # naming matches a Kubernetes/VMSS/container pattern. This is the case the
+        # ratio test cannot catch (no online agents to take a ratio of), and is
+        # exactly the "very high offline count" false positive to suppress.
+        kind="ephemeral"
+        expected_offline=$offline
     fi
 
     echo "AGENT_COUNT=$total"
@@ -264,39 +338,62 @@ get_all_users() (
 
 # Fetch agents for every non-hosted pool concurrently, writing one JSON file per
 # pool to <out_dir>/agents_<poolId>.json. This turns what was an O(pools)
-# sequential wall of `az` calls into a bounded-parallel pass, which is the
-# dominant cost for organisations with hundreds of pools.
+# sequential wall of calls into a bounded-parallel pass, the dominant cost for
+# organisations with hundreds of pools.
+#
+# Agents are fetched via a direct REST call (curl) rather than `az pipelines
+# agent list`. The az CLI pays a ~1s Python startup PER pool, so for ~200 pools
+# that alone is several minutes and was causing the 180s task timeouts. The PAT/
+# bearer header is resolved once and passed to the workers via the environment
+# (not argv) so it never appears in `ps`. When no credential is available we
+# fall back to the az CLI.
 #
 # On a fetch FAILURE the file is written as {"__fetch_error__": true} (and the
-# stderr is preserved in agents_<poolId>.err) so callers can distinguish a
+# error is preserved in agents_<poolId>.err) so callers can distinguish a
 # permission/timeout/throttling error from a genuinely empty pool. Use the
 # agents_fetch_failed helper below to test for this.
-# Args: $1 = pools JSON array, $2 = output dir, $3 = max parallelism (default 8)
+# Args: $1 = pools JSON array, $2 = output dir, $3 = max parallelism (default 20)
 fetch_pool_agents_parallel() {
     local pools_json="$1" out_dir="$2"
-    local max_par="${3:-${AGENT_FETCH_PARALLELISM:-8}}"
+    local max_par="${3:-${AGENT_FETCH_PARALLELISM:-20}}"
     local org_url="https://dev.azure.com/$AZURE_DEVOPS_ORG"
     # Validate/clamp parallelism. xargs -P 0 means UNLIMITED concurrency, which
-    # would spawn one `az` per pool and overwhelm the runner/API.
+    # would spawn one worker per pool and overwhelm the runner/API.
     case "$max_par" in
-        ''|*[!0-9]*) max_par=8 ;;
+        ''|*[!0-9]*) max_par=20 ;;
     esac
     [ "$max_par" -lt 1 ] && max_par=1
     [ "$max_par" -gt 32 ] && max_par=32
     mkdir -p "$out_dir"
+
+    # Resolve auth once; pass via env to the parallel workers (keeps PAT out of argv).
+    export ADO_AUTH_HDR; ADO_AUTH_HDR=$(ado_auth_header)
+
     echo "$pools_json" \
         | jq -r '.[] | select((.isHosted // false) == false) | .id' \
         | xargs -r -P "$max_par" -I {} bash -c '
-            out="$1/agents_$2.json"
-            err="$1/agents_$2.err"
-            if az pipelines agent list --pool-id "$2" --org "$3" --output json >"$out" 2>"$err"; then
-                rm -f "$err"
+            pool="$2"; out="$1/agents_$2.json"; err="$1/agents_$2.err"; raw="$1/agents_$2.raw"
+            if [ -n "${ADO_AUTH_HDR:-}" ]; then
+                url="$3/_apis/distributedtask/pools/$pool/agents?includeAssignedRequest=true&api-version=7.1"
+                if curl -fsS --max-time 60 -H "Authorization: $ADO_AUTH_HDR" "$url" -o "$raw" 2>"$err"; then
+                    if jq -e "type == \"object\" and has(\"value\")" "$raw" >/dev/null 2>&1; then
+                        jq ".value // []" "$raw" >"$out" && rm -f "$raw" "$err"
+                    else
+                        echo "{\"__fetch_error__\": true}" >"$out"; mv -f "$raw" "$err" 2>/dev/null || true
+                    fi
+                else
+                    echo "{\"__fetch_error__\": true}" >"$out"; rm -f "$raw"
+                fi
             else
-                # Preserve the error; write a marker so callers report a real
-                # per-pool access/availability failure instead of "no agents".
-                echo "{\"__fetch_error__\": true}" >"$out"
+                # No credential header available: fall back to the az CLI.
+                if az pipelines agent list --pool-id "$pool" --org "$3" --output json >"$out" 2>"$err"; then
+                    rm -f "$err"
+                else
+                    echo "{\"__fetch_error__\": true}" >"$out"
+                fi
             fi
           ' _ "$out_dir" {} "$org_url"
+    unset ADO_AUTH_HDR
 }
 
 # Return 0 if the agents file for a pool indicates a fetch failure (marker), and

--- a/codebundles/azure-devops-project-health/_az_helpers.sh
+++ b/codebundles/azure-devops-project-health/_az_helpers.sh
@@ -207,23 +207,10 @@ pool_is_elastic() {
 # linger as "offline" registrations, so a raw offline count is misleading. The
 # meaningful signal for these pools is ONLINE capacity, not offline backlog.
 #
-# Heuristic: does this pool look like a self-managed ephemeral farm (Kubernetes/
-# KEDA, AKS, VMSS/scale-set, container agents) based on its NAME and its AGENT
-# NAMES? Such pools auto-generate agents with sequential/templated names and
-# leave stale "offline" registrations behind, so a raw offline count (or a
-# scaled-to-zero state) is expected churn, not an outage. This is the signal the
-# elastic-pools API and the online>0 ratio test miss when a pool is scaled to 0.
-# Args: $1 = agents JSON array, $2 = pool name
-pool_looks_ephemeral() {
-    local agents="$1" pool_name="${2:-}"
-    # Pool-name patterns.
-    if printf '%s' "$pool_name" \
-        | grep -Eiq 'k8s|aks|kube|keda|vmss|scale.?set|ephemeral|autoscale|elastic|container|-agents?$|aci'; then
-        return 0
-    fi
-    # Agent-name patterns: a majority named like generated/scaled instances, e.g.
-    # "azp-...", "...agents-0", "<base>-<N>" (trailing numeric suffix).
-    echo "$agents" | jq -e '
+# True when a majority of agent names look auto-generated (VMSS/K8s/container).
+# Args: $1 = agents JSON array
+agents_look_generated() {
+    echo "$1" | jq -e '
         ([.[] | .name // ""]) as $n
         | ($n | length) as $tot
         | if $tot == 0 then false
@@ -235,6 +222,22 @@ pool_looks_ephemeral() {
             )] | length) as $gen
             | ($gen * 2) >= $tot
           end' >/dev/null 2>&1
+}
+
+# Heuristic: self-managed ephemeral farm (Kubernetes/KEDA/AKS/VMSS/container).
+# Requires generated-looking agent names so static pools named "*-agent" or
+# containing "elastic" are not misclassified when every agent is offline.
+# Args: $1 = agents JSON array, $2 = pool name
+pool_looks_ephemeral() {
+    local agents="$1" pool_name="${2:-}"
+    agents_look_generated "$agents" || return 1
+    # Strong infra signals in the pool name reinforce the agent-name signal.
+    if printf '%s' "$pool_name" \
+        | grep -Eiq 'k8s|aks|kube|keda|vmss|scale.?set|ephemeral'; then
+        return 0
+    fi
+    # Agent-name majority alone is sufficient (e.g. cts-pool + azp-maven-agent-N).
+    return 0
 }
 
 # Args: $1 = agents JSON array, $2 = is_elastic ("true"/"false"), $3 = pool name (optional)
@@ -336,6 +339,59 @@ get_all_users() (
             '{items: ., totalCount: (. | length), partial: $partial}'
 )
 
+# Load agents JSON from a per-pool cache file. Returns 1 on fetch_error marker.
+# Always echoes a JSON array (never a non-array body that would break jq).
+# Args: $1 = path to agents_<poolId>.json
+load_pool_agents_json() {
+    local f="$1"
+    if agents_fetch_failed "$f"; then
+        return 1
+    fi
+    if [ ! -s "$f" ]; then
+        echo "[]"
+        return 0
+    fi
+    if jq -e 'type == "array"' "$f" >/dev/null 2>&1; then
+        cat "$f"
+    else
+        echo "[]"
+    fi
+}
+
+# Rich issue_details text for agent-pool findings (RunWhen agents consume the
+# JSON "details" field as issue_details).
+# Args: summary, pool_name, pool_id, pool_type, pool_kind, total, online, offline,
+#       busy, expected_offline, [extra paragraph], [sample offline agent names]
+ado_pool_issue_details() {
+    local summary="$1" pool_name="$2" pool_id="$3" pool_type="$4" pool_kind="$5"
+    local total="$6" online="$7" offline="$8" busy="$9" expected_offline="${10:-0}"
+    local extra="${11:-}" sample="${12:-}"
+    local org="${AZURE_DEVOPS_ORG:-unknown}"
+    printf '%s\n\n' "$summary"
+    printf 'Organization: %s\n' "$org"
+    printf 'Pool: %s (id=%s, poolType=%s, classified_as=%s)\n' "$pool_name" "$pool_id" "$pool_type" "$pool_kind"
+    printf 'Agent counts: total=%s online=%s offline=%s busy_assigned=%s expected_offline_churn=%s\n' \
+        "$total" "$online" "$offline" "$busy" "$expected_offline"
+    printf '\nInterpretation:\n'
+    printf '- classified_as elastic/ephemeral: most offline rows are torn-down VMSS/Kubernetes/container registrations, not necessarily failed machines.\n'
+    printf '- busy_assigned: agents with a non-null assignedRequest (work bound to a registered agent). This does NOT count pipeline jobs waiting in the pool queue when no agent is online.\n'
+    printf '- If builds are queued in Azure DevOps while online=0, open Organization Settings > Agent pools > %s and verify autoscale/VMSS/KEDA and service connections.\n' "$pool_name"
+    [ -n "$extra" ] && printf '\n%s\n' "$extra"
+    [ -n "$sample" ] && printf '\nSample offline agents: %s\n' "$sample"
+    printf '\nAPI probed: GET .../distributedtask/pools/%s/agents?includeAssignedRequest=true\n' "$pool_id"
+}
+
+# Generic structured issue_details for non-pool scripts.
+# Args: summary line, then zero or more "Key: value" lines
+ado_issue_details() {
+    local summary="$1"; shift
+    printf '%s\n\n--- Context ---\n' "$summary"
+    printf 'Organization: %s\n' "${AZURE_DEVOPS_ORG:-unknown}"
+    for line in "$@"; do
+        [ -n "$line" ] && printf '%s\n' "$line"
+    done
+}
+
 # Fetch agents for every non-hosted pool concurrently, writing one JSON file per
 # pool to <out_dir>/agents_<poolId>.json. This turns what was an O(pools)
 # sequential wall of calls into a bounded-parallel pass, the dominant cost for
@@ -373,23 +429,28 @@ fetch_pool_agents_parallel() {
         | jq -r '.[] | select((.isHosted // false) == false) | .id' \
         | xargs -r -P "$max_par" -I {} bash -c '
             pool="$2"; out="$1/agents_$2.json"; err="$1/agents_$2.err"; raw="$1/agents_$2.raw"
+            org="$3"
+            mark_err() { echo "{\"__fetch_error__\": true}" >"$out"; }
+            az_fetch() {
+                az pipelines agent list --pool-id "$pool" --org "$org" \
+                    --include-assigned-request --output json >"$out" 2>"$err"
+            }
+            wrote=false
             if [ -n "${ADO_AUTH_HDR:-}" ]; then
-                url="$3/_apis/distributedtask/pools/$pool/agents?includeAssignedRequest=true&api-version=7.1"
+                url="$org/_apis/distributedtask/pools/$pool/agents?includeAssignedRequest=true&api-version=7.1"
                 if curl -fsS --max-time 60 -H "Authorization: $ADO_AUTH_HDR" "$url" -o "$raw" 2>"$err"; then
-                    if jq -e "type == \"object\" and has(\"value\")" "$raw" >/dev/null 2>&1; then
-                        jq ".value // []" "$raw" >"$out" && rm -f "$raw" "$err"
-                    else
-                        echo "{\"__fetch_error__\": true}" >"$out"; mv -f "$raw" "$err" 2>/dev/null || true
+                    if jq -e "type == \"object\" and (.value | type) == \"array\"" "$raw" >/dev/null 2>&1 \
+                            && jq -c ".value" "$raw" >"$out" 2>/dev/null && [ -s "$out" ]; then
+                        rm -f "$raw" "$err"; wrote=true
                     fi
-                else
-                    echo "{\"__fetch_error__\": true}" >"$out"; rm -f "$raw"
                 fi
-            else
-                # No credential header available: fall back to the az CLI.
-                if az pipelines agent list --pool-id "$pool" --org "$3" --output json >"$out" 2>"$err"; then
+                rm -f "$raw"
+            fi
+            if [ "$wrote" = false ]; then
+                if az_fetch; then
                     rm -f "$err"
                 else
-                    echo "{\"__fetch_error__\": true}" >"$out"
+                    mark_err
                 fi
             fi
           ' _ "$out_dir" {} "$org_url"

--- a/codebundles/azure-devops-project-health/agent-pools.sh
+++ b/codebundles/azure-devops-project-health/agent-pools.sh
@@ -96,17 +96,20 @@ for ((i=0; i<pool_count; i++)); do
     # Distinguish a real fetch failure (permission/timeout/throttle) from an
     # empty pool so we don't silently report inaccessible pools as healthy.
     if fetch_err=$(agents_fetch_failed "$agents_file"); then
+        pool_details=$(ado_pool_issue_details \
+            "Failed to list agents for pool \`$pool_name\` (id=$pool_id). This is an access/availability error, not an empty pool." \
+            "$pool_name" "$pool_id" "$pool_type" "unknown" "0" "0" "0" "0" "0" \
+            "Fetch error: ${fetch_err:-unknown}. The task tried REST first, then az pipelines agent list as fallback." "")
         issues_json=$(echo "$issues_json" | jq \
             --arg title "Unable To Retrieve Agents For Pool \`$pool_name\`" \
-            --arg details "Failed to list agents for pool \`$pool_name\` (ID: $pool_id). This is an access/availability error, not an empty pool. Error: ${fetch_err:-unknown}" \
+            --arg details "$pool_details" \
             --arg severity "3" \
             --arg nextStep "Verify the identity has the Agent Pools (Read) scope and 'Reader' on this pool, then re-run. Transient throttling/timeouts may also cause this." \
             '. += [{"title": $title, "details": $details, "next_steps": $nextStep, "severity": ($severity | tonumber)}]')
         echo "  WARNING: could not fetch agents for pool $pool_name ($pool_id): ${fetch_err:-unknown}"
         continue
     fi
-    [ -s "$agents_file" ] || echo "[]" > "$agents_file"
-    agents=$(cat "$agents_file")
+    agents=$(load_pool_agents_json "$agents_file")
 
     # VMSS-aware classification of online/offline/busy.
     eval "$(classify_pool_agents "$agents" "$is_elastic" "$pool_name")"
@@ -129,16 +132,30 @@ for ((i=0; i<pool_count; i++)); do
         # instances and must NOT be flagged. The only actionable failure is a
         # complete lack of online capacity *while work is waiting*.
         if [[ "$online_count" -eq 0 && "$busy_count" -gt 0 ]]; then
-            # No online agents but assignments exist -> work cannot be serviced.
+            pool_details=$(ado_pool_issue_details \
+                "Elastic/ephemeral pool has 0 online agents but $busy_count agent(s) with an active assignedRequest — work is bound to offline/unavailable agents." \
+                "$pool_name" "$pool_id" "$pool_type" "$pool_kind" "$agent_count" "$online_count" \
+                "$offline_count" "$busy_count" "$offline_count" \
+                "Action: verify the scaler can provision online agents immediately." "")
             issues_json=$(echo "$issues_json" | jq \
-                --arg title "Elastic Pool \`$pool_name\` Has No Online Agents While Work Is Queued" \
-                --arg details "Elastic/ephemeral pool \`$pool_name\` ($pool_kind) has 0 online agents but $busy_count assigned request(s). The $offline_count offline registrations are expected scale-set/ephemeral churn; the problem is that no agent is online to service queued work." \
+                --arg title "Elastic Pool \`$pool_name\` Has No Online Agents While Work Is Assigned" \
+                --arg details "$pool_details" \
                 --arg severity "2" \
                 --arg nextStep "Verify the VMSS/scale-set/Kubernetes scaler can provision agents: check the elastic pool sizing, backing Azure scale set / KEDA health, and the associated service connection." \
                 '. += [{"title": $title, "details": $details, "next_steps": $nextStep, "severity": ($severity | tonumber)}]')
         elif [[ "$online_count" -eq 0 ]]; then
-            # Scaled to zero with no pending work: this is normal idle autoscaling.
-            echo "  Elastic/ephemeral pool \`$pool_name\` scaled to zero (idle): 0 online, $offline_count expected offline registrations, no queued work. Not an issue."
+            pool_details=$(ado_pool_issue_details \
+                "Elastic/ephemeral pool is scaled to zero (0 online, $offline_count offline registrations). No assignedRequest detected on registered agents." \
+                "$pool_name" "$pool_id" "$pool_type" "$pool_kind" "$agent_count" "$online_count" \
+                "$offline_count" "$busy_count" "$offline_count" \
+                "Advisory: this is often normal idle autoscaling. If pipeline runs are queued for this pool in Azure DevOps, treat as a capacity incident and investigate autoscale/VMSS/KEDA." "")
+            issues_json=$(echo "$issues_json" | jq \
+                --arg title "Elastic Pool \`$pool_name\` Scaled To Zero (Verify Queue)" \
+                --arg details "$pool_details" \
+                --arg severity "4" \
+                --arg nextStep "If no pipelines are waiting, no action needed. If builds are queued for this pool, verify autoscale rules, backing VMSS/Kubernetes health, and service connections." \
+                '. += [{"title": $title, "details": $details, "next_steps": $nextStep, "severity": ($severity | tonumber)}]')
+            echo "  Elastic/ephemeral pool \`$pool_name\` scaled to zero: advisory issue raised (verify queue if pipelines are waiting)."
         else
             echo "  Elastic/ephemeral pool healthy: $online_count online agent(s); ignoring $offline_count expected offline registrations."
         fi
@@ -153,11 +170,14 @@ for ((i=0; i<pool_count; i++)); do
         if [[ "$offline_count" -gt "$max_names" ]]; then
             offline_names="$offline_names, ... (+$((offline_count - max_names)) more)"
         fi
-        offline_details="Pool \`$pool_name\` (Type: $pool_type) has $offline_count of $agent_count agents offline. Offline agents: $offline_names"
+        pool_details=$(ado_pool_issue_details \
+            "Static pool has $offline_count of $agent_count agents offline (actionable lost capacity)." \
+            "$pool_name" "$pool_id" "$pool_type" "$pool_kind" "$agent_count" "$online_count" \
+            "$offline_count" "$busy_count" "0" "" "$offline_names")
 
         issues_json=$(echo "$issues_json" | jq \
             --arg title "Offline Agents Found in Pool \`$pool_name\` ($offline_count of $agent_count agents)" \
-            --arg details "$offline_details" \
+            --arg details "$pool_details" \
             --arg severity "3" \
             --arg nextStep "Check the offline agent machines and restart the agent service if needed. Verify network connectivity between agents and Azure DevOps. If this is an autoscaled VMSS pool, configure Azure DevOps to remove torn-down agents automatically." \
             '. += [{"title": $title, "details": $details, "next_steps": $nextStep, "severity": ($severity | tonumber)}]')

--- a/codebundles/azure-devops-project-health/agent-pools.sh
+++ b/codebundles/azure-devops-project-health/agent-pools.sh
@@ -67,7 +67,7 @@ pool_count=$(jq '. | length' pools.json)
 
 # Fetch agents for all non-hosted pools in parallel (much faster than a
 # sequential call per pool when an organisation has many pools).
-echo "Fetching agents for all self-hosted pools (parallelism: ${AGENT_FETCH_PARALLELISM:-8})..."
+echo "Fetching agents for all self-hosted pools (parallelism: ${AGENT_FETCH_PARALLELISM:-20})..."
 fetch_pool_agents_parallel "$pools" "$AGENT_CACHE_DIR"
 
 # Process each agent pool using a for loop instead of pipe to while
@@ -109,7 +109,7 @@ for ((i=0; i<pool_count; i++)); do
     agents=$(cat "$agents_file")
 
     # VMSS-aware classification of online/offline/busy.
-    eval "$(classify_pool_agents "$agents" "$is_elastic")"
+    eval "$(classify_pool_agents "$agents" "$is_elastic" "$pool_name")"
     agent_count=$AGENT_COUNT
     online_count=$ONLINE_COUNT
     offline_count=$OFFLINE_COUNT
@@ -127,14 +127,18 @@ for ((i=0; i<pool_count; i++)); do
     if [[ "$pool_kind" == "elastic" || "$pool_kind" == "ephemeral" ]]; then
         # Elastic/VMSS/ephemeral pool: offline agents are torn-down scale-set
         # instances and must NOT be flagged. The only actionable failure is a
-        # complete lack of online capacity.
-        if [[ "$online_count" -eq 0 ]]; then
+        # complete lack of online capacity *while work is waiting*.
+        if [[ "$online_count" -eq 0 && "$busy_count" -gt 0 ]]; then
+            # No online agents but assignments exist -> work cannot be serviced.
             issues_json=$(echo "$issues_json" | jq \
-                --arg title "Elastic Pool \`$pool_name\` Has No Online Agents" \
-                --arg details "Elastic/ephemeral pool \`$pool_name\` ($pool_kind) has 0 online agents. The $offline_count offline registrations are expected scale-set/ephemeral churn and are not the problem; the pool simply cannot service jobs right now." \
+                --arg title "Elastic Pool \`$pool_name\` Has No Online Agents While Work Is Queued" \
+                --arg details "Elastic/ephemeral pool \`$pool_name\` ($pool_kind) has 0 online agents but $busy_count assigned request(s). The $offline_count offline registrations are expected scale-set/ephemeral churn; the problem is that no agent is online to service queued work." \
                 --arg severity "2" \
-                --arg nextStep "Verify the VMSS/scale-set can provision agents: check the elastic pool sizing configuration, the backing Azure scale set health, and the associated service connection." \
+                --arg nextStep "Verify the VMSS/scale-set/Kubernetes scaler can provision agents: check the elastic pool sizing, backing Azure scale set / KEDA health, and the associated service connection." \
                 '. += [{"title": $title, "details": $details, "next_steps": $nextStep, "severity": ($severity | tonumber)}]')
+        elif [[ "$online_count" -eq 0 ]]; then
+            # Scaled to zero with no pending work: this is normal idle autoscaling.
+            echo "  Elastic/ephemeral pool \`$pool_name\` scaled to zero (idle): 0 online, $offline_count expected offline registrations, no queued work. Not an issue."
         else
             echo "  Elastic/ephemeral pool healthy: $online_count online agent(s); ignoring $offline_count expected offline registrations."
         fi

--- a/codebundles/azure-devops-project-health/long-running-pipelines.sh
+++ b/codebundles/azure-devops-project-health/long-running-pipelines.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
-set -x
+# NOTE: `set -x` is intentionally NOT used (it leaks AZURE_DEVOPS_PAT into logs
+# and bloats output). Set AZ_DEBUG=1 to opt in to tracing for local debugging.
+[ "${AZ_DEBUG:-0}" = "1" ] && set -x
 # -----------------------------------------------------------------------------
 # REQUIRED ENV VARS:
 #   AZURE_DEVOPS_ORG

--- a/codebundles/azure-devops-project-health/meta.yaml
+++ b/codebundles/azure-devops-project-health/meta.yaml
@@ -57,10 +57,10 @@ spec:
       default: "60"
       example: "70"
     - name: AGENT_FETCH_PARALLELISM
-      description: "Number of agent-pool agent lists to fetch concurrently (performance tuning for organizations with many pools)"
+      description: "Number of agent-pool agent lists to fetch concurrently (performance tuning for organizations with many pools). Clamped to 1-32; agents are fetched via REST to avoid per-pool CLI startup cost."
       required: false
-      default: "8"
-      example: "12"
+      default: "20"
+      example: "24"
   secrets:
     - name: azure_credentials
       description: "Azure service principal credentials for authentication"

--- a/codebundles/azure-devops-project-health/pipeline-failure-investigation.sh
+++ b/codebundles/azure-devops-project-health/pipeline-failure-investigation.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
-set -x
+# NOTE: `set -x` is intentionally NOT used (it leaks AZURE_DEVOPS_PAT into logs
+# and bloats output). Set AZ_DEBUG=1 to opt in to tracing for local debugging.
+[ "${AZ_DEBUG:-0}" = "1" ] && set -x
 # -----------------------------------------------------------------------------
 # REQUIRED ENV VARS:
 #   AZURE_DEVOPS_ORG

--- a/codebundles/azure-devops-project-health/pipeline-logs.sh
+++ b/codebundles/azure-devops-project-health/pipeline-logs.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 #set -euo pipefail
-set -x
+# NOTE: `set -x` is intentionally NOT used (it leaks AZURE_DEVOPS_PAT into logs
+# and bloats output). Set AZ_DEBUG=1 to opt in to tracing for local debugging.
+[ "${AZ_DEBUG:-0}" = "1" ] && set -x
 # -----------------------------------------------------------------------------
 # REQUIRED ENV VARS:
 #   AZURE_DEVOPS_ORG

--- a/codebundles/azure-devops-project-health/pipeline-performance-analysis.sh
+++ b/codebundles/azure-devops-project-health/pipeline-performance-analysis.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
-set -x
+# NOTE: `set -x` is intentionally NOT used (it leaks AZURE_DEVOPS_PAT into logs
+# and bloats output). Set AZ_DEBUG=1 to opt in to tracing for local debugging.
+[ "${AZ_DEBUG:-0}" = "1" ] && set -x
 # -----------------------------------------------------------------------------
 # REQUIRED ENV VARS:
 #   AZURE_DEVOPS_ORG
@@ -84,7 +86,14 @@ for ((i=0; i<pipeline_count; i++)); do
             echo "    Calculating performance metrics..."
             
             # Extract durations (in seconds)
-            durations=$(echo "$recent_runs" | jq -r '.[] | select(.startTime != null and .finishTime != null) | ((.finishTime | fromdateiso8601) - (.startTime | fromdateiso8601))')
+            # ADO timestamps carry fractional seconds and a numeric UTC offset
+            # (e.g. 2026-05-29T10:04:46.231362+00:00), which jq's fromdateiso8601
+            # (%Y-%m-%dT%H:%M:%SZ) cannot parse. Normalise to ...Z first. Durations
+            # are deltas of same-offset timestamps, so dropping the offset is safe.
+            durations=$(echo "$recent_runs" | jq -r '
+                def parsedate: (sub("\\.[0-9]+";"") | sub("(Z|[+-][0-9][0-9]:?[0-9][0-9])$";"")) + "Z" | fromdateiso8601;
+                .[] | select(.startTime != null and .finishTime != null)
+                | ((.finishTime | parsedate) - (.startTime | parsedate))')
             
             if [ -n "$durations" ] && [ "$(echo "$durations" | wc -l)" -gt 0 ]; then
                 # Calculate statistics
@@ -128,7 +137,10 @@ for ((i=0; i<pipeline_count; i++)); do
                 
                 # Get queue time analysis
                 echo "    Analyzing queue times..."
-                queue_times=$(echo "$recent_runs" | jq -r '.[] | select(.queueTime != null and .startTime != null) | ((.startTime | fromdateiso8601) - (.queueTime | fromdateiso8601))')
+                queue_times=$(echo "$recent_runs" | jq -r '
+                    def parsedate: (sub("\\.[0-9]+";"") | sub("(Z|[+-][0-9][0-9]:?[0-9][0-9])$";"")) + "Z" | fromdateiso8601;
+                    .[] | select(.queueTime != null and .startTime != null)
+                    | ((.startTime | parsedate) - (.queueTime | parsedate))')
                 
                 if [ -n "$queue_times" ] && [ "$(echo "$queue_times" | wc -l)" -gt 0 ]; then
                     avg_queue_time=$(echo "$queue_times" | awk '{sum+=$1} END {print sum/NR}' | xargs printf "%.0f")

--- a/codebundles/azure-devops-project-health/preflight-check.sh
+++ b/codebundles/azure-devops-project-health/preflight-check.sh
@@ -83,23 +83,15 @@ probe() {
 # 1. Identity (best effort, non-blocking)
 # =========================================================================
 echo "=== Authenticated Identity ==="
-identity_json='{"name":"unknown","id":"unknown","auth_type":"'"$AUTH_TYPE"'","confirmed":false}'
-conn_hdr=$(ado_auth_header)
-if [ -n "$conn_hdr" ]; then
-    conn_data=$(curl -s --max-time 15 -H "Authorization: $conn_hdr" \
-        "$ORG_URL/_apis/connectionData?api-version=7.1" 2>/dev/null || echo "")
-    if echo "$conn_data" | jq -e '.authenticatedUser.id' >/dev/null 2>&1; then
-        uname=$(echo "$conn_data" | jq -r '.authenticatedUser.providerDisplayName // .authenticatedUser.customDisplayName // "unknown"')
-        uid=$(echo "$conn_data" | jq -r '.authenticatedUser.id // "unknown"')
-        echo "  Display Name: $uname"
-        echo "  User ID:      $uid"
-        identity_json=$(jq -n --arg n "$uname" --arg i "$uid" --arg a "$AUTH_TYPE" \
-            '{name:$n, id:$i, auth_type:$a, confirmed:true}')
-    else
-        echo "  NOTE: connectionData did not return an identity (often blocked by a proxy or"
-        echo "        a PAT without the Graph scope). This is non-blocking; capability probes"
-        echo "        below are the authoritative access signal."
-    fi
+identity_json=$(ado_identity_json)
+if [ "$(echo "$identity_json" | jq -r '.confirmed')" = "true" ]; then
+    echo "  Display Name: $(echo "$identity_json" | jq -r '.name')"
+    echo "  User ID:      $(echo "$identity_json" | jq -r '.id')"
+    [ -n "$(echo "$identity_json" | jq -r '.email')" ] && echo "  Account:      $(echo "$identity_json" | jq -r '.email')"
+else
+    echo "  NOTE: could not resolve the authenticated identity (connectionData blocked"
+    echo "        by a proxy, or a PAT without Graph scope). Non-blocking; the capability"
+    echo "        probes below are the authoritative access signal."
 fi
 
 # =========================================================================

--- a/codebundles/azure-devops-project-health/queued-pipelines.sh
+++ b/codebundles/azure-devops-project-health/queued-pipelines.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
-set -x
+# NOTE: `set -x` is intentionally NOT used (it leaks AZURE_DEVOPS_PAT into logs
+# and bloats output). Set AZ_DEBUG=1 to opt in to tracing for local debugging.
+[ "${AZ_DEBUG:-0}" = "1" ] && set -x
 # -----------------------------------------------------------------------------
 # REQUIRED ENV VARS:
 #   AZURE_DEVOPS_ORG

--- a/codebundles/azure-devops-project-health/repository-health-analysis.sh
+++ b/codebundles/azure-devops-project-health/repository-health-analysis.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
-set -x
+# NOTE: `set -x` is intentionally NOT used (it leaks AZURE_DEVOPS_PAT into logs
+# and bloats output). Set AZ_DEBUG=1 to opt in to tracing for local debugging.
+[ "${AZ_DEBUG:-0}" = "1" ] && set -x
 # -----------------------------------------------------------------------------
 # REQUIRED ENV VARS:
 #   AZURE_DEVOPS_ORG

--- a/codebundles/azure-devops-project-health/runbook.robot
+++ b/codebundles/azure-devops-project-health/runbook.robot
@@ -64,7 +64,7 @@ Check Agent Pool Availability Across Projects in `${AZURE_DEVOPS_ORG}`
         ...    actual=Failed to collect agent pool data — the script likely timed out or the Azure DevOps API was unreachable
         ...    title=Agent Pool Data Collection Failed for `${AZURE_DEVOPS_ORG}`
         ...    reproduce_hint=${agent_pool.cmd}
-        ...    details=The agent-pools.sh script did not produce valid JSON output. This typically indicates the Azure DevOps API was unresponsive or the script exceeded its ${{'180'}}s timeout.\n\nPreflight access check: ${PREFLIGHT_SUMMARY}\n\nStdout: ${agent_pool.stdout}
+        ...    details=The agent-pools.sh script did not produce valid JSON output. This typically indicates the Azure DevOps API was unresponsive or the script exceeded its ${{'300'}}s timeout while fetching agents for all organization pools.\n\nPreflight access check: ${PREFLIGHT_SUMMARY}\n\nStdout: ${agent_pool.stdout}
         ...    next_steps=Review the preflight access check results in the report for identity and permission details. Check Azure DevOps API availability for organization `${AZURE_DEVOPS_ORG}`. Verify network connectivity from the runner to dev.azure.com. Review Azure DevOps service health at https://status.dev.azure.com.
     END
 

--- a/codebundles/azure-devops-project-health/runbook.robot
+++ b/codebundles/azure-devops-project-health/runbook.robot
@@ -46,7 +46,7 @@ Check Agent Pool Availability Across Projects in `${AZURE_DEVOPS_ORG}`
     ...    bash_file=agent-pools.sh
     ...    env=${env}
     ...    secret__azure_devops_pat=${AZURE_DEVOPS_PAT}
-    ...    timeout_seconds=180
+    ...    timeout_seconds=300
     ...    include_in_history=false
     ...    show_in_rwl_cheatsheet=true
     


### PR DESCRIPTION
…ser license analysis

- Introduced `ado_identity_json` function in `_az_helpers.sh` for better resolution of authenticated identities, improving error handling and proxy support.
- Updated `classify_pool_agents` to include pool name in its parameters for more accurate classification of agent pools.
- Increased default parallelism for fetching agents in `agent-pool-capacity.sh` and related scripts to enhance performance for organizations with many pools.
- Improved license utilization analysis in `license-utilization.sh` to provide clearer categorization of user licenses and updated output messages for better clarity.
- Enhanced preflight checks in `preflight-check.sh` to ensure necessary permissions are validated before execution.
- Updated `meta.yaml` to reflect changes in environment variable defaults and descriptions for better configuration management.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect how capacity and license issues are reported org-wide (classification heuristics and billing estimates); mis-tuning could hide real outages or over-report advisories, but scope is monitoring scripts rather than production app code.
> 
> **Overview**
> This PR tightens **Azure DevOps organization/project health** runbooks: fewer false positives on elastic/Kubernetes agent pools, faster agent enumeration, clearer license math, and safer logging.
> 
> **Agent pools:** Shared `_az_helpers` now classifies **scaled-to-zero** VMSS/K8s-style pools (all offline + generated agent names) as ephemeral so huge offline counts are not treated as outages. **Zero online** on elastic/ephemeral pools is only a real issue when `assignedRequest` indicates work; otherwise a low-severity “verify queue” advisory is emitted. Parallel agent fetch defaults to **20** (max 32), uses **REST + curl** with one auth header (fallback to `az pipelines agent list`) to avoid per-pool CLI startup timeouts; issues use **`ado_pool_issue_details`** for richer `details` text.
> 
> **Licensing & policies:** `license-utilization.sh` and `organization-policies.sh` map **`express`/`professional` → Basic**, **`advanced` → Basic + Test Plans**, and VS subscribers via **msdn** fields—fixing under-reported paid seats and cost estimates (~$52/mo for advanced).
> 
> **Ops & safety:** Preflight uses **`ado_identity_json`** (`az devops invoke` first). Several scripts drop always-on **`set -x`** (PAT leak risk); use **`AZ_DEBUG=1`** instead. Runbook agent-pool task timeouts go **180s → 300s** with a clearer failure issue when JSON is missing. **Pipeline performance** normalizes ADO ISO8601 timestamps before `jq` duration math.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81865dd45e7a1dd6705831e25af0fba068f8fca5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->