### PR TITLE
Enhance Azure DevOps organization health scripts with new features an…

### DIFF
--- a/codebundles/azure-devops-organization-health/.runwhen/templates/azure-devops-organization-health-sli.yaml
+++ b/codebundles/azure-devops-organization-health/.runwhen/templates/azure-devops-organization-health-sli.yaml
@@ -11,18 +11,38 @@ spec:
   displayUnitsShort: ok
   locations:
     - {{default_location}}
-  description: Comprehensive organization health check for Azure DevOps including agent pool capacity, license utilization, security policies, service connectivity, and platform incidents in organization {{ organization }}
+  description: Cheap hourly composite health score for Azure DevOps organization {{ organization }} — averages four lightweight binary sub-scores (no active platform incident, queue-derived pool capacity, license headroom, required org security policy present). The heavy license/policy/cross-project scans stay in the daily deep runbook. A breach triggers this SLX's organization runbook.
   codeBundle:
-    repoUrl: https://github.com/runwhen-contrib/rw-workspace-utils.git
+    {% if repo_url %}
+    repoUrl: {{repo_url}}
+    {% else %}
+    repoUrl: https://github.com/runwhen-contrib/rw-cli-codecollection.git
+    {% endif %}
+    {% if ref %}
+    ref: {{ref}}
+    {% else %}
     ref: main
-    pathToRobot: codebundles/cron-scheduler-sli/sli.robot
+    {% endif %}
+    pathToRobot: codebundles/azure-devops-organization-health/sli.robot
   intervalStrategy: intermezzo
-  intervalSeconds: 300
+  intervalSeconds: 3600
   configProvided:
-    - name: CRON_SCHEDULE
-      value: "0 8 * * *" 
-    - name: TARGET_SLX
-      value: ""
-    - name: DRY_RUN
-      value: "false"
-  secretsProvided: []
+    - name: AZURE_DEVOPS_ORG
+      value: "{{ organization }}"
+    - name: LICENSE_UTILIZATION_THRESHOLD
+      value: "90"
+    - name: QUEUE_AGING_THRESHOLD_MIN
+      value: "30"
+    - name: ORG_POOL_PROBE_LIMIT
+      value: "150"
+  secretsProvided:
+  {% if wb_version %}
+    {% include "azure-devops-auth.yaml" ignore missing %}
+  {% else %}
+    - name: azure_credentials
+      workspaceKey: AUTH DETAILS NOT FOUND
+  {% endif %}
+  alertConfig:
+    tasks:
+      persona: eager-edgar
+      sessionTTL: 10m

--- a/codebundles/azure-devops-organization-health/README.md
+++ b/codebundles/azure-devops-organization-health/README.md
@@ -249,11 +249,10 @@ Enable debug logging by setting appropriate log levels in the Robot Framework ex
 ## Integration
 
 This codebundle complements:
-- **azure-devops-project-health**: Project-specific health monitoring
-- **azure-devops-pipeline-health**: Pipeline-focused diagnostics
-- **azure-devops-repository-health**: Repository and code quality monitoring
+- **azure-devops-project-health**: Per-project health (pipelines, agent pools visible to the project, service connections, branch policies). Pipeline failure/queue/long-running/performance tasks live here — there is no separate pipeline codebundle.
+- **azure-devops-repository-health**: Per-repository security, policies, and code-quality monitoring
 
-Use together for comprehensive Azure DevOps monitoring across all organizational levels.
+Use together for comprehensive Azure DevOps monitoring: organization (this bundle) → project → repository.
 
 ## Output
 

--- a/codebundles/azure-devops-organization-health/_az_helpers.sh
+++ b/codebundles/azure-devops-organization-health/_az_helpers.sh
@@ -127,15 +127,17 @@ ado_platform_incident_probe() {
         return 0
     fi
 
-    # HTML/JS fallback (numeric portal enum).
-    local incident_num=""
-    if curl -s --max-time 15 -o status_page.html 'https://status.dev.azure.com' 2>/dev/null; then
+    # HTML/JS fallback (numeric portal enum). Use a private temp file so callers
+    # are not affected if they download the status page for connectivity checks.
+    local incident_num="" html_file=""
+    html_file=$(mktemp ado_status_page.XXXXXX)
+    if curl -s --max-time 15 -o "$html_file" 'https://status.dev.azure.com' 2>/dev/null; then
         local svc
-        svc=$(grep -o '"serviceStatus":{[^}]*"health":[0-9]*[^}]*}' status_page.html 2>/dev/null | head -1 || true)
+        svc=$(grep -o '"serviceStatus":{[^}]*"health":[0-9]*[^}]*}' "$html_file" 2>/dev/null | head -1 || true)
         incident_num=$(printf '%s' "$svc" | grep -o '"health":[0-9]*' | head -1 | cut -d':' -f2)
         ADO_PLATFORM_STATUS_MESSAGE=$(printf '%s' "$svc" | grep -o '"message":"[^"]*"' | head -1 | cut -d'"' -f4)
     fi
-    rm -f status_page.html
+    rm -f "$html_file"
 
     if [ -n "$incident_num" ]; then
         ADO_PLATFORM_HEALTH="$incident_num"

--- a/codebundles/azure-devops-organization-health/_az_helpers.sh
+++ b/codebundles/azure-devops-organization-health/_az_helpers.sh
@@ -154,7 +154,10 @@ ado_platform_incident_probe() {
 # project is configured. Org-health tasks must use --scope organization.
 ado_security_groups_json() {
     local org_url="https://dev.azure.com/${AZURE_DEVOPS_ORG}"
-    az devops security group list --org "$org_url" --scope organization --output json
+    local raw
+    raw=$(az devops security group list --org "$org_url" --scope organization --output json) || return $?
+    # CLI returns {graphGroups:[...]}; REST may use {value:[...]}. Callers expect an array.
+    printf '%s' "$raw" | jq -c 'if type == "array" then . elif type == "object" then (.graphGroups // .value // []) else [] end'
 }
 
 # ---------------------------------------------------------------------------

--- a/codebundles/azure-devops-organization-health/_az_helpers.sh
+++ b/codebundles/azure-devops-organization-health/_az_helpers.sh
@@ -77,6 +77,85 @@ setup_azure_auth() {
 }
 
 # ---------------------------------------------------------------------------
+# Azure DevOps public status page (platform incidents)
+#
+# The status portal embeds a NUMERIC health code in its HTML/JS payload:
+#   1 = unhealthy, 2 = degraded, 3 = advisory, 4 = healthy
+# (matches ScopeHealth enum order; 4 is "Everything is looking good".)
+# Older scripts incorrectly assumed 1=healthy and treated 4 as an outage.
+#
+# Prefer the official Status REST API, which returns string health values.
+# ---------------------------------------------------------------------------
+
+# Probe whether Azure DevOps is reporting a platform-wide incident.
+# Sets globals: ADO_PLATFORM_INCIDENT_OK (0|1), ADO_PLATFORM_HEALTH, ADO_PLATFORM_STATUS_MESSAGE
+# Test override: SLI_INCIDENT_HEALTH may be a portal numeric code (1-4) or API string (healthy, degraded, ...).
+ado_platform_incident_probe() {
+    ADO_PLATFORM_INCIDENT_OK=1
+    ADO_PLATFORM_HEALTH="unknown"
+    ADO_PLATFORM_STATUS_MESSAGE=""
+
+    if [ -n "${SLI_INCIDENT_HEALTH:-}" ]; then
+        ADO_PLATFORM_HEALTH="${SLI_INCIDENT_HEALTH}"
+        case "$(printf '%s' "${SLI_INCIDENT_HEALTH}" | tr '[:upper:]' '[:lower:]')" in
+            healthy|advisory|4|3) ADO_PLATFORM_INCIDENT_OK=1 ;;
+            degraded|unhealthy|2|1) ADO_PLATFORM_INCIDENT_OK=0 ;;
+            *) ADO_PLATFORM_INCIDENT_OK=1 ;;
+        esac
+        return 0
+    fi
+
+    local api_json overall msg bad_geo
+    api_json=$(curl -s --max-time 15 \
+        'https://status.dev.azure.com/_apis/status/health?api-version=7.1-preview.1' 2>/dev/null || true)
+    overall=$(printf '%s' "$api_json" | jq -r '.status.health // empty' 2>/dev/null)
+    msg=$(printf '%s' "$api_json" | jq -r '.status.message // empty' 2>/dev/null)
+    if [ -n "$overall" ]; then
+        ADO_PLATFORM_HEALTH="$overall"
+        ADO_PLATFORM_STATUS_MESSAGE="$msg"
+        case "$(printf '%s' "$overall" | tr '[:upper:]' '[:lower:]')" in
+            unhealthy|degraded) ADO_PLATFORM_INCIDENT_OK=0 ;;
+            *) ADO_PLATFORM_INCIDENT_OK=1 ;;
+        esac
+        bad_geo=$(printf '%s' "$api_json" | jq -r '
+            ([.services[]?.geographies[]?.health // empty | ascii_downcase]
+             | any(. == "degraded" or . == "unhealthy")) // false
+        ' 2>/dev/null || echo false)
+        if [ "$bad_geo" = "true" ]; then
+            ADO_PLATFORM_INCIDENT_OK=0
+        fi
+        return 0
+    fi
+
+    # HTML/JS fallback (numeric portal enum).
+    local incident_num=""
+    if curl -s --max-time 15 -o status_page.html 'https://status.dev.azure.com' 2>/dev/null; then
+        local svc
+        svc=$(grep -o '"serviceStatus":{[^}]*"health":[0-9]*[^}]*}' status_page.html 2>/dev/null | head -1 || true)
+        incident_num=$(printf '%s' "$svc" | grep -o '"health":[0-9]*' | head -1 | cut -d':' -f2)
+        ADO_PLATFORM_STATUS_MESSAGE=$(printf '%s' "$svc" | grep -o '"message":"[^"]*"' | head -1 | cut -d'"' -f4)
+    fi
+    rm -f status_page.html
+
+    if [ -n "$incident_num" ]; then
+        ADO_PLATFORM_HEALTH="$incident_num"
+        case "$incident_num" in
+            1|2) ADO_PLATFORM_INCIDENT_OK=0 ;;   # unhealthy, degraded
+            3|4) ADO_PLATFORM_INCIDENT_OK=1 ;;   # advisory, healthy
+            *) ADO_PLATFORM_INCIDENT_OK=1 ;;
+        esac
+    fi
+}
+
+# List organization-scoped security groups (Graph). The az CLI defaults to
+# --scope project, which fails with "project must be specified" unless a default
+# project is configured. Org-health tasks must use --scope organization.
+ado_security_groups_json() {
+    local org_url="https://dev.azure.com/${AZURE_DEVOPS_ORG}"
+    az devops security group list --org "$org_url" --scope organization --output json 2>/dev/null || echo ""
+}
+
+# ---------------------------------------------------------------------------
 # Shared Azure DevOps REST / data helpers
 #
 # These functions are intentionally defensive: they never abort the calling
@@ -123,8 +202,13 @@ ado_identity_json() {
         fi
     fi
 
+    # Always emit a single, valid JSON object. Callers (notably preflight) feed
+    # this straight into `jq --argjson`, which aborts the whole script if it ever
+    # receives an empty string — so guard every path and fall back to a valid
+    # "unconfirmed" object rather than echoing nothing.
+    local out=""
     if echo "$resp" | jq -e '(.authenticatedUser.id // .authorizedUser.id)' >/dev/null 2>&1; then
-        echo "$resp" | jq --arg a "$auth" '
+        out=$(echo "$resp" | jq --arg a "$auth" '
             (.authenticatedUser // .authorizedUser) as $u
             | ($u.properties.Account."$value" // $u.emailAddress // "") as $email
             | {
@@ -133,10 +217,12 @@ ado_identity_json() {
                 email:     $email,
                 auth_type: $a,
                 confirmed: true
-              }'
-    else
-        jq -n --arg a "$auth" '{name:"unknown", id:"unknown", email:"", auth_type:$a, confirmed:false}'
+              }' 2>/dev/null)
     fi
+    if [ -z "$out" ] || ! echo "$out" | jq -e . >/dev/null 2>&1; then
+        out=$(jq -n --arg a "$auth" '{name:"unknown", id:"unknown", email:"", auth_type:$a, confirmed:false}')
+    fi
+    echo "$out"
 }
 
 # Newline-separated list of elastic (VMSS / scale-set / agent-cloud) pool IDs.
@@ -240,6 +326,21 @@ pool_looks_ephemeral() {
     return 0
 }
 
+# Echo up to N (default 3) agent names that match the generated/ephemeral name
+# patterns, comma-separated. Used as human-readable evidence in issue details.
+# Args: $1 = agents JSON array, $2 = max names (optional, default 3)
+agents_generated_sample() {
+    echo "$1" | jq -r --argjson n "${2:-3}" '
+        [ .[] | (.name // "")
+          | select(test("^azp-"; "i") or test("agents?-[0-9]+$"; "i") or test("-[0-9]+$")) ]
+        | .[:$n] | join(", ")' 2>/dev/null || true
+}
+
+# Classify a pool and emit eval-able assignments. In addition to the counts and
+# POOL_KIND it now exposes WHY the classification was chosen so callers can put
+# concrete, plain-language evidence in the issue text:
+#   POOL_KIND_REASON   : sentence describing which heuristic fired (eval-safe)
+#   POOL_KIND_EVIDENCE : the specific markers (ratios, sample names) (eval-safe)
 # Args: $1 = agents JSON array, $2 = is_elastic ("true"/"false"), $3 = pool name (optional)
 classify_pool_agents() {
     local agents="$1" is_elastic="${2:-false}" pool_name="${3:-}"
@@ -257,16 +358,27 @@ classify_pool_agents() {
     offline=$(echo "$counts" | jq -r '.offline')
     busy=$(echo "$counts" | jq -r '.busy')
 
-    local kind="static" expected_offline=0
+    # A few generated-looking agent names to show the reader WHY a pool reads as
+    # dynamic (e.g. azp-maven-agent-7). Empty string when none match.
+    local gen_sample name_markers
+    gen_sample=$(agents_generated_sample "$agents" 3)
+    name_markers=$(printf '%s' "$pool_name" \
+        | grep -Eio 'k8s|aks|kube|keda|vmss|scale.?set|ephemeral' | head -1 || true)
+
+    local kind="static" expected_offline=0 reason="" evidence=""
     if [ "$is_elastic" = "true" ]; then
         kind="elastic"
         expected_offline=$offline
+        reason="the pool is reported by the Distributed Task elastic-pools API or carries an agentCloudId/targetSize, i.e. an Azure DevOps-managed VMSS / agent-cloud (dynamic) pool"
+        evidence="elastic-pools API entry or agentCloudId/targetSize marker present"
     elif [ "$online" -gt 0 ] && [ "$total" -gt 0 ] \
             && [ "$(( offline * 100 / total ))" -ge "$ephemeral_ratio" ]; then
         # Online capacity exists but offline dominates: classic signature of a
         # self-managed VMSS/AKS/container pool leaving stale registrations.
         kind="ephemeral"
         expected_offline=$offline
+        reason="online capacity exists but offline registrations dominate the pool (>= ${ephemeral_ratio}% of total) -- the classic signature of a self-managed VMSS/AKS/container farm that leaves stale registrations behind as it scales"
+        evidence="offline ratio $(( offline * 100 / total ))% >= ${ephemeral_ratio}% threshold${gen_sample:+; generated agent names: ${gen_sample}}"
     elif [ "$total" -gt 0 ] && [ "$offline" -eq "$total" ] \
             && pool_looks_ephemeral "$agents" "$pool_name"; then
         # Scaled-to-zero ephemeral farm: every agent offline AND the pool/agent
@@ -275,6 +387,11 @@ classify_pool_agents() {
         # exactly the "very high offline count" false positive to suppress.
         kind="ephemeral"
         expected_offline=$offline
+        reason="every registered agent is offline AND the pool/agent naming matches a Kubernetes/VMSS/container/KEDA pattern -- a dynamic farm that has scaled to zero"
+        evidence="all ${total} agents offline; generated agent names: ${gen_sample:-n/a}${name_markers:+; pool-name marker: ${name_markers}}"
+    else
+        reason="no dynamic markers were found (no elastic-pools API entry, no agentCloudId, no targetSize) and the agent names are not predominantly auto-generated -- treated as a persistent/static pool"
+        evidence="no VMSS/scale-set/agent-cloud markers detected${gen_sample:+; generated-looking names present but below threshold: ${gen_sample}}"
     fi
 
     echo "AGENT_COUNT=$total"
@@ -283,6 +400,94 @@ classify_pool_agents() {
     echo "BUSY_COUNT=$busy"
     echo "POOL_KIND=$kind"
     echo "EXPECTED_OFFLINE=$expected_offline"
+    # %q keeps the free-text reason/evidence safe for `eval` in the callers.
+    printf 'POOL_KIND_REASON=%q\n' "$reason"
+    printf 'POOL_KIND_EVIDENCE=%q\n' "$evidence"
+}
+
+# ---------------------------------------------------------------------------
+# Queued-work pressure: the ONLY signal that distinguishes an idle dynamic pool
+# (scaled to zero on purpose, expected, sev 4 at most) from a real outage
+# (pipelines are queued but nothing can pick them up). busy_assigned does NOT
+# capture this -- a job waiting in the pool queue while online=0 has no agent to
+# be "assigned" to. These helpers are best-effort and degrade to zeros so they
+# can never break or fail the calling task.
+# ---------------------------------------------------------------------------
+
+# Echo the pool's job requests as a JSON array (the .value of the jobrequests
+# API) or "[]" on any failure. Prefers `az devops invoke` (proxy/auth aware)
+# then falls back to a direct REST call, mirroring the rest of the toolchain.
+# Args: $1 = pool id
+ado_pool_job_requests_json() {
+    local pool_id="$1"
+    local org_url="https://dev.azure.com/$AZURE_DEVOPS_ORG"
+    local resp=""
+
+    resp=$(az devops invoke \
+        --area distributedtask --resource jobrequests \
+        --route-parameters poolId="$pool_id" \
+        --org "$org_url" --api-version 7.1 --output json 2>/dev/null || echo "")
+
+    if ! echo "$resp" | jq -e '.value' >/dev/null 2>&1; then
+        local hdr; hdr=$(ado_auth_header)
+        if [ -n "$hdr" ]; then
+            resp=$(curl -s --max-time 20 -H "Authorization: $hdr" \
+                "$org_url/_apis/distributedtask/pools/$pool_id/jobrequests?api-version=7.1" \
+                2>/dev/null || echo "")
+        fi
+    fi
+
+    if echo "$resp" | jq -e '.value' >/dev/null 2>&1; then
+        echo "$resp" | jq -c '.value'
+    else
+        echo "[]"
+    fi
+}
+
+# Given job-requests JSON and an aging threshold (minutes) emit eval-able vars:
+#   QUEUED_TOTAL      : requests queued but not yet picked up by any agent
+#   QUEUED_AGING      : of those, how many have waited longer than the threshold
+#   OLDEST_QUEUED_MIN : age (minutes, floored) of the oldest queued request
+# A queued-but-unassigned request has a queueTime but no assignTime/receiveTime
+# and no result/finishTime yet. All date parsing is wrapped in try/catch so a
+# malformed timestamp degrades to 0 rather than aborting.
+# Args: $1 = job requests JSON array, $2 = aging threshold minutes (optional)
+pool_queue_pressure() {
+    local jobs="$1" threshold_min="${2:-${QUEUE_AGING_THRESHOLD_MIN:-15}}"
+    echo "$jobs" | jq -r --argjson thr "$threshold_min" '
+        def age_min($t):
+            ($t | sub("\\.[0-9]+"; "") | sub("([+-][0-9]{2}:?[0-9]{2})$"; "Z")) as $clean
+            | ((try ($clean | fromdateiso8601) catch null)) as $epoch
+            | if $epoch == null then 0 else ((now - $epoch) / 60) end;
+        [ .[]
+          | select((.result == null) and (.finishTime == null))
+          | select((.reservedAgent == null) and (.assignTime == null) and (.receiveTime == null))
+          | (if (.queueTime // null) != null then age_min(.queueTime) else 0 end)
+        ] as $ages
+        | "QUEUED_TOTAL=\($ages | length)",
+          "QUEUED_AGING=\([ $ages[] | select(. >= $thr) ] | length)",
+          "OLDEST_QUEUED_MIN=\((($ages | max) // 0) | floor)"
+    ' 2>/dev/null || printf 'QUEUED_TOTAL=0\nQUEUED_AGING=0\nOLDEST_QUEUED_MIN=0\n'
+}
+
+# Build the one-line "is work blocked?" status used in issue details. Combines
+# the queue-pressure counts with busy_assigned so the reader sees whether any
+# pipeline work is actually stuck behind a pool with no online agents.
+# Args: $1 = busy_assigned, $2 = QUEUED_TOTAL, $3 = QUEUED_AGING, $4 = OLDEST_QUEUED_MIN
+pool_queue_status_line() {
+    local busy="${1:-0}" qtotal="${2:-0}" qaging="${3:-0}" oldest="${4:-0}"
+    if [ "$qaging" -gt 0 ]; then
+        printf 'YES -- %s queued job(s) have been waiting >%s min (oldest %s min) with no online agent to run them. This is a real capacity outage.' \
+            "$qaging" "${QUEUE_AGING_THRESHOLD_MIN:-15}" "$oldest"
+    elif [ "$qtotal" -gt 0 ]; then
+        printf 'PARTIAL -- %s job(s) are queued but still young (<%s min). The pool may simply be scaling up; re-check shortly.' \
+            "$qtotal" "${QUEUE_AGING_THRESHOLD_MIN:-15}"
+    elif [ "$busy" -gt 0 ]; then
+        printf 'MAYBE -- no jobs are queued, but %s registered agent(s) still carry an assignedRequest while offline; this is usually a stale record from scale-down.' \
+            "$busy"
+    else
+        printf 'NO -- no jobs are queued for this pool and no agent carries an assignedRequest, so nothing is currently blocked. A dynamic pool at 0 online while idle is expected.'
+    fi
 }
 
 # Fetch ALL user entitlements, transparently paginating past the 100-row API
@@ -359,25 +564,82 @@ load_pool_agents_json() {
 }
 
 # Rich issue_details text for agent-pool findings (RunWhen agents consume the
-# JSON "details" field as issue_details).
+# JSON "details" field as issue_details). The text explains, in plain language,
+# WHY agents are offline and whether any pipeline work is actually blocked, so a
+# reader does not mistake expected dynamic scale-down for an outage.
 # Args: summary, pool_name, pool_id, pool_type, pool_kind, total, online, offline,
-#       busy, expected_offline, [extra paragraph], [sample offline agent names]
+#       busy, expected_offline,
+#       [extra paragraph], [sample offline agent names],
+#       [classification reason (POOL_KIND_REASON)], [work-blocked status line]
 ado_pool_issue_details() {
     local summary="$1" pool_name="$2" pool_id="$3" pool_type="$4" pool_kind="$5"
     local total="$6" online="$7" offline="$8" busy="$9" expected_offline="${10:-0}"
-    local extra="${11:-}" sample="${12:-}"
+    local extra="${11:-}" sample="${12:-}" classification="${13:-}" queue_status="${14:-}"
     local org="${AZURE_DEVOPS_ORG:-unknown}"
+
     printf '%s\n\n' "$summary"
     printf 'Organization: %s\n' "$org"
     printf 'Pool: %s (id=%s, poolType=%s, classified_as=%s)\n' "$pool_name" "$pool_id" "$pool_type" "$pool_kind"
     printf 'Agent counts: total=%s online=%s offline=%s busy_assigned=%s expected_offline_churn=%s\n' \
         "$total" "$online" "$offline" "$busy" "$expected_offline"
-    printf '\nInterpretation:\n'
-    printf '- classified_as elastic/ephemeral: most offline rows are torn-down VMSS/Kubernetes/container registrations, not necessarily failed machines.\n'
-    printf '- busy_assigned: agents with a non-null assignedRequest (work bound to a registered agent). This does NOT count pipeline jobs waiting in the pool queue when no agent is online.\n'
-    printf '- If builds are queued in Azure DevOps while online=0, open Organization Settings > Agent pools > %s and verify autoscale/VMSS/KEDA and service connections.\n' "$pool_name"
+    [ -n "$classification" ] && printf 'Why classified as "%s": %s\n' "$pool_kind" "$classification"
+
+    # Plain-language likely cause, tailored to the pool kind. This is the core
+    # of the "explain the WHY" requirement: dynamic vs static get very different
+    # explanations because the offline count means very different things.
+    printf '\nLikely cause:\n'
+    case "$pool_kind" in
+        elastic|ephemeral)
+            printf -- '- This pool provides DYNAMIC capacity (VMSS / scale-set / Kubernetes / container / agent-cloud). Agents are created on demand and torn down when idle.\n'
+            printf -- '- The offline registrations are EXPECTED scale-down artifacts of autoscale, not failed machines. A dynamic pool sitting at 0 online while idle is normal and is NOT an outage.\n'
+            if [ "${busy:-0}" -gt 0 ]; then
+                printf -- '- Note: %s registered agent(s) still carry an assignedRequest while not online. That is usually a stale record left by scale-down; confirm the scaler is replacing them.\n' "$busy"
+            fi
+            ;;
+        static)
+            printf -- '- This is a STATIC pool (persistent, manually-managed agents). Offline agents here are NOT expected churn -- each one is lost capacity.\n'
+            printf -- '- A static agent goes offline when its agent service is stopped, the host is powered off or unreachable, it lost network connectivity to dev.azure.com, or the credentials/PAT it runs under expired.\n'
+            ;;
+        *)
+            printf -- '- Pool kind could not be determined (agent data may be unreadable). Treat the counts above with caution until agents can be listed.\n'
+            ;;
+    esac
+
+    # Whether pipeline work is actually blocked. Driven by the queue-pressure
+    # check when available; otherwise spells out the busy_assigned caveat.
+    printf '\nIs pipeline work actually blocked?\n'
+    if [ -n "$queue_status" ]; then
+        printf -- '- %s\n' "$queue_status"
+    else
+        printf -- '- busy_assigned counts agents with a non-null assignedRequest. It does NOT count pipeline jobs waiting in the pool queue while online=0. If online=0 AND builds are queued, work is blocked regardless of busy_assigned.\n'
+    fi
+
+    printf '\nReading the counts:\n'
+    printf -- '- expected_offline_churn=%s of the %s offline registrations are attributed to dynamic scale-down (0 for static pools).\n' "$expected_offline" "$offline"
+    printf -- '- For dynamic pools the actionable signal is ONLINE capacity + queued work, NOT the offline backlog.\n'
+
+    printf '\nNext step:\n'
+    case "$pool_kind" in
+        elastic|ephemeral)
+            printf -- '- Open Organization Settings > Agent pools > %s and confirm autoscale/VMSS/KEDA sizing and the backing service connection are healthy. No action is needed if no pipelines are waiting.\n' "$pool_name"
+            ;;
+        static)
+            printf -- '- Open Organization Settings > Agent pools > %s, then on each offline agent: restart the agent service, confirm the host is powered on and can reach dev.azure.com, and verify the agent credentials/PAT.\n' "$pool_name"
+            ;;
+        *)
+            printf -- '- Open Organization Settings > Agent pools > %s to inspect the pool once agent data can be retrieved.\n' "$pool_name"
+            ;;
+    esac
+
     [ -n "$extra" ] && printf '\n%s\n' "$extra"
-    [ -n "$sample" ] && printf '\nSample offline agents: %s\n' "$sample"
+    if [ -n "$sample" ]; then
+        case "$pool_kind" in
+            elastic|ephemeral)
+                printf '\nSample offline agents (note the generated/ephemeral naming): %s\n' "$sample" ;;
+            *)
+                printf '\nSample offline agents: %s\n' "$sample" ;;
+        esac
+    fi
     printf '\nAPI probed: GET .../distributedtask/pools/%s/agents?includeAssignedRequest=true\n' "$pool_id"
 }
 
@@ -469,4 +731,205 @@ agents_fetch_failed() {
         return 0
     fi
     return 1
+}
+
+# ===========================================================================
+# Phase 0 single-pass build-dataset helpers
+#
+# WHY: the per-task pipeline scripts previously iterated over EVERY pipeline in
+# a project, issuing `az pipelines runs list --pipeline-id <id>` once per
+# pipeline (plus follow-up calls). On large projects (hundreds of pipelines)
+# that serial wall of ~6s/call calls blew past the 180s/300s Robot task
+# timeouts. These helpers fetch the project's builds ONCE via a small number of
+# paginated Build REST calls into a single on-disk dataset; every task then
+# derives its signals (failures, queue aging, long-running, perf percentiles)
+# from that dataset with jq -- with NO further per-pipeline calls.
+# ===========================================================================
+
+# Convert a lookback window like "24h", "30d", "90m", "2w" to an ISO-8601 UTC
+# timestamp at (now - window), suitable for the Build API minTime parameter.
+# Unrecognised input falls back to 24h.
+window_to_min_time() {
+    local window="${1:-24h}" num unit spec
+    num=$(printf '%s' "$window" | sed -E 's/[^0-9].*$//')
+    unit=$(printf '%s' "$window" | sed -E 's/^[0-9]*//' | tr '[:upper:]' '[:lower:]')
+    [ -z "$num" ] && { num=24; unit=h; }
+    case "$unit" in
+        m|min|mins|minute|minutes) spec="$num minutes ago" ;;
+        h|hr|hrs|hour|hours|"")    spec="$num hours ago" ;;
+        d|day|days)                spec="$num days ago" ;;
+        w|wk|wks|week|weeks)       spec="$((num * 7)) days ago" ;;
+        *)                         spec="24 hours ago" ;;
+    esac
+    date -u -d "$spec" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u +"%Y-%m-%dT%H:%M:%SZ"
+}
+
+# URL-encode a string (project names may contain spaces, e.g. "IT Services").
+ado_urlencode() { jq -rn --arg s "${1:-}" '$s|@uri' 2>/dev/null || printf '%s' "${1:-}"; }
+
+# Fetch a project's builds into a single JSON-array file ($2). The dataset is the
+# UNION of:
+#   A) builds that FINISHED within the lookback window (for failures, completed
+#      long-running, and performance percentiles), and
+#   B) builds currently ACTIVE (inProgress / notStarted) -- a point-in-time set
+#      with NO historical filter (for queue aging and in-flight long-running),
+# de-duplicated by build id. Echoes the resulting build count on stdout.
+#
+# An on-disk cache keyed by org|project|window means that when several tasks in
+# the same suite need the same dataset, only the FIRST call hits the API; the
+# rest reuse the cached file (set BUILDS_CACHE_ENABLED=false to disable;
+# BUILDS_CACHE_TTL_SEC, default 600, bounds staleness across runs).
+#
+# Build fields used downstream: id, buildNumber, status, result, queueTime,
+# startTime, finishTime, sourceBranch, sourceVersion, reason, definition.{id,name},
+# _links.web.href. These mirror what `az pipelines runs list` returned, so the
+# derivations are drop-in.
+#
+# Args: $1 = project name, $2 = output file, $3 = lookback window
+#       (default $RW_LOOKBACK_WINDOW or 24h).
+# Returns: 0 on success (even with partial pages), non-zero only if NO data could
+#          be fetched and no cache exists.
+fetch_project_builds() {
+    local project="$1" out_file="$2"
+    local window="${3:-${RW_LOOKBACK_WINDOW:-24h}}"
+    local org_url="https://dev.azure.com/$AZURE_DEVOPS_ORG"
+    local page_size="${BUILDS_PAGE_SIZE:-1000}"
+    local max_pages="${BUILDS_MAX_PAGES:-25}"
+    local min_time proj_enc
+    min_time=$(window_to_min_time "$window")
+    proj_enc=$(ado_urlencode "$project")
+
+    # ---- cache lookup -----------------------------------------------------
+    local cache_dir cache_key cache_file ttl now mtime age
+    cache_dir="${BUILDS_CACHE_DIR:-.ado_cache}"
+    mkdir -p "$cache_dir" 2>/dev/null || cache_dir="."
+    cache_key=$(printf '%s|%s|%s' "$AZURE_DEVOPS_ORG" "$project" "$window" \
+        | { md5sum 2>/dev/null || cksum; } | awk '{print $1}')
+    cache_file="$cache_dir/ado_builds_${cache_key}.json"
+    ttl="${BUILDS_CACHE_TTL_SEC:-600}"
+    if [ "${BUILDS_CACHE_ENABLED:-true}" = "true" ] && [ -s "$cache_file" ]; then
+        now=$(date +%s); mtime=$(date -r "$cache_file" +%s 2>/dev/null || echo 0)
+        age=$((now - mtime))
+        if [ "$mtime" -gt 0 ] && [ "$age" -lt "$ttl" ]; then
+            { cp "$cache_file" "$out_file" 2>/dev/null || cat "$cache_file" > "$out_file"; }
+            echo "  Reusing cached build dataset ($cache_file, age ${age}s, window ${window})." >&2
+            jq 'length' "$out_file" 2>/dev/null || echo 0
+            return 0
+        fi
+    fi
+
+    local hdr work rc=0
+    hdr=$(ado_auth_header)
+    work=$(mktemp -d ado_builds.XXXXXX)
+
+    # Run one paginated query variant, appending each page's .value array to a
+    # file in $work. Uses dynamic scoping to read $hdr/$work/$proj_enc/etc.
+    _fetch_builds_query() {
+        local extra="$1" tag="$2" page=0 cont="" url body hdrs
+        while [ "$page" -lt "$max_pages" ]; do
+            url="$org_url/$proj_enc/_apis/build/builds?api-version=7.1&\$top=$page_size$extra"
+            [ -n "$cont" ] && url="$url&continuationToken=$cont"
+            if [ -n "$hdr" ]; then
+                hdrs="$work/h_${tag}_${page}.txt"
+                if ! body=$(curl -fsS --max-time 60 -D "$hdrs" -H "Authorization: $hdr" "$url" 2>/dev/null); then
+                    return 1
+                fi
+                printf '%s' "$body" | jq -c '.value // []' > "$work/p_${tag}_${page}.json" 2>/dev/null || true
+                cont=$(grep -i '^x-ms-continuationtoken:' "$hdrs" 2>/dev/null \
+                    | head -1 | sed -E 's/^[^:]*:[[:space:]]*//' | tr -d '\r')
+            else
+                # No usable credential: fall back to az devops invoke (single page,
+                # no continuation token support).
+                body=$(az devops invoke --area build --resource builds \
+                    --route-parameters project="$project" --org "$org_url" \
+                    --api-version 7.1 --output json 2>/dev/null || echo "")
+                printf '%s' "$body" | jq -c '.value // []' > "$work/p_${tag}_${page}.json" 2>/dev/null || true
+                cont=""
+            fi
+            page=$((page + 1))
+            [ -z "$cont" ] && break
+        done
+        return 0
+    }
+
+    # A) finished builds in the lookback window
+    _fetch_builds_query "&minTime=$min_time&queryOrder=finishTimeDescending" "fin" || rc=1
+    # B) currently active builds (point-in-time; no historical filter)
+    _fetch_builds_query "&statusFilter=inProgress,notStarted&queryOrder=queueTimeDescending" "act" || true
+
+    if ls "$work"/p_*.json >/dev/null 2>&1; then
+        jq -s 'add // [] | unique_by(.id)' "$work"/p_*.json > "$out_file" 2>/dev/null || echo '[]' > "$out_file"
+    else
+        echo '[]' > "$out_file"
+    fi
+    rm -rf "$work"
+    unset -f _fetch_builds_query
+
+    if [ "${BUILDS_CACHE_ENABLED:-true}" = "true" ] && [ -s "$out_file" ] \
+            && jq -e 'type == "array"' "$out_file" >/dev/null 2>&1; then
+        cp "$out_file" "$cache_file" 2>/dev/null || true
+    fi
+
+    jq 'length' "$out_file" 2>/dev/null || echo 0
+    return $rc
+}
+
+# ===========================================================================
+# Parallel per-pool job-request (queue) probe
+#
+# WHY: agent-pool-capacity.sh / platform-issue-investigation.sh already fetch
+# pool AGENTS in parallel, but still probed each scaled-to-zero dynamic pool's
+# job queue SERIALLY inside the loop. For orgs with hundreds of pools that idle
+# at 0 online (e.g. 473 pools, many ephemeral), that serial probe was the
+# dominant remaining wall. Pre-fetching all candidate pools' job requests in a
+# bounded-parallel pass (identical to the agent fetch) removes that wall WITHOUT
+# changing any severity logic -- callers still derive queue pressure per pool,
+# just from a pre-fetched file instead of an inline serial call.
+# ===========================================================================
+
+# Fetch the job-request queue for the given pool ids concurrently, writing one
+# JSON array file per pool to <out_dir>/jobreqs_<poolId>.json ("[]" on failure).
+# Args: $1 = newline-separated pool ids, $2 = output dir, $3 = parallelism (default 20)
+fetch_pool_job_requests_parallel() {
+    local pool_ids="$1" out_dir="$2"
+    local max_par="${3:-${AGENT_FETCH_PARALLELISM:-20}}"
+    local org_url="https://dev.azure.com/$AZURE_DEVOPS_ORG"
+    case "$max_par" in ''|*[!0-9]*) max_par=20 ;; esac
+    [ "$max_par" -lt 1 ] && max_par=1
+    [ "$max_par" -gt 32 ] && max_par=32
+    mkdir -p "$out_dir"
+
+    export ADO_AUTH_HDR; ADO_AUTH_HDR=$(ado_auth_header)
+    printf '%s\n' "$pool_ids" | grep -E '^[0-9]+$' \
+        | xargs -r -P "$max_par" -I {} bash -c '
+            pool="$2"; out="$1/jobreqs_$2.json"; org="$3"; raw="$1/jr_$2.raw"
+            url="$org/_apis/distributedtask/pools/$pool/jobrequests?api-version=7.1"
+            if [ -n "${ADO_AUTH_HDR:-}" ] \
+                 && curl -fsS --max-time 30 -H "Authorization: $ADO_AUTH_HDR" "$url" -o "$raw" 2>/dev/null \
+                 && jq -e "(.value | type) == \"array\"" "$raw" >/dev/null 2>&1; then
+                jq -c ".value" "$raw" > "$out" 2>/dev/null || echo "[]" > "$out"
+            else
+                # Fall back to az devops invoke (proxy/auth aware) for this pool.
+                if resp=$(az devops invoke --area distributedtask --resource jobrequests \
+                        --route-parameters poolId="$pool" --org "$org" --api-version 7.1 \
+                        --output json 2>/dev/null) && printf "%s" "$resp" | jq -e ".value" >/dev/null 2>&1; then
+                    printf "%s" "$resp" | jq -c ".value" > "$out" 2>/dev/null || echo "[]" > "$out"
+                else
+                    echo "[]" > "$out"
+                fi
+            fi
+            rm -f "$raw"
+          ' _ "$out_dir" {} "$org_url"
+    unset ADO_AUTH_HDR
+}
+
+# Echo the cached job-requests array for a pool, or "[]" if absent/invalid.
+# Args: $1 = path to jobreqs_<poolId>.json
+load_pool_job_requests_json() {
+    local f="$1"
+    if [ -s "$f" ] && jq -e 'type == "array"' "$f" >/dev/null 2>&1; then
+        cat "$f"
+    else
+        echo "[]"
+    fi
 }

--- a/codebundles/azure-devops-organization-health/_az_helpers.sh
+++ b/codebundles/azure-devops-organization-health/_az_helpers.sh
@@ -154,7 +154,7 @@ ado_platform_incident_probe() {
 # project is configured. Org-health tasks must use --scope organization.
 ado_security_groups_json() {
     local org_url="https://dev.azure.com/${AZURE_DEVOPS_ORG}"
-    az devops security group list --org "$org_url" --scope organization --output json 2>/dev/null || echo ""
+    az devops security group list --org "$org_url" --scope organization --output json
 }
 
 # ---------------------------------------------------------------------------

--- a/codebundles/azure-devops-organization-health/agent-pool-capacity.sh
+++ b/codebundles/azure-devops-organization-health/agent-pool-capacity.sh
@@ -15,6 +15,10 @@ set -euo pipefail
 #   EPHEMERAL_OFFLINE_RATIO  - % offline above which a pool with online capacity
 #                              is treated as elastic/ephemeral churn (default 60)
 #   AGENT_FETCH_PARALLELISM  - parallel agent-list calls (default 8)
+#   QUEUE_AGING_THRESHOLD_MIN- minutes a queued job must wait before a dynamic
+#                              pool at 0 online is treated as a real outage (15)
+#   CHECK_QUEUE_ON_ZERO      - "true"/"false": probe the pool job queue when a
+#                              dynamic pool has 0 online agents (default true)
 #
 # This script:
 #   1) Analyzes all agent pools in the organization
@@ -22,6 +26,15 @@ set -euo pipefail
 #      not mis-reported as outages
 #   3) Checks agent capacity and utilization
 #   4) Identifies capacity bottlenecks
+#
+# Severity policy (uniform across the agent-pool scripts):
+#   * DYNAMIC pools (elastic/ephemeral) torn-down agents are EXPECTED. A pool at
+#     0 online while idle is NOT an outage. It is escalated above sev 4 ONLY with
+#     real evidence of impact: queued builds aging past QUEUE_AGING_THRESHOLD_MIN
+#     (sev 2), or work still assigned to offline agents (sev 3). Otherwise it is a
+#     sev-4 advisory worded as expected scale-down.
+#   * STATIC pools with offline agents keep a higher severity (lost capacity), but
+#     the issue text always explains the likely cause.
 # -----------------------------------------------------------------------------
 
 : "${AZURE_DEVOPS_ORG:?Must set AZURE_DEVOPS_ORG}"
@@ -87,6 +100,17 @@ echo "Found $pool_count agent pools. Analyzing capacity..."
 # with hundreds of pools that previously ran one sequential call per pool).
 echo "Fetching agents for all self-hosted pools (parallelism: ${AGENT_FETCH_PARALLELISM:-20})..."
 fetch_pool_agents_parallel "$agent_pools" "$AGENT_CACHE_DIR"
+
+# Pre-fetch each self-hosted pool's job-request queue in parallel. This replaces
+# the serial per-pool queue probe that ran inside the loop below -- the dominant
+# remaining cost for orgs with hundreds of scaled-to-zero dynamic pools. The
+# severity logic is UNCHANGED; it simply reads a pre-fetched file instead of
+# making an inline serial call.
+if [ "${CHECK_QUEUE_ON_ZERO:-true}" = "true" ]; then
+    nonhosted_pool_ids=$(echo "$agent_pools" | jq -r '.[] | select((.isHosted // false) == false) | .id')
+    echo "Pre-fetching job-request queues for self-hosted pools (parallelism: ${AGENT_FETCH_PARALLELISM:-20})..."
+    fetch_pool_job_requests_parallel "$nonhosted_pool_ids" "$AGENT_CACHE_DIR"
+fi
 
 # Initialize counters
 total_agents=0
@@ -189,22 +213,62 @@ for ((i=0; i<pool_count; i++)); do
     # always a real problem.
     if [ "$agent_count" -gt 0 ] && [ "$online_count" -eq 0 ]; then
         if [ "$pool_kind" = "elastic" ] || [ "$pool_kind" = "ephemeral" ]; then
-            if [ "$busy_count" -gt 0 ]; then
-                pool_issues+=("No online agents but $busy_count assigned request(s) on registered agents (pool cannot service work)")
-                if [ "$severity" -gt 2 ]; then severity=2; fi
-            else
+            # Probe the pool's job queue. This is the ONLY signal that separates an
+            # idle dynamic pool (expected, sev 4) from a real outage (queued builds
+            # with nothing to run them). busy_assigned does NOT capture queued work.
+            QUEUED_TOTAL=0; QUEUED_AGING=0; OLDEST_QUEUED_MIN=0
+            if [ "${CHECK_QUEUE_ON_ZERO:-true}" = "true" ]; then
+                eval "$(pool_queue_pressure "$(load_pool_job_requests_json "$AGENT_CACHE_DIR/jobreqs_${pool_id}.json")" "${QUEUE_AGING_THRESHOLD_MIN:-15}")"
+            fi
+            queue_status="$(pool_queue_status_line "$busy_count" "$QUEUED_TOTAL" "$QUEUED_AGING" "$OLDEST_QUEUED_MIN")"
+
+            # ESCALATION CONDITION (intent): escalate above sev 4 only with real
+            # evidence of impact -- aging queued work, or work assigned to offline
+            # agents. Idle scale-down stays advisory.
+            if [ "$QUEUED_AGING" -gt 0 ]; then
                 pool_details=$(ado_pool_issue_details \
-                    "Pool scaled to zero: 0 online, $offline_count expected offline churn, no assignedRequest on agents." \
+                    "Dynamic pool has 0 online agents AND $QUEUED_AGING queued build(s) aging past ${QUEUE_AGING_THRESHOLD_MIN:-15} min -- pipelines are blocked." \
                     "$pool_name" "$pool_id" "$pool_type" "$pool_kind" "$agent_count" "$online_count" \
                     "$offline_count" "$busy_count" "$expected_offline" \
-                    "Advisory only: verify in Azure DevOps whether pipeline runs are queued for this pool." "")
+                    "Oldest queued job has waited ${OLDEST_QUEUED_MIN} min with no agent to run it." "" \
+                    "$POOL_KIND_REASON" "$queue_status")
                 capacity_json=$(echo "$capacity_json" | jq \
-                    --arg title "Agent Pool \`$pool_name\` Scaled To Zero (Verify Queue)" \
+                    --arg title "Agent Pool \`$pool_name\` Has Queued Builds But No Online Agents" \
+                    --arg details "$pool_details" \
+                    --arg severity "2" \
+                    --arg nextStep "The dynamic scaler is not provisioning agents. Check autoscale/VMSS/KEDA sizing, the backing scale set / Kubernetes health, and the service connection for this pool in Organization Settings > Agent pools." \
+                    '. += [{"title": $title, "details": $details, "next_steps": $nextStep, "severity": ($severity | tonumber)}]')
+                pools_with_issues=$((pools_with_issues + 1))
+                echo "  $pool_kind pool $pool_name: $QUEUED_AGING queued build(s) aging with 0 online agents -> sev 2."
+            elif [ "$busy_count" -gt 0 ]; then
+                pool_details=$(ado_pool_issue_details \
+                    "Dynamic pool has 0 online agents but $busy_count agent(s) still carry an assignedRequest." \
+                    "$pool_name" "$pool_id" "$pool_type" "$pool_kind" "$agent_count" "$online_count" \
+                    "$offline_count" "$busy_count" "$expected_offline" \
+                    "No queued work is aging; an assignedRequest on an offline agent is usually a stale record left by scale-down." "" \
+                    "$POOL_KIND_REASON" "$queue_status")
+                capacity_json=$(echo "$capacity_json" | jq \
+                    --arg title "Agent Pool \`$pool_name\` Has Work Assigned To Offline Agents" \
+                    --arg details "$pool_details" \
+                    --arg severity "3" \
+                    --arg nextStep "Confirm the scaler replaced the torn-down agents. If the assignedRequest persists, the job may be stuck -- re-queue it or verify the backing VMSS/Kubernetes infrastructure." \
+                    '. += [{"title": $title, "details": $details, "next_steps": $nextStep, "severity": ($severity | tonumber)}]')
+                pools_with_issues=$((pools_with_issues + 1))
+                echo "  $pool_kind pool $pool_name: work assigned to offline agents -> sev 3."
+            else
+                pool_details=$(ado_pool_issue_details \
+                    "Pool scaled to zero: 0 online, $offline_count expected offline churn, no queued work and no assignedRequest." \
+                    "$pool_name" "$pool_id" "$pool_type" "$pool_kind" "$agent_count" "$online_count" \
+                    "$offline_count" "$busy_count" "$expected_offline" \
+                    "Advisory only -- expected dynamic scale-down. No pipelines are waiting on this pool." "" \
+                    "$POOL_KIND_REASON" "$queue_status")
+                capacity_json=$(echo "$capacity_json" | jq \
+                    --arg title "Agent Pool \`$pool_name\` Scaled To Zero (Expected Dynamic Scale-Down)" \
                     --arg details "$pool_details" \
                     --arg severity "4" \
-                    --arg nextStep "No action if pipelines are not waiting. If builds are queued, investigate autoscale/VMSS/KEDA and service connections for this pool." \
+                    --arg nextStep "No action needed -- a dynamic pool idle at 0 online agents is expected. If builds later queue without starting, investigate autoscale/VMSS/KEDA and service connections." \
                     '. += [{"title": $title, "details": $details, "next_steps": $nextStep, "severity": ($severity | tonumber)}]')
-                echo "  $pool_kind pool $pool_name scaled to zero: advisory issue raised."
+                echo "  $pool_kind pool $pool_name scaled to zero: sev-4 advisory (expected)."
             fi
         else
             pool_issues+=("All agents offline")
@@ -244,11 +308,15 @@ for ((i=0; i<pool_count; i++)); do
         pools_with_issues=$((pools_with_issues + 1))
         issues_summary=$(IFS='; '; echo "${pool_issues[*]}")
         title="Agent Pool Capacity Issue: $pool_name"
+        # A short sample of offline agent names so a human can see whether they are
+        # generated/ephemeral or named persistent hosts.
+        offline_sample=$(echo "$agents" | jq -r '[.[] | select(.status == "offline") | .name][:5] | join(", ")' 2>/dev/null || true)
         pool_details=$(ado_pool_issue_details \
             "Capacity issues: $issues_summary" \
             "$pool_name" "$pool_id" "$pool_type" "$pool_kind" "$agent_count" "$online_count" \
             "$offline_count" "$busy_count" "$expected_offline" \
-            "Utilization (online agents only): ${utilization}%" "")
+            "Utilization (online agents only): ${utilization}%" "$offline_sample" \
+            "$POOL_KIND_REASON" "")
         
         capacity_json=$(echo "$capacity_json" | jq \
             --arg title "$title" \

--- a/codebundles/azure-devops-organization-health/cross-project-dependencies.sh
+++ b/codebundles/azure-devops-organization-health/cross-project-dependencies.sh
@@ -136,8 +136,9 @@ for ((i=0; i<scan_count; i++)); do
 
     # Agent queues (one call). Maps each non-hosted pool to projects that reference it.
     if [ -n "$hdr" ]; then
+        project_enc=$(ado_urlencode "$project_name")
         if queues_json=$(curl -s --max-time 20 -H "Authorization: $hdr" \
-            "$ORG_URL/$project_name/_apis/distributedtask/queues?api-version=7.1" 2>/dev/null); then
+            "$ORG_URL/$project_enc/_apis/distributedtask/queues?api-version=7.1" 2>/dev/null); then
             while IFS= read -r pool_name; do
                 [ -z "$pool_name" ] && continue
                 if [[ -v pool_projects["$pool_name"] ]]; then

--- a/codebundles/azure-devops-organization-health/cross-project-dependencies.sh
+++ b/codebundles/azure-devops-organization-health/cross-project-dependencies.sh
@@ -119,6 +119,8 @@ declare -A pool_projects
 cross_repo_refs=0
 analyzed=0
 
+hdr=$(ado_auth_header)
+
 for ((i=0; i<scan_count; i++)); do
     project_name=$(jq -r ".value[${i}].name" projects.json)
     echo "  Scanning project: $project_name"
@@ -133,7 +135,6 @@ for ((i=0; i<scan_count; i++)); do
     fi
 
     # Agent queues (one call). Maps each non-hosted pool to projects that reference it.
-    hdr=$(ado_auth_header)
     if [ -n "$hdr" ]; then
         if queues_json=$(curl -s --max-time 20 -H "Authorization: $hdr" \
             "$ORG_URL/$project_name/_apis/distributedtask/queues?api-version=7.1" 2>/dev/null); then

--- a/codebundles/azure-devops-organization-health/cross-project-dependencies.sh
+++ b/codebundles/azure-devops-organization-health/cross-project-dependencies.sh
@@ -16,7 +16,8 @@ set -euo pipefail
 # This script (Phase 0 single-pass refactor):
 #   1) Lists projects and agent pools ONCE.
 #   2) Makes a SINGLE bounded pass over projects (capped to MAX_PROJECTS),
-#      fetching each project's pipelines and service connections exactly once,
+#      fetching each project's pipelines, agent queues, and service connections
+#      exactly once,
 #      and derives shared-pool / duplicate-connection / cross-project signals
 #      from that. Previously it looped pools x projects (e.g. 473 x 168) issuing
 #      `az pipelines list --project` inside BOTH the pool loop and again for
@@ -30,7 +31,10 @@ set -euo pipefail
 AZURE_DEVOPS_PAT="${AZURE_DEVOPS_PAT:-$azure_devops_pat}"
 export AZURE_DEVOPS_EXT_PAT="${AZURE_DEVOPS_PAT}"
 
+source "$(dirname "$0")/_az_helpers.sh"
+
 OUTPUT_FILE="cross_project_dependencies.json"
+ORG_URL="https://dev.azure.com/$AZURE_DEVOPS_ORG"
 dependencies_json='[]'
 
 echo "Analyzing Cross-Project Dependencies..."
@@ -108,18 +112,10 @@ if [ "$scan_count" -gt "$MAX_PROJECTS" ]; then
 fi
 echo "Found $project_count projects. Analyzing dependencies across the first $scan_count (MAX_PROJECTS=$MAX_PROJECTS)..."
 
-# Agent pools (single call) for the shared-pool denominator.
-non_hosted_pools=()
-if agent_pools=$(az pipelines pool list --output json 2>/dev/null); then
-    while IFS= read -r pname; do
-        [ -n "$pname" ] && non_hosted_pools+=("$pname")
-    done < <(echo "$agent_pools" | jq -r '.[] | select((.isHosted // false) == false) | .name')
-fi
-
-# SINGLE bounded pass over projects: one pipelines call + one service-endpoint
-# call per project, accumulating everything we need.
+# SINGLE bounded pass over projects: pipelines + agent queues + service-endpoint
+# calls per project, accumulating everything we need.
 declare -A connection_projects
-projects_with_pipelines=0
+declare -A pool_projects
 cross_repo_refs=0
 analyzed=0
 
@@ -128,14 +124,30 @@ for ((i=0; i<scan_count; i++)); do
     echo "  Scanning project: $project_name"
     analyzed=$((analyzed + 1))
 
-    # Pipelines (one call). Used for shared-pool denominator + cross-repo heuristic.
+    # Pipelines (one call). Used for cross-repo heuristic.
     if pipelines=$(az pipelines list --project "$project_name" --output json 2>/dev/null); then
         pipeline_count=$(echo "$pipelines" | jq '. | length')
-        if [ "$pipeline_count" -gt 0 ]; then
-            projects_with_pipelines=$((projects_with_pipelines + 1))
-        fi
         if [ "$pipeline_count" -gt 5 ]; then
             cross_repo_refs=$((cross_repo_refs + 1))
+        fi
+    fi
+
+    # Agent queues (one call). Maps each non-hosted pool to projects that reference it.
+    hdr=$(ado_auth_header)
+    if [ -n "$hdr" ]; then
+        if queues_json=$(curl -s --max-time 20 -H "Authorization: $hdr" \
+            "$ORG_URL/$project_name/_apis/distributedtask/queues?api-version=7.1" 2>/dev/null); then
+            while IFS= read -r pool_name; do
+                [ -z "$pool_name" ] && continue
+                if [[ -v pool_projects["$pool_name"] ]]; then
+                    if ! echo ",${pool_projects[$pool_name]}," | grep -q ",${project_name},"; then
+                        pool_projects["$pool_name"]="${pool_projects[$pool_name]},$project_name"
+                    fi
+                else
+                    pool_projects["$pool_name"]="$project_name"
+                fi
+            done < <(printf '%s' "$queues_json" | jq -r \
+                '.value[]? | .pool | select((.isHosted // false) == false) | .name')
         fi
     fi
 
@@ -154,14 +166,16 @@ for ((i=0; i<scan_count; i++)); do
 done
 
 # --- Shared agent pools ---------------------------------------------------
-# A non-hosted pool is treated as shared when more than one analyzed project has
-# pipelines (same approximation as before, now derived from the single pass).
+# A pool is shared only when two or more analyzed projects have agent queues for it.
 shared_pools=()
-if [ "$projects_with_pipelines" -gt 1 ]; then
-    for pname in "${non_hosted_pools[@]}"; do
-        shared_pools+=("$pname:$projects_with_pipelines")
-    done
-fi
+for pname in "${!pool_projects[@]}"; do
+    project_list="${pool_projects[$pname]}"
+    pool_project_count=$(echo "$project_list" | tr ',' '\n' | grep -c . || echo 0)
+    if [ "$pool_project_count" -gt 1 ]; then
+        shared_pools+=("$pname:$pool_project_count")
+        echo "    Pool $pname is shared across $pool_project_count projects"
+    fi
+done
 if [ ${#shared_pools[@]} -gt 10 ]; then
     shared_pools_summary=$(IFS=', '; echo "${shared_pools[*]}")
     dependencies_json=$(echo "$dependencies_json" | jq \

--- a/codebundles/azure-devops-organization-health/cross-project-dependencies.sh
+++ b/codebundles/azure-devops-organization-health/cross-project-dependencies.sh
@@ -9,15 +9,24 @@ set -euo pipefail
 #   AUTH_TYPE (optional, default: service_principal)
 #   AZURE_DEVOPS_PAT (required if AUTH_TYPE=pat)
 #
-# This script:
-#   1) Analyzes cross-project dependencies
-#   2) Checks shared resource usage
-#   3) Identifies potential dependency issues
-#   4) Reports on resource sharing patterns
+# OPTIONAL ENV VARS:
+#   MAX_PROJECTS   - cap on the number of projects scanned for shared resources
+#                    (bounds runtime on large orgs; default 25)
+#
+# This script (Phase 0 single-pass refactor):
+#   1) Lists projects and agent pools ONCE.
+#   2) Makes a SINGLE bounded pass over projects (capped to MAX_PROJECTS),
+#      fetching each project's pipelines and service connections exactly once,
+#      and derives shared-pool / duplicate-connection / cross-project signals
+#      from that. Previously it looped pools x projects (e.g. 473 x 168) issuing
+#      `az pipelines list --project` inside BOTH the pool loop and again for
+#      repos -- the volume wall that drove the 180s timeout.
+#   3) Reports on resource sharing patterns.
 # -----------------------------------------------------------------------------
 
 : "${AZURE_DEVOPS_ORG:?Must set AZURE_DEVOPS_ORG}"
 : "${AUTH_TYPE:=service_principal}"
+: "${MAX_PROJECTS:=25}"
 AZURE_DEVOPS_PAT="${AZURE_DEVOPS_PAT:-$azure_devops_pat}"
 export AZURE_DEVOPS_EXT_PAT="${AZURE_DEVOPS_PAT}"
 
@@ -39,8 +48,6 @@ az devops configure --defaults organization="https://dev.azure.com/$AZURE_DEVOPS
 # Setup authentication
 if [ "$AUTH_TYPE" = "service_principal" ]; then
     echo "Using service principal authentication..."
-    # Service principal authentication is handled by Azure CLI login
-    # Verify authentication is working before proceeding
     echo "Verifying Azure DevOps authentication..."
     for i in {1..3}; do
         if az devops project list --output none &>/dev/null; then
@@ -66,24 +73,18 @@ else
     exit 1
 fi
 
-# Get list of projects
+# Get list of projects (single call)
 echo "Getting projects..."
 if ! projects=$(az devops project list --output json 2>projects_err.log); then
     err_msg=$(cat projects_err.log)
     rm -f projects_err.log
-    
     echo "ERROR: Could not list projects."
     dependencies_json=$(echo "$dependencies_json" | jq \
         --arg title "Failed to List Projects" \
         --arg details "$err_msg" \
         --arg severity "3" \
         --arg next_steps "Check permissions to access projects" \
-        '. += [{
-           "title": $title,
-           "details": $details,
-           "severity": ($severity | tonumber),
-           "next_steps": $next_steps
-         }]')
+        '. += [{"title": $title, "details": $details, "severity": ($severity | tonumber), "next_steps": $next_steps}]')
     echo "$dependencies_json" > "$OUTPUT_FILE"
     exit 1
 fi
@@ -96,222 +97,137 @@ if [ "$project_count" -eq 0 ]; then
     echo "No projects found."
     dependencies_json='[{"title": "No Projects Found", "details": "No projects found in the organization", "severity": 2, "next_steps": "Verify project access permissions"}]'
     echo "$dependencies_json" > "$OUTPUT_FILE"
+    rm -f projects.json
     exit 0
 fi
 
-echo "Found $project_count projects. Analyzing dependencies..."
+# Bound the scan to keep runtime predictable on large orgs (168+ projects).
+scan_count=$project_count
+if [ "$scan_count" -gt "$MAX_PROJECTS" ]; then
+    scan_count=$MAX_PROJECTS
+fi
+echo "Found $project_count projects. Analyzing dependencies across the first $scan_count (MAX_PROJECTS=$MAX_PROJECTS)..."
 
-# Analyze shared agent pools usage
-echo "Analyzing shared agent pool usage..."
-shared_pools=()
+# Agent pools (single call) for the shared-pool denominator.
+non_hosted_pools=()
 if agent_pools=$(az pipelines pool list --output json 2>/dev/null); then
-    
-    # Check each agent pool for usage across projects
-    pool_count=$(echo "$agent_pools" | jq '. | length')
-    
-    for ((i=0; i<pool_count; i++)); do
-        pool_json=$(jq -c ".[${i}]" <<< "$agent_pools")
-        pool_name=$(echo "$pool_json" | jq -r '.name')
-        pool_id=$(echo "$pool_json" | jq -r '.id')
-        is_hosted=$(echo "$pool_json" | jq -r '.isHosted // false')
-        
-        # Skip Microsoft-hosted pools
-        if [ "$is_hosted" = "true" ]; then
-            continue
-        fi
-        
-        echo "  Checking pool usage: $pool_name"
-        
-        # Count projects using this pool (this is an approximation)
-        projects_using_pool=0
-        
-        for ((j=0; j<project_count; j++)); do
-            project_json=$(jq -c ".value[${j}]" projects.json)
-            project_name=$(echo "$project_json" | jq -r '.name')
-            
-            # Check if project has pipelines using this pool
-            if pipelines=$(az pipelines list --project "$project_name" --output json 2>/dev/null); then
-                pipeline_count=$(echo "$pipelines" | jq '. | length')
-                if [ "$pipeline_count" -gt 0 ]; then
-                    projects_using_pool=$((projects_using_pool + 1))
-                fi
-            fi
-        done
-        
-        if [ "$projects_using_pool" -gt 1 ]; then
-            shared_pools+=("$pool_name:$projects_using_pool")
-            echo "    Pool $pool_name is shared across $projects_using_pool projects"
-        fi
-    done
-    
-    if [ ${#shared_pools[@]} -gt 0 ]; then
-        shared_pools_summary=$(IFS=', '; echo "${shared_pools[*]}")
-        echo "  Found ${#shared_pools[@]} shared agent pools: $shared_pools_summary"
-        
-        # Only flag as an issue if there are excessive shared pools (might indicate poor organization)
-        if [ ${#shared_pools[@]} -gt 10 ]; then
-            dependencies_json=$(echo "$dependencies_json" | jq \
-                --arg title "Excessive Shared Agent Pools" \
-                --arg details "Large number of agent pools (${#shared_pools[@]}) shared across projects: $shared_pools_summary" \
-                --arg severity "3" \
-                --arg next_steps "Review agent pool organization and consider consolidating or restructuring pools for better management" \
-                '. += [{
-                   "title": $title,
-                   "details": $details,
-                   "severity": ($severity | tonumber),
-                   "next_steps": $next_steps
-                 }]')
-        fi
-    fi
-else
-    echo "  Could not analyze agent pool usage"
+    while IFS= read -r pname; do
+        [ -n "$pname" ] && non_hosted_pools+=("$pname")
+    done < <(echo "$agent_pools" | jq -r '.[] | select((.isHosted // false) == false) | .name')
 fi
 
-# Analyze service connections sharing
-echo "Analyzing service connection sharing..."
-service_connections_by_name=()
+# SINGLE bounded pass over projects: one pipelines call + one service-endpoint
+# call per project, accumulating everything we need.
 declare -A connection_projects
+projects_with_pipelines=0
+cross_repo_refs=0
+analyzed=0
 
-for ((i=0; i<project_count; i++)); do
-    project_json=$(jq -c ".value[${i}]" projects.json)
-    project_name=$(echo "$project_json" | jq -r '.name')
-    
-    echo "  Checking service connections in: $project_name"
-    
-    if service_conns=$(az devops service-endpoint list --project "$project_name" --output json 2>/dev/null); then
-        conn_count=$(echo "$service_conns" | jq '. | length')
-        
-        if [ "$conn_count" -gt 0 ]; then
-            # Extract connection names and types
-            connection_names=$(echo "$service_conns" | jq -r '.[].name')
-            
-            while IFS= read -r conn_name; do
-                if [ -n "$conn_name" ]; then
-                    if [[ -v connection_projects["$conn_name"] ]]; then
-                        connection_projects["$conn_name"]="${connection_projects["$conn_name"]},$project_name"
-                    else
-                        connection_projects["$conn_name"]="$project_name"
-                    fi
-                fi
-            done <<< "$connection_names"
+for ((i=0; i<scan_count; i++)); do
+    project_name=$(jq -r ".value[${i}].name" projects.json)
+    echo "  Scanning project: $project_name"
+    analyzed=$((analyzed + 1))
+
+    # Pipelines (one call). Used for shared-pool denominator + cross-repo heuristic.
+    if pipelines=$(az pipelines list --project "$project_name" --output json 2>/dev/null); then
+        pipeline_count=$(echo "$pipelines" | jq '. | length')
+        if [ "$pipeline_count" -gt 0 ]; then
+            projects_with_pipelines=$((projects_with_pipelines + 1))
         fi
+        if [ "$pipeline_count" -gt 5 ]; then
+            cross_repo_refs=$((cross_repo_refs + 1))
+        fi
+    fi
+
+    # Service connections (one call). Used for duplicate-connection detection.
+    if service_conns=$(az devops service-endpoint list --project "$project_name" --output json 2>/dev/null); then
+        while IFS= read -r conn_name; do
+            if [ -n "$conn_name" ]; then
+                if [[ -v connection_projects["$conn_name"] ]]; then
+                    connection_projects["$conn_name"]="${connection_projects["$conn_name"]},$project_name"
+                else
+                    connection_projects["$conn_name"]="$project_name"
+                fi
+            fi
+        done < <(echo "$service_conns" | jq -r '.[].name')
     fi
 done
 
-# Check for similarly named connections (potential duplicates)
+# --- Shared agent pools ---------------------------------------------------
+# A non-hosted pool is treated as shared when more than one analyzed project has
+# pipelines (same approximation as before, now derived from the single pass).
+shared_pools=()
+if [ "$projects_with_pipelines" -gt 1 ]; then
+    for pname in "${non_hosted_pools[@]}"; do
+        shared_pools+=("$pname:$projects_with_pipelines")
+    done
+fi
+if [ ${#shared_pools[@]} -gt 10 ]; then
+    shared_pools_summary=$(IFS=', '; echo "${shared_pools[*]}")
+    dependencies_json=$(echo "$dependencies_json" | jq \
+        --arg title "Excessive Shared Agent Pools" \
+        --arg details "Large number of agent pools (${#shared_pools[@]}) shared across projects: $shared_pools_summary" \
+        --arg severity "3" \
+        --arg next_steps "Review agent pool organization and consider consolidating or restructuring pools for better management" \
+        '. += [{"title": $title, "details": $details, "severity": ($severity | tonumber), "next_steps": $next_steps}]')
+fi
+
+# --- Duplicate service connections ----------------------------------------
 duplicate_connections=()
 for conn_name in "${!connection_projects[@]}"; do
     project_list="${connection_projects[$conn_name]}"
     project_count_for_conn=$(echo "$project_list" | tr ',' '\n' | wc -l)
-    
     if [ "$project_count_for_conn" -gt 1 ]; then
         duplicate_connections+=("$conn_name")
-        echo "    Connection '$conn_name' found in multiple projects: $project_list"
     fi
 done
-
 if [ ${#duplicate_connections[@]} -gt 0 ]; then
     duplicate_summary=$(IFS=', '; echo "${duplicate_connections[*]}")
-    
     dependencies_json=$(echo "$dependencies_json" | jq \
         --arg title "Duplicate Service Connections" \
         --arg details "Service connections with similar names across projects: $duplicate_summary" \
         --arg severity "2" \
         --arg next_steps "Review duplicate service connections and consider consolidating or using organization-level connections" \
-        '. += [{
-           "title": $title,
-           "details": $details,
-           "severity": ($severity | tonumber),
-           "next_steps": $next_steps
-         }]')
+        '. += [{"title": $title, "details": $details, "severity": ($severity | tonumber), "next_steps": $next_steps}]')
 fi
 
-# Analyze repository dependencies (check for cross-project repository references)
-echo "Analyzing repository dependencies..."
-cross_repo_refs=0
-
-for ((i=0; i<project_count; i++)); do
-    project_json=$(jq -c ".value[${i}]" projects.json)
-    project_name=$(echo "$project_json" | jq -r '.name')
-    
-    echo "  Checking repositories in: $project_name"
-    
-    if repos=$(az repos list --project "$project_name" --output json 2>/dev/null); then
-        repo_count=$(echo "$repos" | jq '. | length')
-        
-        if [ "$repo_count" -gt 0 ]; then
-            # Check for pipeline definitions that might reference other projects
-            if pipelines=$(az pipelines list --project "$project_name" --output json 2>/dev/null); then
-                pipeline_count=$(echo "$pipelines" | jq '. | length')
-                
-                # This is a simplified check - in practice, you'd need to examine pipeline YAML
-                # for cross-project repository references
-                if [ "$pipeline_count" -gt 5 ]; then
-                    cross_repo_refs=$((cross_repo_refs + 1))
-                fi
-            fi
-        fi
-    fi
-done
-
+# --- Cross-project dependency heuristic -----------------------------------
 if [ "$cross_repo_refs" -gt 0 ]; then
     dependencies_json=$(echo "$dependencies_json" | jq \
         --arg title "Potential Cross-Project Dependencies" \
         --arg details "$cross_repo_refs projects have complex pipeline configurations that may include cross-project dependencies" \
         --arg severity "4" \
         --arg next_steps "Review pipeline configurations for cross-project repository dependencies and ensure proper access controls" \
-        '. += [{
-           "title": $title,
-           "details": $details,
-           "severity": ($severity | tonumber),
-           "next_steps": $next_steps
-         }]')
+        '. += [{"title": $title, "details": $details, "severity": ($severity | tonumber), "next_steps": $next_steps}]')
 fi
 
-# Check for projects with similar names (potential organizational issues)
-echo "Analyzing project naming patterns..."
+# --- Similar project names (no API calls) ---------------------------------
 similar_projects=()
-
-for ((i=0; i<project_count; i++)); do
-    project_json=$(jq -c ".value[${i}]" projects.json)
-    project_name=$(echo "$project_json" | jq -r '.name')
-    
-    # Look for projects with similar prefixes
-    for ((j=i+1; j<project_count; j++)); do
-        other_project_json=$(jq -c ".value[${j}]" projects.json)
-        other_project_name=$(echo "$other_project_json" | jq -r '.name')
-        
-        # Simple similarity check - same first 3 characters
+for ((i=0; i<scan_count; i++)); do
+    project_name=$(jq -r ".value[${i}].name" projects.json)
+    for ((j=i+1; j<scan_count; j++)); do
+        other_project_name=$(jq -r ".value[${j}].name" projects.json)
         if [ ${#project_name} -gt 3 ] && [ ${#other_project_name} -gt 3 ]; then
             prefix1=$(echo "$project_name" | cut -c1-3)
             prefix2=$(echo "$other_project_name" | cut -c1-3)
-            
             if [ "$prefix1" = "$prefix2" ]; then
                 similar_projects+=("$project_name/$other_project_name")
             fi
         fi
     done
 done
-
 if [ ${#similar_projects[@]} -gt 0 ]; then
     similar_summary=$(IFS=', '; echo "${similar_projects[*]}")
-    
     dependencies_json=$(echo "$dependencies_json" | jq \
         --arg title "Similar Project Names Detected" \
         --arg details "Projects with similar naming patterns: $similar_summary" \
         --arg severity "4" \
         --arg next_steps "Review project organization and consider if projects should be consolidated or have clearer naming conventions" \
-        '. += [{
-           "title": $title,
-           "details": $details,
-           "severity": ($severity | tonumber),
-           "next_steps": $next_steps
-         }]')
+        '. += [{"title": $title, "details": $details, "severity": ($severity | tonumber), "next_steps": $next_steps}]')
 fi
 
-# Only report if there are actual dependency issues - don't create issues for well-organized dependencies
 if [ "$(echo "$dependencies_json" | jq '. | length')" -eq 0 ]; then
-    echo "No significant cross-project dependency issues detected across $project_count projects"
+    echo "No significant cross-project dependency issues detected across $analyzed analyzed projects"
 fi
 
 # Clean up temporary files
@@ -324,8 +240,8 @@ echo "Cross-project dependencies analysis completed. Results saved to $OUTPUT_FI
 # Output summary to stdout
 echo ""
 echo "=== CROSS-PROJECT DEPENDENCIES SUMMARY ==="
-echo "Projects Analyzed: $project_count"
+echo "Projects in Org: $project_count (analyzed: $analyzed)"
 echo "Shared Agent Pools: ${#shared_pools[@]}"
 echo "Duplicate Service Connections: ${#duplicate_connections[@]}"
 echo ""
-echo "$dependencies_json" | jq -r '.[] | "Finding: \(.title)\nDetails: \(.details)\nSeverity: \(.severity)\n---"' 
+echo "$dependencies_json" | jq -r '.[] | "Finding: \(.title)\nDetails: \(.details)\nSeverity: \(.severity)\n---"'

--- a/codebundles/azure-devops-organization-health/cross-project-dependencies.sh
+++ b/codebundles/azure-devops-organization-health/cross-project-dependencies.sh
@@ -28,7 +28,7 @@ set -euo pipefail
 : "${AZURE_DEVOPS_ORG:?Must set AZURE_DEVOPS_ORG}"
 : "${AUTH_TYPE:=service_principal}"
 : "${MAX_PROJECTS:=25}"
-AZURE_DEVOPS_PAT="${AZURE_DEVOPS_PAT:-$azure_devops_pat}"
+AZURE_DEVOPS_PAT="${AZURE_DEVOPS_PAT:-${azure_devops_pat:-}}"
 export AZURE_DEVOPS_EXT_PAT="${AZURE_DEVOPS_PAT}"
 
 source "$(dirname "$0")/_az_helpers.sh"

--- a/codebundles/azure-devops-organization-health/meta.yaml
+++ b/codebundles/azure-devops-organization-health/meta.yaml
@@ -70,6 +70,26 @@ spec:
       required: false
       default: "20"
       example: "50"
+    - name: RW_LOOKBACK_WINDOW
+      description: "Lookback window for time-windowed organization analyses. Format: 24h, 7d, 30d. Point-in-time signals (agent pool capacity, platform incidents) ignore it."
+      required: false
+      default: "24h"
+      example: "30d"
+    - name: MAX_PROJECTS
+      description: "Maximum number of projects scanned for cross-project dependency analysis. Bounds runtime on large organizations (the analysis makes a single bounded pass over projects rather than a pools x projects nested loop)."
+      required: false
+      default: "25"
+      example: "50"
+    - name: QUEUE_AGING_THRESHOLD_MIN
+      description: "SLI only. Minutes a build (notStarted job request) may wait in a self-hosted pool's queue before the pool_capacity_ok sub-score drops to 0. Queue-derived so a scaled-to-zero elastic/ephemeral pool with no aging queue is NOT penalised (consistent with the agent-pool fix)."
+      required: false
+      default: "30"
+      example: "15"
+    - name: ORG_POOL_PROBE_LIMIT
+      description: "SLI only. Maximum number of self-hosted pools whose job-request queue is probed per hourly SLI run. Bounds the probe so it stays cheap on organizations with hundreds of pools; the deep daily runbook covers the full 473-pool scan."
+      required: false
+      default: "150"
+      example: "300"
   secrets:
     - name: azure_credentials
       description: "Azure service principal credentials for authentication"

--- a/codebundles/azure-devops-organization-health/organization-policies.sh
+++ b/codebundles/azure-devops-organization-health/organization-policies.sh
@@ -38,7 +38,7 @@ setup_azure_auth
 
 # Check organization security groups and permissions
 echo "Checking organization security groups..."
-if ! security_groups=$(az devops security group list --output json 2>security_err.log); then
+if ! security_groups=$(ado_security_groups_json 2>security_err.log); then
     err_msg=$(cat security_err.log)
     rm -f security_err.log
     

--- a/codebundles/azure-devops-organization-health/organization-service-health.sh
+++ b/codebundles/azure-devops-organization-health/organization-service-health.sh
@@ -175,7 +175,7 @@ fi
 
 # Test organization settings access
 echo "Testing organization settings access..."
-if ! org_settings=$(az devops security group list --output json 2>settings_err.log); then
+if ! org_settings=$(az devops security group list --org "https://dev.azure.com/$AZURE_DEVOPS_ORG" --scope organization --output json 2>settings_err.log); then
     err_msg=$(cat settings_err.log)
     rm -f settings_err.log
     

--- a/codebundles/azure-devops-organization-health/organization-service-health.sh
+++ b/codebundles/azure-devops-organization-health/organization-service-health.sh
@@ -18,7 +18,7 @@ set -euo pipefail
 
 : "${AZURE_DEVOPS_ORG:?Must set AZURE_DEVOPS_ORG}"
 : "${AUTH_TYPE:=service_principal}"
-AZURE_DEVOPS_PAT="${AZURE_DEVOPS_PAT:-$azure_devops_pat}"
+AZURE_DEVOPS_PAT="${AZURE_DEVOPS_PAT:-${azure_devops_pat:-}}"
 export AZURE_DEVOPS_EXT_PAT="${AZURE_DEVOPS_PAT}"
 
 OUTPUT_FILE="organization_service_health.json"

--- a/codebundles/azure-devops-organization-health/platform-issue-investigation.sh
+++ b/codebundles/azure-devops-organization-health/platform-issue-investigation.sh
@@ -14,12 +14,21 @@ set -euo pipefail
 #                              is treated as elastic/ephemeral churn (default 60)
 #   AGENT_FETCH_PARALLELISM  - parallel agent-list calls (default 8)
 #   MAX_OFFLINE_DETAIL       - max offline agent names listed per pool (default 20)
+#   QUEUE_AGING_THRESHOLD_MIN- minutes a queued job must wait before a dynamic
+#                              pool at 0 online is treated as a real outage (15)
+#   CHECK_QUEUE_ON_ZERO      - "true"/"false": probe the pool job queue when a
+#                              dynamic pool has 0 online agents (default true)
 #
 # This script:
 #   1) Performs deep investigation of platform-wide issues
 #   2) Detects elastic/VMSS pools so transient offline agents are not flagged
 #   3) Correlates issues across different services
 #   4) Suggests remediation steps
+#
+# Severity policy mirrors agent-pool-capacity.sh: DYNAMIC pools torn-down agents
+# are expected (sev 4 advisory at most when idle); escalate only on aging queued
+# work (sev 2) or work assigned to offline agents (sev 3). STATIC pools with
+# offline agents keep a higher severity but always explain the likely cause.
 # -----------------------------------------------------------------------------
 
 : "${AZURE_DEVOPS_ORG:?Must set AZURE_DEVOPS_ORG}"
@@ -51,6 +60,15 @@ if agent_pools=$(az pipelines pool list --output json 2>/dev/null); then
     # Fetch all pool agents in parallel rather than one slow call per pool.
     echo "  Fetching agents for $pool_count pools (parallelism: ${AGENT_FETCH_PARALLELISM:-20})..."
     fetch_pool_agents_parallel "$agent_pools" "$AGENT_CACHE_DIR"
+
+    # Pre-fetch each self-hosted pool's job-request queue in parallel, replacing
+    # the serial per-pool probe that ran inside the loop. Severity logic below is
+    # UNCHANGED; it just reads a pre-fetched file instead of an inline call.
+    if [ "${CHECK_QUEUE_ON_ZERO:-true}" = "true" ]; then
+        nonhosted_pool_ids=$(echo "$agent_pools" | jq -r '.[] | select((.isHosted // false) == false) | .id')
+        echo "  Pre-fetching job-request queues for self-hosted pools (parallelism: ${AGENT_FETCH_PARALLELISM:-20})..."
+        fetch_pool_job_requests_parallel "$nonhosted_pool_ids" "$AGENT_CACHE_DIR"
+    fi
 
     for ((i=0; i<pool_count; i++)); do
         pool_json=$(jq -c ".[${i}]" <<< "$agent_pools")
@@ -102,29 +120,57 @@ if agent_pools=$(az pipelines pool list --output json 2>/dev/null); then
             # Offline agents in elastic/ephemeral pools are torn-down scale-set
             # instances, not failures. A complete lack of online capacity is only
             # actionable when work is actually queued; idle scaled-to-zero is normal.
-            if [ "$agent_count" -gt 0 ] && [ "$online_count" -eq 0 ] && [ "${busy_count:-0}" -gt 0 ]; then
-                pool_details=$(ado_pool_issue_details \
-                    "Elastic/ephemeral pool has 0 online agents but active assignedRequest on $busy_count agent(s)." \
-                    "$pool_name" "$pool_id" "$pool_type" "$pool_kind" "$agent_count" "$online_count" \
-                    "$offline_count" "$busy_count" "$offline_count" "" "")
-                investigation_json=$(echo "$investigation_json" | jq \
-                    --arg title "Elastic Pool Has No Online Agents While Work Is Assigned: $pool_name" \
-                    --arg details "$pool_details" \
-                    --arg severity "2" \
-                    --arg next_steps "Verify the VMSS/scale-set/Kubernetes scaler can provision agents: check the elastic pool configuration, the backing Azure scale set / KEDA health, the service connection, and any sizing errors in Azure DevOps > Organization Settings > Agent pools." \
-                    '. += [{"title": $title, "details": $details, "severity": ($severity | tonumber), "next_steps": $next_steps}]')
-            elif [ "$agent_count" -gt 0 ] && [ "$online_count" -eq 0 ]; then
-                pool_details=$(ado_pool_issue_details \
-                    "Pool scaled to zero with $offline_count expected offline registrations; no assignedRequest detected." \
-                    "$pool_name" "$pool_id" "$pool_type" "$pool_kind" "$agent_count" "$online_count" \
-                    "$offline_count" "$busy_count" "$offline_count" \
-                    "Advisory: verify whether pipeline runs are queued for this pool in Azure DevOps." "")
-                investigation_json=$(echo "$investigation_json" | jq \
-                    --arg title "Elastic Pool Scaled To Zero (Verify Queue): $pool_name" \
-                    --arg details "$pool_details" \
-                    --arg severity "4" \
-                    --arg next_steps "No action if no pipelines are waiting. If builds are queued, investigate autoscale/VMSS/KEDA." \
-                    '. += [{"title": $title, "details": $details, "severity": ($severity | tonumber), "next_steps": $next_steps}]')
+            if [ "$agent_count" -gt 0 ] && [ "$online_count" -eq 0 ]; then
+                # Probe the job queue: aging queued work is the real outage signal,
+                # not busy_assigned (which can't see jobs waiting with no agent).
+                QUEUED_TOTAL=0; QUEUED_AGING=0; OLDEST_QUEUED_MIN=0
+                if [ "${CHECK_QUEUE_ON_ZERO:-true}" = "true" ]; then
+                    eval "$(pool_queue_pressure "$(load_pool_job_requests_json "$AGENT_CACHE_DIR/jobreqs_${pool_id}.json")" "${QUEUE_AGING_THRESHOLD_MIN:-15}")"
+                fi
+                queue_status="$(pool_queue_status_line "${busy_count:-0}" "$QUEUED_TOTAL" "$QUEUED_AGING" "$OLDEST_QUEUED_MIN")"
+
+                # ESCALATION CONDITION (intent): sev 2 only for aging queued work,
+                # sev 3 for work stuck on offline agents, else sev 4 advisory.
+                if [ "$QUEUED_AGING" -gt 0 ]; then
+                    pool_details=$(ado_pool_issue_details \
+                        "Dynamic pool has 0 online agents AND $QUEUED_AGING queued build(s) aging past ${QUEUE_AGING_THRESHOLD_MIN:-15} min." \
+                        "$pool_name" "$pool_id" "$pool_type" "$pool_kind" "$agent_count" "$online_count" \
+                        "$offline_count" "$busy_count" "$offline_count" \
+                        "Oldest queued job has waited ${OLDEST_QUEUED_MIN} min." "" \
+                        "$POOL_KIND_REASON" "$queue_status")
+                    investigation_json=$(echo "$investigation_json" | jq \
+                        --arg title "Elastic Pool Has Queued Builds But No Online Agents: $pool_name" \
+                        --arg details "$pool_details" \
+                        --arg severity "2" \
+                        --arg next_steps "Verify the VMSS/scale-set/Kubernetes scaler can provision agents: check the elastic pool sizing, the backing Azure scale set / KEDA health, the service connection, and any sizing errors in Organization Settings > Agent pools." \
+                        '. += [{"title": $title, "details": $details, "severity": ($severity | tonumber), "next_steps": $next_steps}]')
+                elif [ "${busy_count:-0}" -gt 0 ]; then
+                    pool_details=$(ado_pool_issue_details \
+                        "Dynamic pool has 0 online agents but $busy_count agent(s) still carry an assignedRequest." \
+                        "$pool_name" "$pool_id" "$pool_type" "$pool_kind" "$agent_count" "$online_count" \
+                        "$offline_count" "$busy_count" "$offline_count" \
+                        "No queued work is aging; an assignedRequest on an offline agent is usually a stale scale-down record." "" \
+                        "$POOL_KIND_REASON" "$queue_status")
+                    investigation_json=$(echo "$investigation_json" | jq \
+                        --arg title "Elastic Pool Has Work Assigned To Offline Agents: $pool_name" \
+                        --arg details "$pool_details" \
+                        --arg severity "3" \
+                        --arg next_steps "Confirm the scaler replaced the torn-down agents. If the assignedRequest persists, re-queue the job or verify the backing VMSS/Kubernetes infrastructure." \
+                        '. += [{"title": $title, "details": $details, "severity": ($severity | tonumber), "next_steps": $next_steps}]')
+                else
+                    pool_details=$(ado_pool_issue_details \
+                        "Pool scaled to zero with $offline_count expected offline registrations; no queued work and no assignedRequest." \
+                        "$pool_name" "$pool_id" "$pool_type" "$pool_kind" "$agent_count" "$online_count" \
+                        "$offline_count" "$busy_count" "$offline_count" \
+                        "Advisory only -- expected dynamic scale-down. No pipelines are waiting on this pool." "" \
+                        "$POOL_KIND_REASON" "$queue_status")
+                    investigation_json=$(echo "$investigation_json" | jq \
+                        --arg title "Elastic Pool Scaled To Zero (Expected Dynamic Scale-Down): $pool_name" \
+                        --arg details "$pool_details" \
+                        --arg severity "4" \
+                        --arg next_steps "No action needed -- a dynamic pool idle at 0 online agents is expected. If builds later queue without starting, investigate autoscale/VMSS/KEDA." \
+                        '. += [{"title": $title, "details": $details, "severity": ($severity | tonumber), "next_steps": $next_steps}]')
+                fi
             fi
         elif [ "$offline_count" -gt 0 ]; then
             # Static pool: offline agents are genuine lost capacity. Cap the
@@ -137,14 +183,15 @@ if agent_pools=$(az pipelines pool list --output json 2>/dev/null); then
             fi
 
             pool_details=$(ado_pool_issue_details \
-                "Static pool has $offline_count offline agents out of $agent_count total." \
+                "Static pool has $offline_count offline agents out of $agent_count total (actionable lost capacity)." \
                 "$pool_name" "$pool_id" "${pool_type:-unknown}" "$pool_kind" "$agent_count" "$online_count" \
-                "$offline_count" "$busy_count" "0" "" "$offline_details")
+                "$offline_count" "$busy_count" "0" "" "$offline_details" \
+                "$POOL_KIND_REASON" "")
             investigation_json=$(echo "$investigation_json" | jq \
                 --arg title "Offline Agents in Pool: $pool_name" \
                 --arg details "$pool_details" \
                 --arg severity "3" \
-                --arg next_steps "Check agent connectivity, restart agent services, and verify network connectivity for offline agents" \
+                --arg next_steps "These are persistent/static agents: restart the agent service on each offline host, confirm the host is powered on and can reach dev.azure.com, and verify the agent credentials/PAT have not expired." \
                 '. += [{"title": $title, "details": $details, "severity": ($severity | tonumber), "next_steps": $next_steps}]')
         fi
 

--- a/codebundles/azure-devops-organization-health/preflight-check.sh
+++ b/codebundles/azure-devops-organization-health/preflight-check.sh
@@ -31,20 +31,25 @@ blocking=0
 
 # Classify the outcome of an az command.
 #   $1 = capability name, $2 = required PAT scope, $3 = required role,
-#   $4 = "core"|"optional", $5.. = command
+#   $4 = "core"|"optional", $5 = REST endpoint exercised, $6.. = command
 probe() {
-    local name="$1" scope="$2" role="$3" tier="$4"; shift 4
-    local err status detail
+    local name="$1" scope="$2" role="$3" tier="$4" endpoint="$5"; shift 5
+    local err status detail http_status=""
     err=$("$@" 2>&1 >/dev/null)
     local rc=$?
 
     if [ $rc -eq 0 ]; then
         status="OK"; detail="Accessible."
-        echo "  [OK]     $name"
+        printf '  [OK]      %-42s %s\n' "$name" "$endpoint"
     else
         local lc; lc=$(echo "$err" | tr '[:upper:]' '[:lower:]')
+        # Extract a concrete HTTP status when present so the report can say
+        # exactly what the API returned. Prefer the numeric HTTP code; any
+        # TF###### code stays visible in the captured detail string below.
+        http_status=$(printf '%s' "$err" | grep -oiE '\b(401|403|404|409|429|500|502|503)\b' | head -n1)
         if echo "$lc" | grep -Eq 'denied|not authorized|forbidden|do not have|tf400813|403|unauthorized|401'; then
             status="DENIED"
+            [ -z "$http_status" ] && http_status="403"
         elif echo "$lc" | grep -Eq 'timed out|timeout|could not resolve|connection|network|unreachable'; then
             status="NETWORK"
         else
@@ -52,13 +57,16 @@ probe() {
         fi
         detail=$(echo "$err" | head -c 300 | tr '\n' ' ')
         [ "$tier" = "core" ] && blocking=$((blocking + 1))
-        echo "  [$status] $name -> needs PAT scope '$scope' / role '$role'"
+        local httptxt=""; [ -n "$http_status" ] && httptxt=" (HTTP ${http_status})"
+        printf '  [%-7s] %-42s %s%s\n' "$status" "$name" "$endpoint" "$httptxt"
+        printf '            -> needs PAT scope %s / role %s\n' "$scope" "$role"
     fi
 
     capabilities=$(echo "$capabilities" | jq \
         --arg name "$name" --arg scope "$scope" --arg role "$role" \
         --arg tier "$tier" --arg status "$status" --arg detail "$detail" \
-        '. += [{capability:$name, status:$status, tier:$tier, required_pat_scope:$scope, required_role:$role, detail:$detail}]')
+        --arg endpoint "$endpoint" --arg http "$http_status" \
+        '. += [{capability:$name, status:$status, tier:$tier, required_pat_scope:$scope, required_role:$role, endpoint:$endpoint, http_status:$http, detail:$detail}]')
 }
 
 # =========================================================================
@@ -88,23 +96,28 @@ PRIMARY_PROJECT=$(az devops project list --org "$ORG_URL" --top 1 --output json 
 
 probe "Projects (read)" "vso.project (Project and Team: Read)" \
     "Project-level Reader (or member of Project Valid Users)" "core" \
+    "GET /_apis/projects" \
     az devops project list --org "$ORG_URL" --top 1 --output json
 
 probe "Agent Pools (read)" "vso.agentpools (Agent Pools: Read)" \
     "Reader on Organization Settings > Agent pools" "core" \
+    "GET /_apis/distributedtask/pools" \
     az pipelines pool list --org "$ORG_URL" --output json
 
 probe "User Entitlements / Licensing (read)" "vso.memberentitlementmanagement (Member Entitlement Management: Read)" \
     "Project Collection Administrator" "optional" \
+    "GET /_apis/userentitlements (vsaex)" \
     az devops user list --org "$ORG_URL" --top 1 --output json
 
 probe "Security Groups / Graph (read)" "vso.graph (Graph: Read)" \
     "Project Collection Administrator" "optional" \
-    az devops security group list --org "$ORG_URL" --output json
+    "GET /_apis/graph/groups (vssps)" \
+    az devops security group list --org "$ORG_URL" --scope organization --output json
 
 if [ -n "$PRIMARY_PROJECT" ]; then
     probe "Service Connections (read) [$PRIMARY_PROJECT]" "vso.serviceendpoint (Service Connections: Read)" \
         "Reader on the project's service connections" "optional" \
+        "GET /{project}/_apis/serviceendpoint/endpoints" \
         az devops service-endpoint list --project "$PRIMARY_PROJECT" --org "$ORG_URL" --output json
 fi
 
@@ -114,33 +127,96 @@ fi
 echo ""
 echo "=== Preflight Summary ==="
 
+# Guard: ado_identity_json should always return a JSON object, but a transient
+# failure (or an older helper) could echo an empty string, which would make the
+# final `jq -n --argjson identity ""` abort and leave preflight_results.json
+# missing/empty — the exact bug that made a fully-accessible run report
+# "Insufficient Azure DevOps Access" with no detail. Never trust it blindly.
+if ! echo "$identity_json" | jq -e . >/dev/null 2>&1; then
+    identity_json='{"name":"unknown","id":"unknown","email":"","auth_type":"'"${AUTH_TYPE:-service_principal}"'","confirmed":false}'
+fi
+
+case "${AUTH_TYPE:-service_principal}" in
+    pat) auth_mode="Personal Access Token (PAT)" ;;
+    *)   auth_mode="Service Principal" ;;
+esac
+
 total=$(echo "$capabilities" | jq 'length')
 ok=$(echo "$capabilities" | jq '[.[] | select(.status=="OK")] | length')
-identity_name=$(echo "$identity_json" | jq -r '.name')
+identity_confirmed=$(echo "$identity_json" | jq -r '.confirmed // false')
+identity_name=$(echo "$identity_json" | jq -r '.name // "unknown"')
+if [ "$identity_confirmed" = "true" ]; then
+    identity_line="${identity_name} (id=$(echo "$identity_json" | jq -r '.id // "unknown"'))"
+else
+    identity_line="could not be resolved (connectionData blocked by proxy or PAT lacks vso.profile) — capability probes below are authoritative"
+fi
 optional_missing=$(echo "$capabilities" | jq -r '[.[] | select(.status!="OK" and .tier=="optional") | "\(.capability) (needs \(.required_pat_scope) / \(.required_role))"] | join("; ")')
 
 if [ "$blocking" -eq 0 ]; then
     access_ok=true
     if [ -n "$optional_missing" ]; then
-        summary="Access OK for core tasks ($ok/$total capabilities) as identity '${identity_name}'. Limited: ${optional_missing} — related tasks (e.g. licensing/policy) will be partial until granted."
+        summary="Access OK for core tasks ($ok/$total capabilities) via ${auth_mode} as identity '${identity_name}'. Limited: ${optional_missing} — related tasks (e.g. licensing/policy) will be partial until granted."
     else
-        summary="Access OK: identity '${identity_name}' can perform all required Azure DevOps reads ($ok/$total capabilities). Organization health tasks should run normally."
+        summary="Access OK: identity '${identity_name}' (${auth_mode}) can perform all required Azure DevOps reads ($ok/$total capabilities). Organization health tasks should run normally."
     fi
 else
     access_ok=false
     missing=$(echo "$capabilities" | jq -r '[.[] | select(.status!="OK" and .tier=="core") | "\(.capability) (needs \(.required_pat_scope) / \(.required_role))"] | join("; ")')
-    summary="INSUFFICIENT ACCESS: identity '${identity_name}' is missing $blocking required capability(ies): ${missing}. Grant the listed PAT scopes/roles and re-run; affected tasks will return empty or partial results until then."
+    summary="INSUFFICIENT ACCESS: identity '${identity_name}' (${auth_mode}) is missing $blocking required capability(ies): ${missing}. Grant the listed PAT scopes/roles and re-run; affected tasks will return empty or partial results until then."
 fi
 
 echo "$summary"
 
+# Build a single, self-contained, actionable report block. This is what the
+# runbook drops verbatim into the issue_details so a human or a troubleshooting
+# agent sees EXACTLY which capability failed, on which endpoint, with what
+# status, and precisely what scope/role to grant — without needing the raw log.
+report=$(echo "$capabilities" | jq -r \
+    --arg org "$AZURE_DEVOPS_ORG" \
+    --arg auth "$auth_mode" \
+    --arg ident "$identity_line" \
+    --arg summary "$summary" '
+    [
+      "Azure DevOps preflight access check",
+      "Organization : \($org)",
+      "Auth mode    : \($auth)",
+      "Identity     : \($ident)",
+      "Result       : \($summary)",
+      "",
+      "Capability matrix (capability -> endpoint -> result):"
+    ]
+    + [ .[] | "  [\(.status)] \(.capability)  ->  \(.endpoint)" + (if (.http_status // "") != "" then "  (HTTP \(.http_status))" else "" end) ]
+    + (
+        [ .[] | select(.status != "OK") ] as $bad
+        | if ($bad | length) == 0 then []
+          else
+            ["", "How to grant the missing access:"]
+            + ( $bad | to_entries | map(
+                "  \(.key + 1). \(.value.capability) [\(.value.tier)] returned \(.value.status)\(if (.value.http_status // "") != "" then " (HTTP \(.value.http_status))" else "" end) on \(.value.endpoint)."
+                + "\n       - Add PAT scope: \(.value.required_pat_scope)  (User settings > Personal access tokens > Edit > Scopes)."
+                + "\n       - Ensure role : \(.value.required_role)."
+                + (if (.value.detail // "") != "" and .value.detail != "Accessible." then "\n       - API said    : \(.value.detail)" else "" end)
+              ))
+          end
+      )
+    | join("\n")')
+
 result_json=$(jq -n \
     --arg org "$AZURE_DEVOPS_ORG" \
+    --arg auth_mode "$auth_mode" \
     --argjson identity "$identity_json" \
     --argjson capabilities "$capabilities" \
     --argjson access_ok "$access_ok" \
     --arg summary "$summary" \
-    '{organization:$org, identity:$identity, capabilities:$capabilities, access_ok:$access_ok, summary:$summary}')
+    --arg report "$report" \
+    '{organization:$org, auth_mode:$auth_mode, identity:$identity, capabilities:$capabilities, access_ok:$access_ok, summary:$summary, report:$report}')
+
+# Last-resort guard: the results file must ALWAYS be valid JSON so the runbook
+# never has to fall back to a contentless "results unavailable" placeholder.
+if [ -z "$result_json" ] || ! echo "$result_json" | jq -e . >/dev/null 2>&1; then
+    result_json=$(jq -n --arg s "$summary" --arg r "${report:-$summary}" --argjson ok "${access_ok:-false}" \
+        '{access_ok:$ok, summary:$s, report:$r}')
+fi
 
 echo "$result_json" > "$OUTPUT_FILE"
 echo "Results saved to $OUTPUT_FILE"

--- a/codebundles/azure-devops-organization-health/runbook.robot
+++ b/codebundles/azure-devops-organization-health/runbook.robot
@@ -25,15 +25,15 @@ Validate Azure DevOps Access for Organization `${AZURE_DEVOPS_ORG}`
         RW.Core.Add Issue
         ...    severity=2
         ...    expected=The configured identity has the PAT scopes / Azure DevOps roles required for organization health checks in `${AZURE_DEVOPS_ORG}`
-        ...    actual=Preflight reported insufficient access for organization `${AZURE_DEVOPS_ORG}`; downstream checks may be incomplete or fail
+        ...    actual=${PREFLIGHT_SUMMARY}
         ...    title=Insufficient Azure DevOps Access for Organization `${AZURE_DEVOPS_ORG}`
         ...    reproduce_hint=preflight-check.sh
-        ...    details=${PREFLIGHT_SUMMARY}
-        ...    next_steps=Grant the missing PAT scopes / Azure DevOps roles listed in the preflight output above, then re-run. See the codebundle troubleshooting docs for the required-access matrix.
+        ...    details=${PREFLIGHT_DETAILS}
+        ...    next_steps=For each capability marked DENIED/ERROR in the matrix above, grant the listed PAT scope (Azure DevOps > User settings > Personal access tokens > Edit > Scopes) and the listed organization/project role, then re-run. If the matrix shows all capabilities OK, the preflight script failed to record its result rather than a true permission gap — re-run and check the raw preflight output.
     END
 
     RW.Core.Add Pre To Report    Preflight Access Summary:
-    RW.Core.Add Pre To Report    ${PREFLIGHT_SUMMARY}
+    RW.Core.Add Pre To Report    ${PREFLIGHT_DETAILS}
 
 Check Service Health Status for Azure DevOps Organization `${AZURE_DEVOPS_ORG}`
     [Documentation]    Tests connectivity and access to core Azure DevOps APIs and services. Identifies service issues vs permission limitations.
@@ -352,10 +352,22 @@ Suite Initialization
     ...    description=License utilization threshold percentage (0-100) above which licensing issues are flagged.
     ...    default=90
     ...    pattern=\w*
+    ${RW_LOOKBACK_WINDOW}=    RW.Core.Import User Variable    RW_LOOKBACK_WINDOW
+    ...    type=string
+    ...    description=Lookback window for time-windowed organization analyses. Format: 24h, 7d, 30d. Point-in-time signals (pool capacity, incidents) ignore it.
+    ...    default=24h
+    ...    pattern=\w*
+    ${MAX_PROJECTS}=    RW.Core.Import User Variable    MAX_PROJECTS
+    ...    type=string
+    ...    description=Maximum number of projects scanned for cross-project dependency analysis (bounds runtime on large organizations).
+    ...    default=25
+    ...    pattern=\w*
     
     Set Suite Variable    ${AZURE_DEVOPS_ORG}    ${AZURE_DEVOPS_ORG}
     Set Suite Variable    ${AGENT_UTILIZATION_THRESHOLD}    ${AGENT_UTILIZATION_THRESHOLD}
     Set Suite Variable    ${LICENSE_UTILIZATION_THRESHOLD}    ${LICENSE_UTILIZATION_THRESHOLD}
+    Set Suite Variable    ${RW_LOOKBACK_WINDOW}    ${RW_LOOKBACK_WINDOW}
+    Set Suite Variable    ${MAX_PROJECTS}    ${MAX_PROJECTS}
 
     Set Suite Variable    ${AZURE_DEVOPS_CONFIG_DIR}    %{CODEBUNDLE_TEMP_DIR}/.azure-devops
 
@@ -364,6 +376,8 @@ Suite Initialization
     ...    AZURE_DEVOPS_ORG=${AZURE_DEVOPS_ORG}
     ...    AGENT_UTILIZATION_THRESHOLD=${AGENT_UTILIZATION_THRESHOLD}
     ...    LICENSE_UTILIZATION_THRESHOLD=${LICENSE_UTILIZATION_THRESHOLD}
+    ...    RW_LOOKBACK_WINDOW=${RW_LOOKBACK_WINDOW}
+    ...    MAX_PROJECTS=${MAX_PROJECTS}
     ...    AUTH_TYPE=${AUTH_TYPE}
     ...    AZURE_CONFIG_DIR=${AZURE_DEVOPS_CONFIG_DIR}
     ...    AZURE_DEVOPS_CONFIG_DIR=${AZURE_DEVOPS_CONFIG_DIR}
@@ -385,15 +399,24 @@ Suite Initialization
     TRY
         ${preflight_data}=    Evaluate    json.loads(r'''${preflight_json_raw.stdout}''')    json
         ${preflight_summary}=    Set Variable    ${preflight_data['summary']}
+        # Prefer the script's full, actionable report (capability matrix + the
+        # exact scope/role/endpoint remediation). Fall back to the raw stdout so
+        # the matrix still reaches the issue even on an older results file.
+        ${preflight_details}=    Evaluate    $preflight_data.get('report') or $preflight_data.get('summary') or r'''${preflight.stdout}'''
         Log    Preflight result: ${preflight_summary}    INFO
     EXCEPT
-        Log    WARNING: Could not parse preflight results.    WARN
-        ${preflight_data}=    Evaluate    {"summary": "Preflight results unavailable", "access_ok": False, "identity": {"name": "unknown"}}
-        ${preflight_summary}=    Set Variable    Preflight results unavailable
+        Log    WARNING: Could not parse preflight results. Raw output: ${preflight.stdout}    WARN
+        # Do NOT swallow this: a missing/invalid results file means the access
+        # probe could not be recorded, so surface it as a real (access_ok=False)
+        # finding and carry the raw probe output so it stays actionable.
+        ${preflight_data}=    Evaluate    {"summary": "Preflight access check did not complete (results file missing or invalid)", "access_ok": False, "identity": {"name": "unknown"}}
+        ${preflight_summary}=    Set Variable    Preflight access check did not complete (results file missing or invalid)
+        ${preflight_details}=    Set Variable    ${preflight.stdout}
     END
 
     Set Suite Variable    ${PREFLIGHT_DATA}    ${preflight_data}
     Set Suite Variable    ${PREFLIGHT_SUMMARY}    ${preflight_summary}
+    Set Suite Variable    ${PREFLIGHT_DETAILS}    ${preflight_details}
 
     RW.Core.Add Pre To Report    Preflight Access Check:
     RW.Core.Add Pre To Report    ${preflight.stdout} 

--- a/codebundles/azure-devops-organization-health/service-incident-check.sh
+++ b/codebundles/azure-devops-organization-health/service-incident-check.sh
@@ -104,49 +104,33 @@ else
          }]')
 fi
 
-# Test Azure DevOps status page connectivity
-echo "Checking Azure DevOps status page..."
-if status_response=$(curl -s -w "%{http_code}" -o status_page.html "$status_url" 2>/dev/null); then
-    status_code=$(echo "$status_response" | tail -c 4)
-    
-    if [ "$status_code" = "200" ]; then
-        echo "Status page accessible"
-        
-        # Prefer the official Status API (string health). HTML numeric enum is
-        # 1=unhealthy, 2=degraded, 3=advisory, 4=healthy — NOT 1=healthy.
-        ado_platform_incident_probe
-        _platform_health_lc=$(printf '%s' "${ADO_PLATFORM_HEALTH:-}" | tr '[:upper:]' '[:lower:]')
-        _raise_platform_incident=0
-        if [ "${ADO_PLATFORM_INCIDENT_OK:-1}" -eq 0 ]; then
-            case "$_platform_health_lc" in
-                4|healthy) _raise_platform_incident=0 ;;
-                *) _raise_platform_incident=1 ;;
-            esac
-        fi
-        if [ "$_raise_platform_incident" -eq 1 ]; then
-            incident_json=$(echo "$incident_json" | jq \
-                --arg title "Azure DevOps Service Degradation Detected" \
-                --arg details "Platform status: ${ADO_PLATFORM_HEALTH}. Message: ${ADO_PLATFORM_STATUS_MESSAGE}" \
-                --arg severity "3" \
-                --arg next_steps "Check https://status.dev.azure.com for current incidents and service advisories" \
-                '. += [{
-                   "title": $title,
-                   "details": $details,
-                   "severity": ($severity | tonumber),
-                   "next_steps": $next_steps
-                 }]')
-        else
-            echo "Azure DevOps platform status OK (health: ${ADO_PLATFORM_HEALTH}, message: ${ADO_PLATFORM_STATUS_MESSAGE})"
-        fi
-    else
-        echo "Status page returned HTTP $status_code"
-    fi
-else
-    echo "Could not access Azure DevOps status page"
+# Platform status via Status REST API (ado_platform_incident_probe); HTML fallback
+# uses a private temp file inside the helper — do not download status_page.html here.
+echo "Checking Azure DevOps platform status..."
+ado_platform_incident_probe
+_platform_health_lc=$(printf '%s' "${ADO_PLATFORM_HEALTH:-}" | tr '[:upper:]' '[:lower:]')
+_raise_platform_incident=0
+if [ "${ADO_PLATFORM_INCIDENT_OK:-1}" -eq 0 ]; then
+    case "$_platform_health_lc" in
+        4|healthy) _raise_platform_incident=0 ;;
+        *) _raise_platform_incident=1 ;;
+    esac
 fi
-
-# Clean up temporary file
-rm -f status_page.html
+if [ "$_raise_platform_incident" -eq 1 ]; then
+    incident_json=$(echo "$incident_json" | jq \
+        --arg title "Azure DevOps Service Degradation Detected" \
+        --arg details "Platform status: ${ADO_PLATFORM_HEALTH}. Message: ${ADO_PLATFORM_STATUS_MESSAGE}" \
+        --arg severity "3" \
+        --arg next_steps "Check https://status.dev.azure.com for current incidents and service advisories" \
+        '. += [{
+           "title": $title,
+           "details": $details,
+           "severity": ($severity | tonumber),
+           "next_steps": $next_steps
+         }]')
+else
+    echo "Azure DevOps platform status OK (health: ${ADO_PLATFORM_HEALTH}, message: ${ADO_PLATFORM_STATUS_MESSAGE})"
+fi
 
 # Check Azure CLI connectivity and authentication
 echo "Testing Azure CLI connectivity..."

--- a/codebundles/azure-devops-organization-health/service-incident-check.sh
+++ b/codebundles/azure-devops-organization-health/service-incident-check.sh
@@ -18,7 +18,7 @@ set -euo pipefail
 
 : "${AZURE_DEVOPS_ORG:?Must set AZURE_DEVOPS_ORG}"
 : "${AUTH_TYPE:=service_principal}"
-AZURE_DEVOPS_PAT="${AZURE_DEVOPS_PAT:-$azure_devops_pat}"
+AZURE_DEVOPS_PAT="${AZURE_DEVOPS_PAT:-${azure_devops_pat:-}}"
 export AZURE_DEVOPS_EXT_PAT="${AZURE_DEVOPS_PAT}"
 
 source "$(dirname "$0")/_az_helpers.sh"

--- a/codebundles/azure-devops-organization-health/service-incident-check.sh
+++ b/codebundles/azure-devops-organization-health/service-incident-check.sh
@@ -21,6 +21,8 @@ set -euo pipefail
 AZURE_DEVOPS_PAT="${AZURE_DEVOPS_PAT:-$azure_devops_pat}"
 export AZURE_DEVOPS_EXT_PAT="${AZURE_DEVOPS_PAT}"
 
+source "$(dirname "$0")/_az_helpers.sh"
+
 OUTPUT_FILE="service_incidents.json"
 incident_json='[]'
 
@@ -110,30 +112,31 @@ if status_response=$(curl -s -w "%{http_code}" -o status_page.html "$status_url"
     if [ "$status_code" = "200" ]; then
         echo "Status page accessible"
         
-        # Parse actual service status from JSON data instead of keyword search
-        if service_status=$(grep -o '"serviceStatus":{[^}]*"health":[0-9]*[^}]*}' status_page.html 2>/dev/null); then
-            # Extract health status (1=healthy, 2=advisory, 3=degraded, 4=unhealthy)
-            health_status=$(echo "$service_status" | grep -o '"health":[0-9]*' | cut -d':' -f2)
-            service_message=$(echo "$service_status" | grep -o '"message":"[^"]*"' | cut -d'"' -f4)
-            
-            if [ "$health_status" -ge 3 ]; then
-                # Health status 3=degraded, 4=unhealthy
-                incident_json=$(echo "$incident_json" | jq \
-                    --arg title "Azure DevOps Service Degradation Detected" \
-                    --arg details "Service health status: $health_status. Message: $service_message" \
-                    --arg severity "3" \
-                    --arg next_steps "Check Azure DevOps status page for current incidents and service advisories" \
-                    '. += [{
-                       "title": $title,
-                       "details": $details,
-                       "severity": ($severity | tonumber),
-                       "next_steps": $next_steps
-                     }]')
-            else
-                echo "Azure DevOps services report healthy status (health: $health_status)"
-            fi
+        # Prefer the official Status API (string health). HTML numeric enum is
+        # 1=unhealthy, 2=degraded, 3=advisory, 4=healthy — NOT 1=healthy.
+        ado_platform_incident_probe
+        _platform_health_lc=$(printf '%s' "${ADO_PLATFORM_HEALTH:-}" | tr '[:upper:]' '[:lower:]')
+        _raise_platform_incident=0
+        if [ "${ADO_PLATFORM_INCIDENT_OK:-1}" -eq 0 ]; then
+            case "$_platform_health_lc" in
+                4|healthy) _raise_platform_incident=0 ;;
+                *) _raise_platform_incident=1 ;;
+            esac
+        fi
+        if [ "$_raise_platform_incident" -eq 1 ]; then
+            incident_json=$(echo "$incident_json" | jq \
+                --arg title "Azure DevOps Service Degradation Detected" \
+                --arg details "Platform status: ${ADO_PLATFORM_HEALTH}. Message: ${ADO_PLATFORM_STATUS_MESSAGE}" \
+                --arg severity "3" \
+                --arg next_steps "Check https://status.dev.azure.com for current incidents and service advisories" \
+                '. += [{
+                   "title": $title,
+                   "details": $details,
+                   "severity": ($severity | tonumber),
+                   "next_steps": $next_steps
+                 }]')
         else
-            echo "Could not parse service status from status page"
+            echo "Azure DevOps platform status OK (health: ${ADO_PLATFORM_HEALTH}, message: ${ADO_PLATFORM_STATUS_MESSAGE})"
         fi
     else
         echo "Status page returned HTTP $status_code"
@@ -283,6 +286,16 @@ if command -v timedatectl >/dev/null 2>&1; then
              }]')
     fi
 fi
+
+# Never keep a platform degradation issue when status is healthy (portal 4 or API "healthy").
+incident_json=$(echo "$incident_json" | jq '
+  map(select(
+    .title != "Azure DevOps Service Degradation Detected"
+    or (
+      ((.details // "") | test("status: (4|healthy)"; "i")) | not
+    )
+  ))
+')
 
 # Only report if there are actual incidents - don't create issues for healthy status
 if [ "$(echo "$incident_json" | jq '. | length')" -eq 0 ]; then

--- a/codebundles/azure-devops-organization-health/service-incident-check.sh
+++ b/codebundles/azure-devops-organization-health/service-incident-check.sh
@@ -108,15 +108,9 @@ fi
 # uses a private temp file inside the helper — do not download status_page.html here.
 echo "Checking Azure DevOps platform status..."
 ado_platform_incident_probe
-_platform_health_lc=$(printf '%s' "${ADO_PLATFORM_HEALTH:-}" | tr '[:upper:]' '[:lower:]')
-_raise_platform_incident=0
+# Trust ADO_PLATFORM_INCIDENT_OK from the probe (includes geographic degradation even
+# when overall status is "healthy"). Do not second-guess with overall health text.
 if [ "${ADO_PLATFORM_INCIDENT_OK:-1}" -eq 0 ]; then
-    case "$_platform_health_lc" in
-        4|healthy) _raise_platform_incident=0 ;;
-        *) _raise_platform_incident=1 ;;
-    esac
-fi
-if [ "$_raise_platform_incident" -eq 1 ]; then
     incident_json=$(echo "$incident_json" | jq \
         --arg title "Azure DevOps Service Degradation Detected" \
         --arg details "Platform status: ${ADO_PLATFORM_HEALTH}. Message: ${ADO_PLATFORM_STATUS_MESSAGE}" \
@@ -270,16 +264,6 @@ if command -v timedatectl >/dev/null 2>&1; then
              }]')
     fi
 fi
-
-# Never keep a platform degradation issue when status is healthy (portal 4 or API "healthy").
-incident_json=$(echo "$incident_json" | jq '
-  map(select(
-    .title != "Azure DevOps Service Degradation Detected"
-    or (
-      ((.details // "") | test("status: (4|healthy)"; "i")) | not
-    )
-  ))
-')
 
 # Only report if there are actual incidents - don't create issues for healthy status
 if [ "$(echo "$incident_json" | jq '. | length')" -eq 0 ]; then

--- a/codebundles/azure-devops-organization-health/sli-org-health-score.sh
+++ b/codebundles/azure-devops-organization-health/sli-org-health-score.sh
@@ -137,7 +137,7 @@ else
 fi
 # Max utilization across billed licenses whose total is measurable (>0). Stakeholder
 # (free) and unlimited/0-total entries are skipped: cannot measure => no penalty.
-license_eval=$(printf '%s' "$license_summary" | jq -r \
+license_eval=$(printf '%s' "$license_summary" | jq -c \
     --argjson thr "$LICENSE_UTILIZATION_THRESHOLD" '
     (.licenses // []) as $lics
     | [ $lics[]
@@ -146,14 +146,14 @@ license_eval=$(printf '%s' "$license_summary" | jq -r \
         | (.licenseName // .accountLicenseType // "license") as $name
         | select(($t | type) == "number" and $t > 0 and ($name | ascii_downcase | test("stakeholder") | not))
         | {name:$name, total:$t, assigned:$a, util: (($a * 100) / $t)} ]
-    | (if length == 0 then "ok=1 max=-1 detail=unmeasurable"
-       else (max_by(.util)) as $m
-         | "ok=\(if ($m.util >= $thr) then 0 else 1 end) max=\(($m.util*10|floor)/10) detail=\($m.name):\($m.assigned)/\($m.total)"
-       end)
-    ' 2>/dev/null || echo "ok=1 max=-1 detail=parse-error")
-license_headroom_ok=$(printf '%s' "$license_eval" | sed -E 's/.*ok=([0-9]).*/\1/')
-license_max_util=$(printf '%s' "$license_eval" | sed -E 's/.*max=([-0-9.]+).*/\1/')
-license_detail=$(printf '%s' "$license_eval" | sed -E 's/.*detail=([^ ]+).*/\1/')
+    | if length == 0 then {ok:1, max:-1, detail:"unmeasurable"}
+      else (max_by(.util)) as $m
+        | {ok:(if $m.util >= $thr then 0 else 1 end), max:(($m.util * 10 | floor) / 10), detail:"\($m.name):\($m.assigned)/\($m.total)"}
+      end
+    ' 2>/dev/null || echo '{"ok":1,"max":-1,"detail":"parse-error"}')
+license_headroom_ok=$(printf '%s' "$license_eval" | jq -r '.ok')
+license_max_util=$(printf '%s' "$license_eval" | jq -r '.max')
+license_detail=$(printf '%s' "$license_eval" | jq -r '.detail')
 case "$license_headroom_ok" in 0|1) ;; *) license_headroom_ok=1 ;; esac
 
 # ===========================================================================

--- a/codebundles/azure-devops-organization-health/sli-org-health-score.sh
+++ b/codebundles/azure-devops-organization-health/sli-org-health-score.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+set -uo pipefail
+# NOTE: `set -x` is intentionally NOT used (it leaks AZURE_DEVOPS_PAT into logs
+# and bloats output). Set AZ_DEBUG=1 to opt in to tracing for local debugging.
+[ "${AZ_DEBUG:-0}" = "1" ] && set -x
+# -----------------------------------------------------------------------------
+# Organization-health SLI scoring (cheap, hourly).
+#
+# Computes FOUR {0,1} sub-scores from LIGHTWEIGHT signals only -- explicitly NOT
+# the full 168-project / 473-pool deep scans the runbook performs. Convention:
+# score 0 ONLY for what we measure and confirm bad; score 1 for what we cannot
+# measure.
+#
+#   platform_incident_ok   no active Azure DevOps platform incident (Status API
+#                          overall health is healthy/advisory, not degraded/
+#                          unhealthy). Unreachable/unparseable => 1.
+#   pool_capacity_ok       queue-derived: no self-hosted pool has a build queued
+#                          (notStarted job request) aging past QUEUE_AGING_
+#                          THRESHOLD_MIN. A scaled-to-zero elastic/ephemeral pool
+#                          with NO aging queue is NOT penalised (consistent with
+#                          the landed agent-pool fix). Pool probing is bounded by
+#                          ORG_POOL_PROBE_LIMIT to stay cheap at hourly cadence.
+#   license_headroom_ok    license utilization (assigned/total) <= LICENSE_
+#                          UTILIZATION_THRESHOLD for any billed license whose
+#                          total is measurable. Derived from the single
+#                          userentitlementsummary call (NOT the full paginated
+#                          user scan). Unmeasurable => 1.
+#   org_policy_ok          required org security policy present (at least one
+#                          Administrator security group). Confirmed-absent => 0;
+#                          unmeasurable => 1.
+#
+# License cost / inactive-user findings are intentionally NOT scored here -- they
+# stay report-only in the daily deep runbook.
+#
+# REQUIRED ENV VARS:
+#   AZURE_DEVOPS_ORG
+#
+# OPTIONAL ENV VARS:
+#   LICENSE_UTILIZATION_THRESHOLD  license util % cap (default 90)
+#   QUEUE_AGING_THRESHOLD_MIN      queued-job aging minutes (default 30)
+#   ORG_POOL_PROBE_LIMIT           max self-hosted pools queue-probed (default 150)
+#   AGENT_FETCH_PARALLELISM        parallel job-request probes (default 20)
+#
+# TEST HOOKS (skip the corresponding live call when set):
+#   SLI_INCIDENT_HEALTH        portal numeric (1 unhealthy,2 degraded,3 advisory,4 healthy)
+#                              or API string (healthy, degraded, ...)
+#   SLI_POOL_AGING_COUNT       integer count of pools with aging queued work
+#   SLI_LICENSE_SUMMARY_FILE   path to a userentitlementsummary JSON
+#   SLI_SECURITY_GROUPS_FILE   path to a security-group-list JSON array
+#
+# Writes sli_org_health_score.json and echoes it to stdout.
+# -----------------------------------------------------------------------------
+
+: "${AZURE_DEVOPS_ORG:?Must set AZURE_DEVOPS_ORG}"
+: "${LICENSE_UTILIZATION_THRESHOLD:=90}"
+: "${QUEUE_AGING_THRESHOLD_MIN:=30}"
+: "${ORG_POOL_PROBE_LIMIT:=150}"
+: "${AUTH_TYPE:=service_principal}"
+AZURE_DEVOPS_PAT="${AZURE_DEVOPS_PAT:-${azure_devops_pat:-}}"
+export AZURE_DEVOPS_EXT_PAT="${AZURE_DEVOPS_PAT}"
+
+source "$(dirname "$0")/_az_helpers.sh"
+
+OUTPUT_FILE="sli_org_health_score.json"
+ORG_URL="https://dev.azure.com/$AZURE_DEVOPS_ORG"
+
+# Decide whether any live call is needed (all four hooks provided => pure test).
+NEED_AUTH=0
+[ -z "${SLI_POOL_AGING_COUNT:-}" ] && NEED_AUTH=1
+[ -z "${SLI_LICENSE_SUMMARY_FILE:-}" ] && NEED_AUTH=1
+[ -z "${SLI_SECURITY_GROUPS_FILE:-}" ] && NEED_AUTH=1
+if [ "$NEED_AUTH" -eq 1 ]; then
+    setup_azure_auth >&2 || true
+fi
+
+# ===========================================================================
+# 1. platform_incident_ok (Status API; portal HTML uses 4=healthy, not 1=healthy)
+# ===========================================================================
+ado_platform_incident_probe
+platform_incident_ok="${ADO_PLATFORM_INCIDENT_OK:-1}"
+incident_health="${ADO_PLATFORM_HEALTH:-unknown}"
+incident_message="${ADO_PLATFORM_STATUS_MESSAGE:-}"
+
+# ===========================================================================
+# 2. pool_capacity_ok (queue-derived, bounded)
+# ===========================================================================
+pool_aging=0
+pools_probed=0
+if [ -n "${SLI_POOL_AGING_COUNT:-}" ]; then
+    pool_aging="${SLI_POOL_AGING_COUNT}"
+else
+    if pools=$(az pipelines pool list --org "$ORG_URL" --output json 2>/dev/null) \
+            && printf '%s' "$pools" | jq -e 'type == "array"' >/dev/null 2>&1; then
+        # Self-hosted pool ids only, capped to keep the hourly probe cheap.
+        nonhosted_ids=$(printf '%s' "$pools" \
+            | jq -r '.[] | select((.isHosted // false) == false) | .id' \
+            | head -n "$ORG_POOL_PROBE_LIMIT")
+        if [ -n "$nonhosted_ids" ]; then
+            probe_dir=$(mktemp -d sli_orgcap.XXXXXX)
+            fetch_pool_job_requests_parallel "$nonhosted_ids" "$probe_dir" >&2 || true
+            while IFS= read -r pid; do
+                [ -z "$pid" ] && continue
+                pools_probed=$((pools_probed + 1))
+                eval "$(pool_queue_pressure "$(load_pool_job_requests_json "$probe_dir/jobreqs_${pid}.json")" "$QUEUE_AGING_THRESHOLD_MIN")"
+                if [ "${QUEUED_AGING:-0}" -gt 0 ]; then
+                    pool_aging=$((pool_aging + 1))
+                fi
+            done <<< "$nonhosted_ids"
+            rm -rf "$probe_dir"
+        fi
+    fi
+fi
+if [ "$pool_aging" -gt 0 ] 2>/dev/null; then
+    pool_capacity_ok=0
+else
+    pool_capacity_ok=1
+fi
+
+# ===========================================================================
+# 3. license_headroom_ok (single userentitlementsummary call)
+# ===========================================================================
+license_summary=""
+if [ -n "${SLI_LICENSE_SUMMARY_FILE:-}" ] && [ -s "${SLI_LICENSE_SUMMARY_FILE}" ]; then
+    license_summary=$(cat "${SLI_LICENSE_SUMMARY_FILE}")
+else
+    license_summary=$(az devops invoke --area MemberEntitlementManagement \
+        --resource UserEntitlementSummary --org "$ORG_URL" \
+        --api-version 7.1-preview --output json 2>/dev/null || echo "")
+    if ! printf '%s' "$license_summary" | jq -e '.licenses' >/dev/null 2>&1; then
+        hdr=$(ado_auth_header)
+        if [ -n "$hdr" ]; then
+            license_summary=$(curl -s --max-time 20 -H "Authorization: $hdr" \
+                "https://vsaex.dev.azure.com/$AZURE_DEVOPS_ORG/_apis/userentitlementsummary?api-version=7.1-preview&select=Licenses" \
+                2>/dev/null || echo "")
+        fi
+    fi
+fi
+# Max utilization across billed licenses whose total is measurable (>0). Stakeholder
+# (free) and unlimited/0-total entries are skipped: cannot measure => no penalty.
+license_eval=$(printf '%s' "$license_summary" | jq -r \
+    --argjson thr "$LICENSE_UTILIZATION_THRESHOLD" '
+    (.licenses // []) as $lics
+    | [ $lics[]
+        | (.total // 0) as $t
+        | (.assigned // 0) as $a
+        | (.licenseName // .accountLicenseType // "license") as $name
+        | select(($t | type) == "number" and $t > 0 and ($name | ascii_downcase | test("stakeholder") | not))
+        | {name:$name, total:$t, assigned:$a, util: (($a * 100) / $t)} ]
+    | (if length == 0 then "ok=1 max=-1 detail=unmeasurable"
+       else (max_by(.util)) as $m
+         | "ok=\(if ($m.util >= $thr) then 0 else 1 end) max=\(($m.util*10|floor)/10) detail=\($m.name):\($m.assigned)/\($m.total)"
+       end)
+    ' 2>/dev/null || echo "ok=1 max=-1 detail=parse-error")
+license_headroom_ok=$(printf '%s' "$license_eval" | sed -E 's/.*ok=([0-9]).*/\1/')
+license_max_util=$(printf '%s' "$license_eval" | sed -E 's/.*max=([-0-9.]+).*/\1/')
+license_detail=$(printf '%s' "$license_eval" | sed -E 's/.*detail=([^ ]+).*/\1/')
+case "$license_headroom_ok" in 0|1) ;; *) license_headroom_ok=1 ;; esac
+
+# ===========================================================================
+# 4. org_policy_ok (at least one Administrator security group present)
+# ===========================================================================
+sec_groups=""
+if [ -n "${SLI_SECURITY_GROUPS_FILE:-}" ] && [ -s "${SLI_SECURITY_GROUPS_FILE}" ]; then
+    sec_groups=$(cat "${SLI_SECURITY_GROUPS_FILE}")
+else
+    sec_groups=$(ado_security_groups_json)
+fi
+# `az devops security group list` returns a top-level array; the REST graph API
+# returns {graphGroups:[...]} or {value:[...]}. Normalise all three shapes.
+admin_groups=-1
+groups_arr=$(printf '%s' "$sec_groups" | jq -c 'if type == "array" then . elif type == "object" then (.graphGroups // .value // []) else [] end' 2>/dev/null || echo "")
+if [ -n "$groups_arr" ] && printf '%s' "$groups_arr" | jq -e 'type == "array" and length > 0' >/dev/null 2>&1; then
+    admin_groups=$(printf '%s' "$groups_arr" | jq '[.[] | select((.displayName // .principalName // "") | test("Administrator"; "i"))] | length' 2>/dev/null || echo -1)
+fi
+# Confirmed-absent (list readable, zero admin groups) => 0; unmeasurable => 1.
+if [ "$admin_groups" = "0" ]; then
+    org_policy_ok=0
+else
+    org_policy_ok=1
+fi
+
+# ===========================================================================
+# Assemble result
+# ===========================================================================
+result=$(jq -n \
+    --argjson platform "$platform_incident_ok" \
+    --argjson pool "$pool_capacity_ok" \
+    --argjson license "$license_headroom_ok" \
+    --argjson policy "$org_policy_ok" \
+    --arg incident_health "${incident_health:-unknown}" \
+    --arg incident_message "${incident_message:-}" \
+    --argjson pools_probed "$pools_probed" \
+    --argjson pool_aging "$pool_aging" \
+    --arg license_max_util "$license_max_util" \
+    --arg license_detail "$license_detail" \
+    --argjson license_thr "$LICENSE_UTILIZATION_THRESHOLD" \
+    --arg admin_groups "$admin_groups" \
+    '{
+       platform_incident_ok: $platform,
+       pool_capacity_ok: $pool,
+       license_headroom_ok: $license,
+       org_policy_ok: $policy,
+       details: {
+         incident_health: $incident_health,
+         incident_message: $incident_message,
+         pools_probed: $pools_probed,
+         pools_with_aging_queue: $pool_aging,
+         license_max_utilization_pct: $license_max_util,
+         license_headroom_detail: $license_detail,
+         license_utilization_threshold_pct: $license_thr,
+         admin_security_groups: $admin_groups
+       }
+     }')
+
+echo "$result" > "$OUTPUT_FILE"
+echo "$result"

--- a/codebundles/azure-devops-organization-health/sli.robot
+++ b/codebundles/azure-devops-organization-health/sli.robot
@@ -1,0 +1,137 @@
+*** Settings ***
+Documentation       Cheap Azure DevOps organization-health SLI. Derives four binary {0,1} sub-scores from lightweight, time-sensitive org signals — no active platform incident, pool capacity OK (queue-derived, ephemeral scaled-to-zero excluded), license headroom within budget, and required org security policy present — then averages them into a primary health score between 0 (failing) and 1 (healthy). Intended to run hourly; the heavy license cost / inactive-user / cross-project scans stay in the daily deep runbook. Its SLO breach triggers this SLX's organization runbook.
+Metadata            Author    runwhen
+Metadata            Display Name    Azure DevOps Organization Health SLI
+Metadata            Supports    AzureDevOps    Organization    Health    SLI
+
+Library             String
+Library             BuiltIn
+Library             Collections
+Library             RW.Core
+Library             RW.CLI
+Library             RW.platform
+
+Suite Setup         Suite Initialization
+
+
+*** Tasks ***
+Score Azure DevOps Organization Health for `${AZURE_DEVOPS_ORG}`
+    [Documentation]    Runs the lightweight org scorer and pushes the four sub-scores: platform_incident_ok, pool_capacity_ok (queue-derived, bounded), license_headroom_ok (single userentitlementsummary call), and org_policy_ok. Convention is "score 0 only for what we measure and confirm bad, 1 for what we cannot measure".
+    [Tags]    Organization    AzureDevOps    sli    access:read-only    data:metrics
+    ${score_env}=    Create Dictionary
+    ...    AZURE_DEVOPS_ORG=${AZURE_DEVOPS_ORG}
+    ...    LICENSE_UTILIZATION_THRESHOLD=${LICENSE_UTILIZATION_THRESHOLD}
+    ...    QUEUE_AGING_THRESHOLD_MIN=${QUEUE_AGING_THRESHOLD_MIN}
+    ...    ORG_POOL_PROBE_LIMIT=${ORG_POOL_PROBE_LIMIT}
+    ...    AGENT_FETCH_PARALLELISM=${AGENT_FETCH_PARALLELISM}
+    ...    AUTH_TYPE=${AUTH_TYPE}
+    ...    AZURE_CONFIG_DIR=${AZURE_DEVOPS_CONFIG_DIR}
+
+    ${data}=    Create Dictionary
+    ...    platform_incident_ok=1    pool_capacity_ok=1
+    ...    license_headroom_ok=1    org_policy_ok=1    details=${{ {} }}
+    TRY
+        ${out}=    RW.CLI.Run Bash File
+        ...    bash_file=sli-org-health-score.sh
+        ...    env=${score_env}
+        ...    secret__azure_devops_pat=${AZURE_DEVOPS_PAT}
+        ...    timeout_seconds=180
+        ...    include_in_history=false
+        ${data}=    Evaluate    json.loads(r'''${out.stdout}''')    json
+    EXCEPT    AS    ${err}
+        Log    Organization SLI scoring failed: ${err}    WARN
+    END
+
+    ${platform_ok}=    Set Variable    ${data.get('platform_incident_ok', 1)}
+    ${pool_ok}=    Set Variable    ${data.get('pool_capacity_ok', 1)}
+    ${license_ok}=    Set Variable    ${data.get('license_headroom_ok', 1)}
+    ${policy_ok}=    Set Variable    ${data.get('org_policy_ok', 1)}
+
+    Set Suite Variable    ${score_platform}    ${platform_ok}
+    Set Suite Variable    ${score_pool}    ${pool_ok}
+    Set Suite Variable    ${score_license}    ${license_ok}
+    Set Suite Variable    ${score_policy}    ${policy_ok}
+
+    RW.Core.Push Metric    ${platform_ok}    sub_name=platform_incident_ok
+    RW.Core.Push Metric    ${pool_ok}    sub_name=pool_capacity_ok
+    RW.Core.Push Metric    ${license_ok}    sub_name=license_headroom_ok
+    RW.Core.Push Metric    ${policy_ok}    sub_name=org_policy_ok
+
+    ${d}=    Evaluate    ${data}.get('details', {})    json
+    ${ctx}=    Set Variable    Org `${AZURE_DEVOPS_ORG}` SLI: platform_status=${d.get('incident_health', '-')} (${d.get('incident_message', '-')}), pools_probed=${d.get('pools_probed', '-')} (aging_queue=${d.get('pools_with_aging_queue', '-')}), license_max_util=${d.get('license_max_utilization_pct', '-')}% (${d.get('license_headroom_detail', '-')}, threshold ${d.get('license_utilization_threshold_pct', '-')}%), admin_groups=${d.get('admin_security_groups', '-')}
+    RW.Core.Add To Report    ${ctx}
+
+Generate Aggregate Azure DevOps Organization Health Score for `${AZURE_DEVOPS_ORG}`
+    [Documentation]    Averages the four sub-scores (platform_incident_ok, pool_capacity_ok, license_headroom_ok, org_policy_ok) into the primary SLI metric. A breach of this SLI's SLO triggers this SLX's deep organization runbook.
+    [Tags]    Organization    AzureDevOps    sli    access:read-only    data:metrics
+    ${total}=    Evaluate    int(${score_platform}) + int(${score_pool}) + int(${score_license}) + int(${score_policy})
+    ${health_score}=    Evaluate    ${total} / 4.0
+    ${health_score}=    Convert To Number    ${health_score}    2
+    ${report_msg}=    Set Variable    Azure DevOps organization health score: ${health_score} (platform_incident_ok=${score_platform}, pool_capacity_ok=${score_pool}, license_headroom_ok=${score_license}, org_policy_ok=${score_policy})
+    RW.Core.Add To Report    ${report_msg}
+    RW.Core.Push Metric    ${health_score}
+
+
+*** Keywords ***
+Suite Initialization
+    Log    Starting Organization SLI Suite Initialization...    INFO
+
+    # Support both Azure Service Principal and Azure DevOps PAT authentication
+    TRY
+        ${azure_credentials}=    RW.Core.Import Secret
+        ...    azure_credentials
+        ...    type=string
+        ...    description=The secret containing AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET, AZURE_SUBSCRIPTION_ID
+        ...    pattern=\w*
+        Set Suite Variable    ${AUTH_TYPE}    service_principal
+        Set Suite Variable    ${AZURE_DEVOPS_PAT}    ${EMPTY}
+    EXCEPT
+        Log    Azure credentials not found, trying Azure DevOps PAT...    INFO
+        TRY
+            ${azure_devops_pat}=    RW.Core.Import Secret
+            ...    azure_devops_pat
+            ...    type=string
+            ...    description=Azure DevOps Personal Access Token
+            ...    pattern=\w*
+            Set Suite Variable    ${AUTH_TYPE}    pat
+            Set Suite Variable    ${AZURE_DEVOPS_PAT}    ${azure_devops_pat}
+        EXCEPT
+            Log    No authentication method found, defaulting to service principal...    WARN
+            Set Suite Variable    ${AUTH_TYPE}    service_principal
+            Set Suite Variable    ${AZURE_DEVOPS_PAT}    ${EMPTY}
+        END
+    END
+
+    ${AZURE_DEVOPS_ORG}=    RW.Core.Import User Variable    AZURE_DEVOPS_ORG
+    ...    type=string
+    ...    description=Azure DevOps organization name.
+    ...    pattern=\w*
+    ${LICENSE_UTILIZATION_THRESHOLD}=    RW.Core.Import User Variable    LICENSE_UTILIZATION_THRESHOLD
+    ...    type=string
+    ...    description=License utilization (assigned/total) percentage above which license_headroom_ok drops to 0, for any billed license whose total is measurable. Stakeholder/unlimited entries are skipped (cannot measure = healthy).
+    ...    default=90
+    ...    pattern=\w*
+    ${QUEUE_AGING_THRESHOLD_MIN}=    RW.Core.Import User Variable    QUEUE_AGING_THRESHOLD_MIN
+    ...    type=string
+    ...    description=Minutes a build (notStarted job request) may wait in a self-hosted pool's queue before pool_capacity_ok drops to 0. A scaled-to-zero elastic/ephemeral pool with no aging queue is not penalised.
+    ...    default=30
+    ...    pattern=^\d+$
+    ${ORG_POOL_PROBE_LIMIT}=    RW.Core.Import User Variable    ORG_POOL_PROBE_LIMIT
+    ...    type=string
+    ...    description=Maximum number of self-hosted pools whose job-request queue is probed per SLI run. Bounds the hourly probe so it stays cheap on organizations with hundreds of pools (the deep daily runbook covers the rest).
+    ...    default=150
+    ...    pattern=^\d+$
+    ${AGENT_FETCH_PARALLELISM}=    RW.Core.Import User Variable    AGENT_FETCH_PARALLELISM
+    ...    type=string
+    ...    description=Parallelism for the bounded job-request queue probe. Clamped to 1-32.
+    ...    default=20
+    ...    pattern=^\d+$
+
+    Set Suite Variable    ${AZURE_DEVOPS_ORG}    ${AZURE_DEVOPS_ORG}
+    Set Suite Variable    ${LICENSE_UTILIZATION_THRESHOLD}    ${LICENSE_UTILIZATION_THRESHOLD}
+    Set Suite Variable    ${QUEUE_AGING_THRESHOLD_MIN}    ${QUEUE_AGING_THRESHOLD_MIN}
+    Set Suite Variable    ${ORG_POOL_PROBE_LIMIT}    ${ORG_POOL_PROBE_LIMIT}
+    Set Suite Variable    ${AGENT_FETCH_PARALLELISM}    ${AGENT_FETCH_PARALLELISM}
+    Set Suite Variable    ${AZURE_DEVOPS_CONFIG_DIR}    %{CODEBUNDLE_TEMP_DIR}/.azure-devops
+
+    Log    Organization SLI Suite Initialization complete (org=${AZURE_DEVOPS_ORG}).    INFO

--- a/codebundles/azure-devops-project-health/.runwhen/templates/azure-devops-project-health-sli.yaml
+++ b/codebundles/azure-devops-project-health/.runwhen/templates/azure-devops-project-health-sli.yaml
@@ -11,18 +11,42 @@ spec:
   displayUnitsShort: ok
   locations:
     - {{default_location}}
-  description: Checks Azure DevOps health by examining pipeline status, agent pools, repository policies, and service connections in project {{ match_resource.name }} of organization {{ organization }}
+  description: Cheap composite health score for Azure DevOps project {{ match_resource.name }} in organization {{ organization }} — averages five binary sub-scores (data collection, pipeline failure ratio, protected-branch failures, queue aging, long-running builds) over a short window aligned to the scrape interval. A breach triggers this SLX's investigation runbook.
   codeBundle:
-    repoUrl: https://github.com/runwhen-contrib/rw-workspace-utils.git
+    {% if repo_url %}
+    repoUrl: {{repo_url}}
+    {% else %}
+    repoUrl: https://github.com/runwhen-contrib/rw-cli-codecollection.git
+    {% endif %}
+    {% if ref %}
+    ref: {{ref}}
+    {% else %}
     ref: main
-    pathToRobot: codebundles/cron-scheduler-sli/sli.robot
+    {% endif %}
+    pathToRobot: codebundles/azure-devops-project-health/sli.robot
   intervalStrategy: intermezzo
-  intervalSeconds: 300
+  intervalSeconds: 1800
   configProvided:
-    - name: CRON_SCHEDULE
-      value: "*/30 * * * *" 
-    - name: TARGET_SLX
-      value: ""
-    - name: DRY_RUN
-      value: "false"
-  secretsProvided: []
+    - name: AZURE_DEVOPS_ORG
+      value: "{{ organization }}"
+    - name: AZURE_DEVOPS_PROJECTS
+      value: "{{ match_resource.name }}"
+    - name: SLI_MAX_FAILURE_RATIO
+      value: "0.50"
+    - name: QUEUE_THRESHOLD
+      value: "30m"
+    - name: DURATION_THRESHOLD
+      value: "60m"
+    - name: SLI_MAX_LONGRUNNING
+      value: "1"
+  secretsProvided:
+  {% if wb_version %}
+    {% include "azure-devops-auth.yaml" ignore missing %}
+  {% else %}
+    - name: azure_credentials
+      workspaceKey: AUTH DETAILS NOT FOUND
+  {% endif %}
+  alertConfig:
+    tasks:
+      persona: eager-edgar
+      sessionTTL: 10m

--- a/codebundles/azure-devops-project-health/.runwhen/templates/azure-devops-project-health-taskset.yaml
+++ b/codebundles/azure-devops-project-health/.runwhen/templates/azure-devops-project-health-taskset.yaml
@@ -30,6 +30,8 @@ spec:
       value: "60m"
     - name: QUEUE_THRESHOLD
       value: "30m"
+    - name: RW_LOOKBACK_WINDOW
+      value: "24h"
   secretsProvided:
   {% if wb_version %}
     {% include "azure-devops-auth.yaml" ignore missing %}

--- a/codebundles/azure-devops-project-health/_az_helpers.sh
+++ b/codebundles/azure-devops-project-health/_az_helpers.sh
@@ -127,15 +127,17 @@ ado_platform_incident_probe() {
         return 0
     fi
 
-    # HTML/JS fallback (numeric portal enum).
-    local incident_num=""
-    if curl -s --max-time 15 -o status_page.html 'https://status.dev.azure.com' 2>/dev/null; then
+    # HTML/JS fallback (numeric portal enum). Use a private temp file so callers
+    # are not affected if they download the status page for connectivity checks.
+    local incident_num="" html_file=""
+    html_file=$(mktemp ado_status_page.XXXXXX)
+    if curl -s --max-time 15 -o "$html_file" 'https://status.dev.azure.com' 2>/dev/null; then
         local svc
-        svc=$(grep -o '"serviceStatus":{[^}]*"health":[0-9]*[^}]*}' status_page.html 2>/dev/null | head -1 || true)
+        svc=$(grep -o '"serviceStatus":{[^}]*"health":[0-9]*[^}]*}' "$html_file" 2>/dev/null | head -1 || true)
         incident_num=$(printf '%s' "$svc" | grep -o '"health":[0-9]*' | head -1 | cut -d':' -f2)
         ADO_PLATFORM_STATUS_MESSAGE=$(printf '%s' "$svc" | grep -o '"message":"[^"]*"' | head -1 | cut -d'"' -f4)
     fi
-    rm -f status_page.html
+    rm -f "$html_file"
 
     if [ -n "$incident_num" ]; then
         ADO_PLATFORM_HEALTH="$incident_num"

--- a/codebundles/azure-devops-project-health/_az_helpers.sh
+++ b/codebundles/azure-devops-project-health/_az_helpers.sh
@@ -154,7 +154,10 @@ ado_platform_incident_probe() {
 # project is configured. Org-health tasks must use --scope organization.
 ado_security_groups_json() {
     local org_url="https://dev.azure.com/${AZURE_DEVOPS_ORG}"
-    az devops security group list --org "$org_url" --scope organization --output json
+    local raw
+    raw=$(az devops security group list --org "$org_url" --scope organization --output json) || return $?
+    # CLI returns {graphGroups:[...]}; REST may use {value:[...]}. Callers expect an array.
+    printf '%s' "$raw" | jq -c 'if type == "array" then . elif type == "object" then (.graphGroups // .value // []) else [] end'
 }
 
 # ---------------------------------------------------------------------------

--- a/codebundles/azure-devops-project-health/_az_helpers.sh
+++ b/codebundles/azure-devops-project-health/_az_helpers.sh
@@ -77,6 +77,85 @@ setup_azure_auth() {
 }
 
 # ---------------------------------------------------------------------------
+# Azure DevOps public status page (platform incidents)
+#
+# The status portal embeds a NUMERIC health code in its HTML/JS payload:
+#   1 = unhealthy, 2 = degraded, 3 = advisory, 4 = healthy
+# (matches ScopeHealth enum order; 4 is "Everything is looking good".)
+# Older scripts incorrectly assumed 1=healthy and treated 4 as an outage.
+#
+# Prefer the official Status REST API, which returns string health values.
+# ---------------------------------------------------------------------------
+
+# Probe whether Azure DevOps is reporting a platform-wide incident.
+# Sets globals: ADO_PLATFORM_INCIDENT_OK (0|1), ADO_PLATFORM_HEALTH, ADO_PLATFORM_STATUS_MESSAGE
+# Test override: SLI_INCIDENT_HEALTH may be a portal numeric code (1-4) or API string (healthy, degraded, ...).
+ado_platform_incident_probe() {
+    ADO_PLATFORM_INCIDENT_OK=1
+    ADO_PLATFORM_HEALTH="unknown"
+    ADO_PLATFORM_STATUS_MESSAGE=""
+
+    if [ -n "${SLI_INCIDENT_HEALTH:-}" ]; then
+        ADO_PLATFORM_HEALTH="${SLI_INCIDENT_HEALTH}"
+        case "$(printf '%s' "${SLI_INCIDENT_HEALTH}" | tr '[:upper:]' '[:lower:]')" in
+            healthy|advisory|4|3) ADO_PLATFORM_INCIDENT_OK=1 ;;
+            degraded|unhealthy|2|1) ADO_PLATFORM_INCIDENT_OK=0 ;;
+            *) ADO_PLATFORM_INCIDENT_OK=1 ;;
+        esac
+        return 0
+    fi
+
+    local api_json overall msg bad_geo
+    api_json=$(curl -s --max-time 15 \
+        'https://status.dev.azure.com/_apis/status/health?api-version=7.1-preview.1' 2>/dev/null || true)
+    overall=$(printf '%s' "$api_json" | jq -r '.status.health // empty' 2>/dev/null)
+    msg=$(printf '%s' "$api_json" | jq -r '.status.message // empty' 2>/dev/null)
+    if [ -n "$overall" ]; then
+        ADO_PLATFORM_HEALTH="$overall"
+        ADO_PLATFORM_STATUS_MESSAGE="$msg"
+        case "$(printf '%s' "$overall" | tr '[:upper:]' '[:lower:]')" in
+            unhealthy|degraded) ADO_PLATFORM_INCIDENT_OK=0 ;;
+            *) ADO_PLATFORM_INCIDENT_OK=1 ;;
+        esac
+        bad_geo=$(printf '%s' "$api_json" | jq -r '
+            ([.services[]?.geographies[]?.health // empty | ascii_downcase]
+             | any(. == "degraded" or . == "unhealthy")) // false
+        ' 2>/dev/null || echo false)
+        if [ "$bad_geo" = "true" ]; then
+            ADO_PLATFORM_INCIDENT_OK=0
+        fi
+        return 0
+    fi
+
+    # HTML/JS fallback (numeric portal enum).
+    local incident_num=""
+    if curl -s --max-time 15 -o status_page.html 'https://status.dev.azure.com' 2>/dev/null; then
+        local svc
+        svc=$(grep -o '"serviceStatus":{[^}]*"health":[0-9]*[^}]*}' status_page.html 2>/dev/null | head -1 || true)
+        incident_num=$(printf '%s' "$svc" | grep -o '"health":[0-9]*' | head -1 | cut -d':' -f2)
+        ADO_PLATFORM_STATUS_MESSAGE=$(printf '%s' "$svc" | grep -o '"message":"[^"]*"' | head -1 | cut -d'"' -f4)
+    fi
+    rm -f status_page.html
+
+    if [ -n "$incident_num" ]; then
+        ADO_PLATFORM_HEALTH="$incident_num"
+        case "$incident_num" in
+            1|2) ADO_PLATFORM_INCIDENT_OK=0 ;;   # unhealthy, degraded
+            3|4) ADO_PLATFORM_INCIDENT_OK=1 ;;   # advisory, healthy
+            *) ADO_PLATFORM_INCIDENT_OK=1 ;;
+        esac
+    fi
+}
+
+# List organization-scoped security groups (Graph). The az CLI defaults to
+# --scope project, which fails with "project must be specified" unless a default
+# project is configured. Org-health tasks must use --scope organization.
+ado_security_groups_json() {
+    local org_url="https://dev.azure.com/${AZURE_DEVOPS_ORG}"
+    az devops security group list --org "$org_url" --scope organization --output json 2>/dev/null || echo ""
+}
+
+# ---------------------------------------------------------------------------
 # Shared Azure DevOps REST / data helpers
 #
 # These functions are intentionally defensive: they never abort the calling
@@ -123,8 +202,13 @@ ado_identity_json() {
         fi
     fi
 
+    # Always emit a single, valid JSON object. Callers (notably preflight) feed
+    # this straight into `jq --argjson`, which aborts the whole script if it ever
+    # receives an empty string — so guard every path and fall back to a valid
+    # "unconfirmed" object rather than echoing nothing.
+    local out=""
     if echo "$resp" | jq -e '(.authenticatedUser.id // .authorizedUser.id)' >/dev/null 2>&1; then
-        echo "$resp" | jq --arg a "$auth" '
+        out=$(echo "$resp" | jq --arg a "$auth" '
             (.authenticatedUser // .authorizedUser) as $u
             | ($u.properties.Account."$value" // $u.emailAddress // "") as $email
             | {
@@ -133,10 +217,12 @@ ado_identity_json() {
                 email:     $email,
                 auth_type: $a,
                 confirmed: true
-              }'
-    else
-        jq -n --arg a "$auth" '{name:"unknown", id:"unknown", email:"", auth_type:$a, confirmed:false}'
+              }' 2>/dev/null)
     fi
+    if [ -z "$out" ] || ! echo "$out" | jq -e . >/dev/null 2>&1; then
+        out=$(jq -n --arg a "$auth" '{name:"unknown", id:"unknown", email:"", auth_type:$a, confirmed:false}')
+    fi
+    echo "$out"
 }
 
 # Newline-separated list of elastic (VMSS / scale-set / agent-cloud) pool IDs.
@@ -240,6 +326,21 @@ pool_looks_ephemeral() {
     return 0
 }
 
+# Echo up to N (default 3) agent names that match the generated/ephemeral name
+# patterns, comma-separated. Used as human-readable evidence in issue details.
+# Args: $1 = agents JSON array, $2 = max names (optional, default 3)
+agents_generated_sample() {
+    echo "$1" | jq -r --argjson n "${2:-3}" '
+        [ .[] | (.name // "")
+          | select(test("^azp-"; "i") or test("agents?-[0-9]+$"; "i") or test("-[0-9]+$")) ]
+        | .[:$n] | join(", ")' 2>/dev/null || true
+}
+
+# Classify a pool and emit eval-able assignments. In addition to the counts and
+# POOL_KIND it now exposes WHY the classification was chosen so callers can put
+# concrete, plain-language evidence in the issue text:
+#   POOL_KIND_REASON   : sentence describing which heuristic fired (eval-safe)
+#   POOL_KIND_EVIDENCE : the specific markers (ratios, sample names) (eval-safe)
 # Args: $1 = agents JSON array, $2 = is_elastic ("true"/"false"), $3 = pool name (optional)
 classify_pool_agents() {
     local agents="$1" is_elastic="${2:-false}" pool_name="${3:-}"
@@ -257,16 +358,27 @@ classify_pool_agents() {
     offline=$(echo "$counts" | jq -r '.offline')
     busy=$(echo "$counts" | jq -r '.busy')
 
-    local kind="static" expected_offline=0
+    # A few generated-looking agent names to show the reader WHY a pool reads as
+    # dynamic (e.g. azp-maven-agent-7). Empty string when none match.
+    local gen_sample name_markers
+    gen_sample=$(agents_generated_sample "$agents" 3)
+    name_markers=$(printf '%s' "$pool_name" \
+        | grep -Eio 'k8s|aks|kube|keda|vmss|scale.?set|ephemeral' | head -1 || true)
+
+    local kind="static" expected_offline=0 reason="" evidence=""
     if [ "$is_elastic" = "true" ]; then
         kind="elastic"
         expected_offline=$offline
+        reason="the pool is reported by the Distributed Task elastic-pools API or carries an agentCloudId/targetSize, i.e. an Azure DevOps-managed VMSS / agent-cloud (dynamic) pool"
+        evidence="elastic-pools API entry or agentCloudId/targetSize marker present"
     elif [ "$online" -gt 0 ] && [ "$total" -gt 0 ] \
             && [ "$(( offline * 100 / total ))" -ge "$ephemeral_ratio" ]; then
         # Online capacity exists but offline dominates: classic signature of a
         # self-managed VMSS/AKS/container pool leaving stale registrations.
         kind="ephemeral"
         expected_offline=$offline
+        reason="online capacity exists but offline registrations dominate the pool (>= ${ephemeral_ratio}% of total) -- the classic signature of a self-managed VMSS/AKS/container farm that leaves stale registrations behind as it scales"
+        evidence="offline ratio $(( offline * 100 / total ))% >= ${ephemeral_ratio}% threshold${gen_sample:+; generated agent names: ${gen_sample}}"
     elif [ "$total" -gt 0 ] && [ "$offline" -eq "$total" ] \
             && pool_looks_ephemeral "$agents" "$pool_name"; then
         # Scaled-to-zero ephemeral farm: every agent offline AND the pool/agent
@@ -275,6 +387,11 @@ classify_pool_agents() {
         # exactly the "very high offline count" false positive to suppress.
         kind="ephemeral"
         expected_offline=$offline
+        reason="every registered agent is offline AND the pool/agent naming matches a Kubernetes/VMSS/container/KEDA pattern -- a dynamic farm that has scaled to zero"
+        evidence="all ${total} agents offline; generated agent names: ${gen_sample:-n/a}${name_markers:+; pool-name marker: ${name_markers}}"
+    else
+        reason="no dynamic markers were found (no elastic-pools API entry, no agentCloudId, no targetSize) and the agent names are not predominantly auto-generated -- treated as a persistent/static pool"
+        evidence="no VMSS/scale-set/agent-cloud markers detected${gen_sample:+; generated-looking names present but below threshold: ${gen_sample}}"
     fi
 
     echo "AGENT_COUNT=$total"
@@ -283,6 +400,94 @@ classify_pool_agents() {
     echo "BUSY_COUNT=$busy"
     echo "POOL_KIND=$kind"
     echo "EXPECTED_OFFLINE=$expected_offline"
+    # %q keeps the free-text reason/evidence safe for `eval` in the callers.
+    printf 'POOL_KIND_REASON=%q\n' "$reason"
+    printf 'POOL_KIND_EVIDENCE=%q\n' "$evidence"
+}
+
+# ---------------------------------------------------------------------------
+# Queued-work pressure: the ONLY signal that distinguishes an idle dynamic pool
+# (scaled to zero on purpose, expected, sev 4 at most) from a real outage
+# (pipelines are queued but nothing can pick them up). busy_assigned does NOT
+# capture this -- a job waiting in the pool queue while online=0 has no agent to
+# be "assigned" to. These helpers are best-effort and degrade to zeros so they
+# can never break or fail the calling task.
+# ---------------------------------------------------------------------------
+
+# Echo the pool's job requests as a JSON array (the .value of the jobrequests
+# API) or "[]" on any failure. Prefers `az devops invoke` (proxy/auth aware)
+# then falls back to a direct REST call, mirroring the rest of the toolchain.
+# Args: $1 = pool id
+ado_pool_job_requests_json() {
+    local pool_id="$1"
+    local org_url="https://dev.azure.com/$AZURE_DEVOPS_ORG"
+    local resp=""
+
+    resp=$(az devops invoke \
+        --area distributedtask --resource jobrequests \
+        --route-parameters poolId="$pool_id" \
+        --org "$org_url" --api-version 7.1 --output json 2>/dev/null || echo "")
+
+    if ! echo "$resp" | jq -e '.value' >/dev/null 2>&1; then
+        local hdr; hdr=$(ado_auth_header)
+        if [ -n "$hdr" ]; then
+            resp=$(curl -s --max-time 20 -H "Authorization: $hdr" \
+                "$org_url/_apis/distributedtask/pools/$pool_id/jobrequests?api-version=7.1" \
+                2>/dev/null || echo "")
+        fi
+    fi
+
+    if echo "$resp" | jq -e '.value' >/dev/null 2>&1; then
+        echo "$resp" | jq -c '.value'
+    else
+        echo "[]"
+    fi
+}
+
+# Given job-requests JSON and an aging threshold (minutes) emit eval-able vars:
+#   QUEUED_TOTAL      : requests queued but not yet picked up by any agent
+#   QUEUED_AGING      : of those, how many have waited longer than the threshold
+#   OLDEST_QUEUED_MIN : age (minutes, floored) of the oldest queued request
+# A queued-but-unassigned request has a queueTime but no assignTime/receiveTime
+# and no result/finishTime yet. All date parsing is wrapped in try/catch so a
+# malformed timestamp degrades to 0 rather than aborting.
+# Args: $1 = job requests JSON array, $2 = aging threshold minutes (optional)
+pool_queue_pressure() {
+    local jobs="$1" threshold_min="${2:-${QUEUE_AGING_THRESHOLD_MIN:-15}}"
+    echo "$jobs" | jq -r --argjson thr "$threshold_min" '
+        def age_min($t):
+            ($t | sub("\\.[0-9]+"; "") | sub("([+-][0-9]{2}:?[0-9]{2})$"; "Z")) as $clean
+            | ((try ($clean | fromdateiso8601) catch null)) as $epoch
+            | if $epoch == null then 0 else ((now - $epoch) / 60) end;
+        [ .[]
+          | select((.result == null) and (.finishTime == null))
+          | select((.reservedAgent == null) and (.assignTime == null) and (.receiveTime == null))
+          | (if (.queueTime // null) != null then age_min(.queueTime) else 0 end)
+        ] as $ages
+        | "QUEUED_TOTAL=\($ages | length)",
+          "QUEUED_AGING=\([ $ages[] | select(. >= $thr) ] | length)",
+          "OLDEST_QUEUED_MIN=\((($ages | max) // 0) | floor)"
+    ' 2>/dev/null || printf 'QUEUED_TOTAL=0\nQUEUED_AGING=0\nOLDEST_QUEUED_MIN=0\n'
+}
+
+# Build the one-line "is work blocked?" status used in issue details. Combines
+# the queue-pressure counts with busy_assigned so the reader sees whether any
+# pipeline work is actually stuck behind a pool with no online agents.
+# Args: $1 = busy_assigned, $2 = QUEUED_TOTAL, $3 = QUEUED_AGING, $4 = OLDEST_QUEUED_MIN
+pool_queue_status_line() {
+    local busy="${1:-0}" qtotal="${2:-0}" qaging="${3:-0}" oldest="${4:-0}"
+    if [ "$qaging" -gt 0 ]; then
+        printf 'YES -- %s queued job(s) have been waiting >%s min (oldest %s min) with no online agent to run them. This is a real capacity outage.' \
+            "$qaging" "${QUEUE_AGING_THRESHOLD_MIN:-15}" "$oldest"
+    elif [ "$qtotal" -gt 0 ]; then
+        printf 'PARTIAL -- %s job(s) are queued but still young (<%s min). The pool may simply be scaling up; re-check shortly.' \
+            "$qtotal" "${QUEUE_AGING_THRESHOLD_MIN:-15}"
+    elif [ "$busy" -gt 0 ]; then
+        printf 'MAYBE -- no jobs are queued, but %s registered agent(s) still carry an assignedRequest while offline; this is usually a stale record from scale-down.' \
+            "$busy"
+    else
+        printf 'NO -- no jobs are queued for this pool and no agent carries an assignedRequest, so nothing is currently blocked. A dynamic pool at 0 online while idle is expected.'
+    fi
 }
 
 # Fetch ALL user entitlements, transparently paginating past the 100-row API
@@ -359,25 +564,82 @@ load_pool_agents_json() {
 }
 
 # Rich issue_details text for agent-pool findings (RunWhen agents consume the
-# JSON "details" field as issue_details).
+# JSON "details" field as issue_details). The text explains, in plain language,
+# WHY agents are offline and whether any pipeline work is actually blocked, so a
+# reader does not mistake expected dynamic scale-down for an outage.
 # Args: summary, pool_name, pool_id, pool_type, pool_kind, total, online, offline,
-#       busy, expected_offline, [extra paragraph], [sample offline agent names]
+#       busy, expected_offline,
+#       [extra paragraph], [sample offline agent names],
+#       [classification reason (POOL_KIND_REASON)], [work-blocked status line]
 ado_pool_issue_details() {
     local summary="$1" pool_name="$2" pool_id="$3" pool_type="$4" pool_kind="$5"
     local total="$6" online="$7" offline="$8" busy="$9" expected_offline="${10:-0}"
-    local extra="${11:-}" sample="${12:-}"
+    local extra="${11:-}" sample="${12:-}" classification="${13:-}" queue_status="${14:-}"
     local org="${AZURE_DEVOPS_ORG:-unknown}"
+
     printf '%s\n\n' "$summary"
     printf 'Organization: %s\n' "$org"
     printf 'Pool: %s (id=%s, poolType=%s, classified_as=%s)\n' "$pool_name" "$pool_id" "$pool_type" "$pool_kind"
     printf 'Agent counts: total=%s online=%s offline=%s busy_assigned=%s expected_offline_churn=%s\n' \
         "$total" "$online" "$offline" "$busy" "$expected_offline"
-    printf '\nInterpretation:\n'
-    printf '- classified_as elastic/ephemeral: most offline rows are torn-down VMSS/Kubernetes/container registrations, not necessarily failed machines.\n'
-    printf '- busy_assigned: agents with a non-null assignedRequest (work bound to a registered agent). This does NOT count pipeline jobs waiting in the pool queue when no agent is online.\n'
-    printf '- If builds are queued in Azure DevOps while online=0, open Organization Settings > Agent pools > %s and verify autoscale/VMSS/KEDA and service connections.\n' "$pool_name"
+    [ -n "$classification" ] && printf 'Why classified as "%s": %s\n' "$pool_kind" "$classification"
+
+    # Plain-language likely cause, tailored to the pool kind. This is the core
+    # of the "explain the WHY" requirement: dynamic vs static get very different
+    # explanations because the offline count means very different things.
+    printf '\nLikely cause:\n'
+    case "$pool_kind" in
+        elastic|ephemeral)
+            printf -- '- This pool provides DYNAMIC capacity (VMSS / scale-set / Kubernetes / container / agent-cloud). Agents are created on demand and torn down when idle.\n'
+            printf -- '- The offline registrations are EXPECTED scale-down artifacts of autoscale, not failed machines. A dynamic pool sitting at 0 online while idle is normal and is NOT an outage.\n'
+            if [ "${busy:-0}" -gt 0 ]; then
+                printf -- '- Note: %s registered agent(s) still carry an assignedRequest while not online. That is usually a stale record left by scale-down; confirm the scaler is replacing them.\n' "$busy"
+            fi
+            ;;
+        static)
+            printf -- '- This is a STATIC pool (persistent, manually-managed agents). Offline agents here are NOT expected churn -- each one is lost capacity.\n'
+            printf -- '- A static agent goes offline when its agent service is stopped, the host is powered off or unreachable, it lost network connectivity to dev.azure.com, or the credentials/PAT it runs under expired.\n'
+            ;;
+        *)
+            printf -- '- Pool kind could not be determined (agent data may be unreadable). Treat the counts above with caution until agents can be listed.\n'
+            ;;
+    esac
+
+    # Whether pipeline work is actually blocked. Driven by the queue-pressure
+    # check when available; otherwise spells out the busy_assigned caveat.
+    printf '\nIs pipeline work actually blocked?\n'
+    if [ -n "$queue_status" ]; then
+        printf -- '- %s\n' "$queue_status"
+    else
+        printf -- '- busy_assigned counts agents with a non-null assignedRequest. It does NOT count pipeline jobs waiting in the pool queue while online=0. If online=0 AND builds are queued, work is blocked regardless of busy_assigned.\n'
+    fi
+
+    printf '\nReading the counts:\n'
+    printf -- '- expected_offline_churn=%s of the %s offline registrations are attributed to dynamic scale-down (0 for static pools).\n' "$expected_offline" "$offline"
+    printf -- '- For dynamic pools the actionable signal is ONLINE capacity + queued work, NOT the offline backlog.\n'
+
+    printf '\nNext step:\n'
+    case "$pool_kind" in
+        elastic|ephemeral)
+            printf -- '- Open Organization Settings > Agent pools > %s and confirm autoscale/VMSS/KEDA sizing and the backing service connection are healthy. No action is needed if no pipelines are waiting.\n' "$pool_name"
+            ;;
+        static)
+            printf -- '- Open Organization Settings > Agent pools > %s, then on each offline agent: restart the agent service, confirm the host is powered on and can reach dev.azure.com, and verify the agent credentials/PAT.\n' "$pool_name"
+            ;;
+        *)
+            printf -- '- Open Organization Settings > Agent pools > %s to inspect the pool once agent data can be retrieved.\n' "$pool_name"
+            ;;
+    esac
+
     [ -n "$extra" ] && printf '\n%s\n' "$extra"
-    [ -n "$sample" ] && printf '\nSample offline agents: %s\n' "$sample"
+    if [ -n "$sample" ]; then
+        case "$pool_kind" in
+            elastic|ephemeral)
+                printf '\nSample offline agents (note the generated/ephemeral naming): %s\n' "$sample" ;;
+            *)
+                printf '\nSample offline agents: %s\n' "$sample" ;;
+        esac
+    fi
     printf '\nAPI probed: GET .../distributedtask/pools/%s/agents?includeAssignedRequest=true\n' "$pool_id"
 }
 
@@ -469,4 +731,205 @@ agents_fetch_failed() {
         return 0
     fi
     return 1
+}
+
+# ===========================================================================
+# Phase 0 single-pass build-dataset helpers
+#
+# WHY: the per-task pipeline scripts previously iterated over EVERY pipeline in
+# a project, issuing `az pipelines runs list --pipeline-id <id>` once per
+# pipeline (plus follow-up calls). On large projects (hundreds of pipelines)
+# that serial wall of ~6s/call calls blew past the 180s/300s Robot task
+# timeouts. These helpers fetch the project's builds ONCE via a small number of
+# paginated Build REST calls into a single on-disk dataset; every task then
+# derives its signals (failures, queue aging, long-running, perf percentiles)
+# from that dataset with jq -- with NO further per-pipeline calls.
+# ===========================================================================
+
+# Convert a lookback window like "24h", "30d", "90m", "2w" to an ISO-8601 UTC
+# timestamp at (now - window), suitable for the Build API minTime parameter.
+# Unrecognised input falls back to 24h.
+window_to_min_time() {
+    local window="${1:-24h}" num unit spec
+    num=$(printf '%s' "$window" | sed -E 's/[^0-9].*$//')
+    unit=$(printf '%s' "$window" | sed -E 's/^[0-9]*//' | tr '[:upper:]' '[:lower:]')
+    [ -z "$num" ] && { num=24; unit=h; }
+    case "$unit" in
+        m|min|mins|minute|minutes) spec="$num minutes ago" ;;
+        h|hr|hrs|hour|hours|"")    spec="$num hours ago" ;;
+        d|day|days)                spec="$num days ago" ;;
+        w|wk|wks|week|weeks)       spec="$((num * 7)) days ago" ;;
+        *)                         spec="24 hours ago" ;;
+    esac
+    date -u -d "$spec" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u +"%Y-%m-%dT%H:%M:%SZ"
+}
+
+# URL-encode a string (project names may contain spaces, e.g. "IT Services").
+ado_urlencode() { jq -rn --arg s "${1:-}" '$s|@uri' 2>/dev/null || printf '%s' "${1:-}"; }
+
+# Fetch a project's builds into a single JSON-array file ($2). The dataset is the
+# UNION of:
+#   A) builds that FINISHED within the lookback window (for failures, completed
+#      long-running, and performance percentiles), and
+#   B) builds currently ACTIVE (inProgress / notStarted) -- a point-in-time set
+#      with NO historical filter (for queue aging and in-flight long-running),
+# de-duplicated by build id. Echoes the resulting build count on stdout.
+#
+# An on-disk cache keyed by org|project|window means that when several tasks in
+# the same suite need the same dataset, only the FIRST call hits the API; the
+# rest reuse the cached file (set BUILDS_CACHE_ENABLED=false to disable;
+# BUILDS_CACHE_TTL_SEC, default 600, bounds staleness across runs).
+#
+# Build fields used downstream: id, buildNumber, status, result, queueTime,
+# startTime, finishTime, sourceBranch, sourceVersion, reason, definition.{id,name},
+# _links.web.href. These mirror what `az pipelines runs list` returned, so the
+# derivations are drop-in.
+#
+# Args: $1 = project name, $2 = output file, $3 = lookback window
+#       (default $RW_LOOKBACK_WINDOW or 24h).
+# Returns: 0 on success (even with partial pages), non-zero only if NO data could
+#          be fetched and no cache exists.
+fetch_project_builds() {
+    local project="$1" out_file="$2"
+    local window="${3:-${RW_LOOKBACK_WINDOW:-24h}}"
+    local org_url="https://dev.azure.com/$AZURE_DEVOPS_ORG"
+    local page_size="${BUILDS_PAGE_SIZE:-1000}"
+    local max_pages="${BUILDS_MAX_PAGES:-25}"
+    local min_time proj_enc
+    min_time=$(window_to_min_time "$window")
+    proj_enc=$(ado_urlencode "$project")
+
+    # ---- cache lookup -----------------------------------------------------
+    local cache_dir cache_key cache_file ttl now mtime age
+    cache_dir="${BUILDS_CACHE_DIR:-.ado_cache}"
+    mkdir -p "$cache_dir" 2>/dev/null || cache_dir="."
+    cache_key=$(printf '%s|%s|%s' "$AZURE_DEVOPS_ORG" "$project" "$window" \
+        | { md5sum 2>/dev/null || cksum; } | awk '{print $1}')
+    cache_file="$cache_dir/ado_builds_${cache_key}.json"
+    ttl="${BUILDS_CACHE_TTL_SEC:-600}"
+    if [ "${BUILDS_CACHE_ENABLED:-true}" = "true" ] && [ -s "$cache_file" ]; then
+        now=$(date +%s); mtime=$(date -r "$cache_file" +%s 2>/dev/null || echo 0)
+        age=$((now - mtime))
+        if [ "$mtime" -gt 0 ] && [ "$age" -lt "$ttl" ]; then
+            { cp "$cache_file" "$out_file" 2>/dev/null || cat "$cache_file" > "$out_file"; }
+            echo "  Reusing cached build dataset ($cache_file, age ${age}s, window ${window})." >&2
+            jq 'length' "$out_file" 2>/dev/null || echo 0
+            return 0
+        fi
+    fi
+
+    local hdr work rc=0
+    hdr=$(ado_auth_header)
+    work=$(mktemp -d ado_builds.XXXXXX)
+
+    # Run one paginated query variant, appending each page's .value array to a
+    # file in $work. Uses dynamic scoping to read $hdr/$work/$proj_enc/etc.
+    _fetch_builds_query() {
+        local extra="$1" tag="$2" page=0 cont="" url body hdrs
+        while [ "$page" -lt "$max_pages" ]; do
+            url="$org_url/$proj_enc/_apis/build/builds?api-version=7.1&\$top=$page_size$extra"
+            [ -n "$cont" ] && url="$url&continuationToken=$cont"
+            if [ -n "$hdr" ]; then
+                hdrs="$work/h_${tag}_${page}.txt"
+                if ! body=$(curl -fsS --max-time 60 -D "$hdrs" -H "Authorization: $hdr" "$url" 2>/dev/null); then
+                    return 1
+                fi
+                printf '%s' "$body" | jq -c '.value // []' > "$work/p_${tag}_${page}.json" 2>/dev/null || true
+                cont=$(grep -i '^x-ms-continuationtoken:' "$hdrs" 2>/dev/null \
+                    | head -1 | sed -E 's/^[^:]*:[[:space:]]*//' | tr -d '\r')
+            else
+                # No usable credential: fall back to az devops invoke (single page,
+                # no continuation token support).
+                body=$(az devops invoke --area build --resource builds \
+                    --route-parameters project="$project" --org "$org_url" \
+                    --api-version 7.1 --output json 2>/dev/null || echo "")
+                printf '%s' "$body" | jq -c '.value // []' > "$work/p_${tag}_${page}.json" 2>/dev/null || true
+                cont=""
+            fi
+            page=$((page + 1))
+            [ -z "$cont" ] && break
+        done
+        return 0
+    }
+
+    # A) finished builds in the lookback window
+    _fetch_builds_query "&minTime=$min_time&queryOrder=finishTimeDescending" "fin" || rc=1
+    # B) currently active builds (point-in-time; no historical filter)
+    _fetch_builds_query "&statusFilter=inProgress,notStarted&queryOrder=queueTimeDescending" "act" || true
+
+    if ls "$work"/p_*.json >/dev/null 2>&1; then
+        jq -s 'add // [] | unique_by(.id)' "$work"/p_*.json > "$out_file" 2>/dev/null || echo '[]' > "$out_file"
+    else
+        echo '[]' > "$out_file"
+    fi
+    rm -rf "$work"
+    unset -f _fetch_builds_query
+
+    if [ "${BUILDS_CACHE_ENABLED:-true}" = "true" ] && [ -s "$out_file" ] \
+            && jq -e 'type == "array"' "$out_file" >/dev/null 2>&1; then
+        cp "$out_file" "$cache_file" 2>/dev/null || true
+    fi
+
+    jq 'length' "$out_file" 2>/dev/null || echo 0
+    return $rc
+}
+
+# ===========================================================================
+# Parallel per-pool job-request (queue) probe
+#
+# WHY: agent-pool-capacity.sh / platform-issue-investigation.sh already fetch
+# pool AGENTS in parallel, but still probed each scaled-to-zero dynamic pool's
+# job queue SERIALLY inside the loop. For orgs with hundreds of pools that idle
+# at 0 online (e.g. 473 pools, many ephemeral), that serial probe was the
+# dominant remaining wall. Pre-fetching all candidate pools' job requests in a
+# bounded-parallel pass (identical to the agent fetch) removes that wall WITHOUT
+# changing any severity logic -- callers still derive queue pressure per pool,
+# just from a pre-fetched file instead of an inline serial call.
+# ===========================================================================
+
+# Fetch the job-request queue for the given pool ids concurrently, writing one
+# JSON array file per pool to <out_dir>/jobreqs_<poolId>.json ("[]" on failure).
+# Args: $1 = newline-separated pool ids, $2 = output dir, $3 = parallelism (default 20)
+fetch_pool_job_requests_parallel() {
+    local pool_ids="$1" out_dir="$2"
+    local max_par="${3:-${AGENT_FETCH_PARALLELISM:-20}}"
+    local org_url="https://dev.azure.com/$AZURE_DEVOPS_ORG"
+    case "$max_par" in ''|*[!0-9]*) max_par=20 ;; esac
+    [ "$max_par" -lt 1 ] && max_par=1
+    [ "$max_par" -gt 32 ] && max_par=32
+    mkdir -p "$out_dir"
+
+    export ADO_AUTH_HDR; ADO_AUTH_HDR=$(ado_auth_header)
+    printf '%s\n' "$pool_ids" | grep -E '^[0-9]+$' \
+        | xargs -r -P "$max_par" -I {} bash -c '
+            pool="$2"; out="$1/jobreqs_$2.json"; org="$3"; raw="$1/jr_$2.raw"
+            url="$org/_apis/distributedtask/pools/$pool/jobrequests?api-version=7.1"
+            if [ -n "${ADO_AUTH_HDR:-}" ] \
+                 && curl -fsS --max-time 30 -H "Authorization: $ADO_AUTH_HDR" "$url" -o "$raw" 2>/dev/null \
+                 && jq -e "(.value | type) == \"array\"" "$raw" >/dev/null 2>&1; then
+                jq -c ".value" "$raw" > "$out" 2>/dev/null || echo "[]" > "$out"
+            else
+                # Fall back to az devops invoke (proxy/auth aware) for this pool.
+                if resp=$(az devops invoke --area distributedtask --resource jobrequests \
+                        --route-parameters poolId="$pool" --org "$org" --api-version 7.1 \
+                        --output json 2>/dev/null) && printf "%s" "$resp" | jq -e ".value" >/dev/null 2>&1; then
+                    printf "%s" "$resp" | jq -c ".value" > "$out" 2>/dev/null || echo "[]" > "$out"
+                else
+                    echo "[]" > "$out"
+                fi
+            fi
+            rm -f "$raw"
+          ' _ "$out_dir" {} "$org_url"
+    unset ADO_AUTH_HDR
+}
+
+# Echo the cached job-requests array for a pool, or "[]" if absent/invalid.
+# Args: $1 = path to jobreqs_<poolId>.json
+load_pool_job_requests_json() {
+    local f="$1"
+    if [ -s "$f" ] && jq -e 'type == "array"' "$f" >/dev/null 2>&1; then
+        cat "$f"
+    else
+        echo "[]"
+    fi
 }

--- a/codebundles/azure-devops-project-health/_az_helpers.sh
+++ b/codebundles/azure-devops-project-health/_az_helpers.sh
@@ -154,7 +154,7 @@ ado_platform_incident_probe() {
 # project is configured. Org-health tasks must use --scope organization.
 ado_security_groups_json() {
     local org_url="https://dev.azure.com/${AZURE_DEVOPS_ORG}"
-    az devops security group list --org "$org_url" --scope organization --output json 2>/dev/null || echo ""
+    az devops security group list --org "$org_url" --scope organization --output json
 }
 
 # ---------------------------------------------------------------------------

--- a/codebundles/azure-devops-project-health/agent-pools.sh
+++ b/codebundles/azure-devops-project-health/agent-pools.sh
@@ -33,7 +33,7 @@
 : "${AZURE_DEVOPS_ORG:?Must set AZURE_DEVOPS_ORG}"
 : "${HIGH_UTILIZATION_THRESHOLD:=80}"
 : "${AUTH_TYPE:=service_principal}"
-AZURE_DEVOPS_PAT="${AZURE_DEVOPS_PAT:-$azure_devops_pat}"
+AZURE_DEVOPS_PAT="${AZURE_DEVOPS_PAT:-${azure_devops_pat:-}}"
 export AZURE_DEVOPS_EXT_PAT="${AZURE_DEVOPS_PAT}"
 
 source "$(dirname "$0")/_az_helpers.sh"
@@ -85,6 +85,13 @@ pool_count=$(jq '. | length' pools.json)
 # sequential call per pool when an organisation has many pools).
 echo "Fetching agents for all self-hosted pools (parallelism: ${AGENT_FETCH_PARALLELISM:-20})..."
 fetch_pool_agents_parallel "$pools" "$AGENT_CACHE_DIR"
+
+# Pre-fetch job-request queues in parallel (same pattern as org agent-pool-capacity).
+if [[ "${CHECK_QUEUE_ON_ZERO:-true}" == "true" ]]; then
+    nonhosted_pool_ids=$(jq -r '.[] | select((.isHosted // false) == false) | .id' pools.json)
+    echo "Pre-fetching job-request queues for self-hosted pools (parallelism: ${AGENT_FETCH_PARALLELISM:-20})..."
+    fetch_pool_job_requests_parallel "$nonhosted_pool_ids" "$AGENT_CACHE_DIR"
+fi
 
 # Process each agent pool using a for loop instead of pipe to while
 for ((i=0; i<pool_count; i++)); do
@@ -153,7 +160,7 @@ for ((i=0; i<pool_count; i++)); do
             # "assigned" anywhere, so busy_assigned stays 0 even during an outage.
             QUEUED_TOTAL=0; QUEUED_AGING=0; OLDEST_QUEUED_MIN=0
             if [[ "${CHECK_QUEUE_ON_ZERO:-true}" == "true" ]]; then
-                eval "$(pool_queue_pressure "$(ado_pool_job_requests_json "$pool_id")" "${QUEUE_AGING_THRESHOLD_MIN:-15}")"
+                eval "$(pool_queue_pressure "$(load_pool_job_requests_json "$AGENT_CACHE_DIR/jobreqs_${pool_id}.json")" "${QUEUE_AGING_THRESHOLD_MIN:-15}")"
             fi
             queue_status="$(pool_queue_status_line "$busy_count" "$QUEUED_TOTAL" "$QUEUED_AGING" "$OLDEST_QUEUED_MIN")"
 

--- a/codebundles/azure-devops-project-health/agent-pools.sh
+++ b/codebundles/azure-devops-project-health/agent-pools.sh
@@ -6,12 +6,28 @@
 #
 # OPTIONAL ENV VARS:
 #   HIGH_UTILIZATION_THRESHOLD - Percentage threshold for agent utilization (default: 80)
+#   EPHEMERAL_OFFLINE_RATIO    - % offline above which a pool with online capacity
+#                                is treated as elastic/ephemeral churn (default 60)
+#   MAX_OFFLINE_DETAIL         - max offline agent names listed per pool (default 20)
+#   QUEUE_AGING_THRESHOLD_MIN  - minutes a queued job must wait before a dynamic
+#                                pool at 0 online is treated as a real outage (15)
+#   CHECK_QUEUE_ON_ZERO        - "true"/"false": probe the pool job queue when a
+#                                dynamic pool has 0 online agents (default true)
 #
 # This script:
 #   1) Lists all agent pools in the specified Azure DevOps organization
 #   2) Checks the status of agents in each pool
 #   3) Identifies offline, disabled, or unhealthy agents
 #   4) Outputs results in JSON format
+#
+# Severity policy (uniform with the organization-health agent-pool scripts):
+#   * DYNAMIC pools (elastic/ephemeral): torn-down agents are EXPECTED. A pool at
+#     0 online while idle is NOT an outage -- it is a sev-4 advisory at most.
+#     Escalate above sev 4 ONLY with real evidence of impact: queued builds aging
+#     past QUEUE_AGING_THRESHOLD_MIN (sev 2), or work assigned to offline agents
+#     (sev 3).
+#   * STATIC pools with offline agents keep a higher severity (lost capacity); the
+#     issue text always explains the likely cause.
 # -----------------------------------------------------------------------------
 
 : "${AZURE_DEVOPS_ORG:?Must set AZURE_DEVOPS_ORG}"
@@ -130,32 +146,61 @@ for ((i=0; i<pool_count; i++)); do
     if [[ "$pool_kind" == "elastic" || "$pool_kind" == "ephemeral" ]]; then
         # Elastic/VMSS/ephemeral pool: offline agents are torn-down scale-set
         # instances and must NOT be flagged. The only actionable failure is a
-        # complete lack of online capacity *while work is waiting*.
-        if [[ "$online_count" -eq 0 && "$busy_count" -gt 0 ]]; then
-            pool_details=$(ado_pool_issue_details \
-                "Elastic/ephemeral pool has 0 online agents but $busy_count agent(s) with an active assignedRequest — work is bound to offline/unavailable agents." \
-                "$pool_name" "$pool_id" "$pool_type" "$pool_kind" "$agent_count" "$online_count" \
-                "$offline_count" "$busy_count" "$offline_count" \
-                "Action: verify the scaler can provision online agents immediately." "")
-            issues_json=$(echo "$issues_json" | jq \
-                --arg title "Elastic Pool \`$pool_name\` Has No Online Agents While Work Is Assigned" \
-                --arg details "$pool_details" \
-                --arg severity "2" \
-                --arg nextStep "Verify the VMSS/scale-set/Kubernetes scaler can provision agents: check the elastic pool sizing, backing Azure scale set / KEDA health, and the associated service connection." \
-                '. += [{"title": $title, "details": $details, "next_steps": $nextStep, "severity": ($severity | tonumber)}]')
-        elif [[ "$online_count" -eq 0 ]]; then
-            pool_details=$(ado_pool_issue_details \
-                "Elastic/ephemeral pool is scaled to zero (0 online, $offline_count offline registrations). No assignedRequest detected on registered agents." \
-                "$pool_name" "$pool_id" "$pool_type" "$pool_kind" "$agent_count" "$online_count" \
-                "$offline_count" "$busy_count" "$offline_count" \
-                "Advisory: this is often normal idle autoscaling. If pipeline runs are queued for this pool in Azure DevOps, treat as a capacity incident and investigate autoscale/VMSS/KEDA." "")
-            issues_json=$(echo "$issues_json" | jq \
-                --arg title "Elastic Pool \`$pool_name\` Scaled To Zero (Verify Queue)" \
-                --arg details "$pool_details" \
-                --arg severity "4" \
-                --arg nextStep "If no pipelines are waiting, no action needed. If builds are queued for this pool, verify autoscale rules, backing VMSS/Kubernetes health, and service connections." \
-                '. += [{"title": $title, "details": $details, "next_steps": $nextStep, "severity": ($severity | tonumber)}]')
-            echo "  Elastic/ephemeral pool \`$pool_name\` scaled to zero: advisory issue raised (verify queue if pipelines are waiting)."
+        # complete lack of online capacity *while work is actually waiting*.
+        if [[ "$online_count" -eq 0 ]]; then
+            # Probe the job queue. Aging queued work (not busy_assigned) is the
+            # real outage signal: a job waiting with no online agent can't be
+            # "assigned" anywhere, so busy_assigned stays 0 even during an outage.
+            QUEUED_TOTAL=0; QUEUED_AGING=0; OLDEST_QUEUED_MIN=0
+            if [[ "${CHECK_QUEUE_ON_ZERO:-true}" == "true" ]]; then
+                eval "$(pool_queue_pressure "$(ado_pool_job_requests_json "$pool_id")" "${QUEUE_AGING_THRESHOLD_MIN:-15}")"
+            fi
+            queue_status="$(pool_queue_status_line "$busy_count" "$QUEUED_TOTAL" "$QUEUED_AGING" "$OLDEST_QUEUED_MIN")"
+
+            # ESCALATION CONDITION (intent): escalate above sev 4 only with real
+            # evidence of impact -- aging queued work (sev 2) or work bound to
+            # offline agents (sev 3). Otherwise this is expected scale-down (sev 4).
+            if [[ "$QUEUED_AGING" -gt 0 ]]; then
+                pool_details=$(ado_pool_issue_details \
+                    "Dynamic pool has 0 online agents AND $QUEUED_AGING queued build(s) aging past ${QUEUE_AGING_THRESHOLD_MIN:-15} min -- pipelines are blocked." \
+                    "$pool_name" "$pool_id" "$pool_type" "$pool_kind" "$agent_count" "$online_count" \
+                    "$offline_count" "$busy_count" "$offline_count" \
+                    "Oldest queued job has waited ${OLDEST_QUEUED_MIN} min with no agent to run it." "" \
+                    "$POOL_KIND_REASON" "$queue_status")
+                issues_json=$(echo "$issues_json" | jq \
+                    --arg title "Elastic Pool \`$pool_name\` Has Queued Builds But No Online Agents" \
+                    --arg details "$pool_details" \
+                    --arg severity "2" \
+                    --arg nextStep "The dynamic scaler is not provisioning agents. Check the elastic pool sizing, backing Azure scale set / KEDA health, and the associated service connection." \
+                    '. += [{"title": $title, "details": $details, "next_steps": $nextStep, "severity": ($severity | tonumber)}]')
+            elif [[ "$busy_count" -gt 0 ]]; then
+                pool_details=$(ado_pool_issue_details \
+                    "Dynamic pool has 0 online agents but $busy_count agent(s) still carry an assignedRequest." \
+                    "$pool_name" "$pool_id" "$pool_type" "$pool_kind" "$agent_count" "$online_count" \
+                    "$offline_count" "$busy_count" "$offline_count" \
+                    "No queued work is aging; an assignedRequest on an offline agent is usually a stale scale-down record." "" \
+                    "$POOL_KIND_REASON" "$queue_status")
+                issues_json=$(echo "$issues_json" | jq \
+                    --arg title "Elastic Pool \`$pool_name\` Has Work Assigned To Offline Agents" \
+                    --arg details "$pool_details" \
+                    --arg severity "3" \
+                    --arg nextStep "Confirm the scaler replaced the torn-down agents. If the assignedRequest persists, re-queue the job or verify the backing VMSS/Kubernetes infrastructure." \
+                    '. += [{"title": $title, "details": $details, "next_steps": $nextStep, "severity": ($severity | tonumber)}]')
+            else
+                pool_details=$(ado_pool_issue_details \
+                    "Elastic/ephemeral pool is scaled to zero (0 online, $offline_count offline registrations). No queued work and no assignedRequest detected." \
+                    "$pool_name" "$pool_id" "$pool_type" "$pool_kind" "$agent_count" "$online_count" \
+                    "$offline_count" "$busy_count" "$offline_count" \
+                    "Advisory only -- expected idle autoscaling. No pipelines are waiting on this pool." "" \
+                    "$POOL_KIND_REASON" "$queue_status")
+                issues_json=$(echo "$issues_json" | jq \
+                    --arg title "Elastic Pool \`$pool_name\` Scaled To Zero (Expected Dynamic Scale-Down)" \
+                    --arg details "$pool_details" \
+                    --arg severity "4" \
+                    --arg nextStep "No action needed -- a dynamic pool idle at 0 online agents is expected. If builds later queue without starting, verify autoscale rules, backing VMSS/Kubernetes health, and service connections." \
+                    '. += [{"title": $title, "details": $details, "next_steps": $nextStep, "severity": ($severity | tonumber)}]')
+                echo "  Elastic/ephemeral pool \`$pool_name\` scaled to zero: sev-4 advisory (expected, no queued work)."
+            fi
         else
             echo "  Elastic/ephemeral pool healthy: $online_count online agent(s); ignoring $offline_count expected offline registrations."
         fi
@@ -173,13 +218,14 @@ for ((i=0; i<pool_count; i++)); do
         pool_details=$(ado_pool_issue_details \
             "Static pool has $offline_count of $agent_count agents offline (actionable lost capacity)." \
             "$pool_name" "$pool_id" "$pool_type" "$pool_kind" "$agent_count" "$online_count" \
-            "$offline_count" "$busy_count" "0" "" "$offline_names")
+            "$offline_count" "$busy_count" "0" "" "$offline_names" \
+            "$POOL_KIND_REASON" "")
 
         issues_json=$(echo "$issues_json" | jq \
             --arg title "Offline Agents Found in Pool \`$pool_name\` ($offline_count of $agent_count agents)" \
             --arg details "$pool_details" \
             --arg severity "3" \
-            --arg nextStep "Check the offline agent machines and restart the agent service if needed. Verify network connectivity between agents and Azure DevOps. If this is an autoscaled VMSS pool, configure Azure DevOps to remove torn-down agents automatically." \
+            --arg nextStep "These are persistent/static agents: restart the agent service on each offline host, confirm the host is powered on and can reach dev.azure.com, and verify the agent credentials/PAT have not expired. If this is actually an autoscaled VMSS pool, configure Azure DevOps to remove torn-down agents automatically." \
             '. += [{"title": $title, "details": $details, "next_steps": $nextStep, "severity": ($severity | tonumber)}]')
 
         # Disabled AND offline agents (static pools only)

--- a/codebundles/azure-devops-project-health/discover-projects.sh
+++ b/codebundles/azure-devops-project-health/discover-projects.sh
@@ -15,7 +15,7 @@ set -euo pipefail
 
 : "${AZURE_DEVOPS_ORG:?Must set AZURE_DEVOPS_ORG}"
 : "${AUTH_TYPE:=service_principal}"
-AZURE_DEVOPS_PAT="${AZURE_DEVOPS_PAT:-$azure_devops_pat}"
+AZURE_DEVOPS_PAT="${AZURE_DEVOPS_PAT:-${azure_devops_pat:-}}"
 export AZURE_DEVOPS_EXT_PAT="${AZURE_DEVOPS_PAT}"
 
 source "$(dirname "$0")/_az_helpers.sh"

--- a/codebundles/azure-devops-project-health/long-running-pipelines.sh
+++ b/codebundles/azure-devops-project-health/long-running-pipelines.sh
@@ -9,17 +9,22 @@ set -euo pipefail
 #   AZURE_DEVOPS_PROJECT
 #
 # OPTIONAL ENV VARS:
-#   DURATION_THRESHOLD - Threshold in minutes or hours (e.g., "60m" or "2h") for long-running pipelines (default: "60m")
+#   DURATION_THRESHOLD   - Threshold in minutes or hours (e.g., "60m" or "2h") for long-running pipelines (default: "60m")
+#   RW_LOOKBACK_WINDOW   - window for completed builds considered (default 24h)
 #
-# This script:
-#   1) Lists all pipelines in the specified Azure DevOps project
-#   2) Checks for runs that exceed the specified duration threshold
-#   3) Outputs results in JSON format
+# This script (Phase 0 single-pass refactor):
+#   1) Fetches the project's builds ONCE via the Build REST API (fetch_project_builds).
+#   2) Derives, with jq, in-flight builds running longer than the threshold AND
+#      completed builds whose run time exceeded it -- with NO per-pipeline API
+#      calls (previously it looped over every pipeline issuing
+#      `az pipelines runs list --pipeline-id <id>`, which timed out at 180s).
+#   3) Outputs results in JSON format.
 # -----------------------------------------------------------------------------
 
 : "${AZURE_DEVOPS_ORG:?Must set AZURE_DEVOPS_ORG}"
 : "${AZURE_DEVOPS_PROJECT:?Must set AZURE_DEVOPS_PROJECT}"
-: "${DURATION_THRESHOLD:=1m}"
+: "${DURATION_THRESHOLD:=60m}"
+: "${RW_LOOKBACK_WINDOW:=24h}"
 : "${AUTH_TYPE:=service_principal}"
 AZURE_DEVOPS_PAT="${AZURE_DEVOPS_PAT:-$azure_devops_pat}"
 export AZURE_DEVOPS_EXT_PAT="${AZURE_DEVOPS_PAT}"
@@ -27,6 +32,7 @@ export AZURE_DEVOPS_EXT_PAT="${AZURE_DEVOPS_PAT}"
 source "$(dirname "$0")/_az_helpers.sh"
 
 OUTPUT_FILE="long_running_pipelines.json"
+BUILDS_FILE="builds_dataset.json"
 issues_json='[]'
 
 # Convert duration threshold to minutes
@@ -34,7 +40,7 @@ convert_to_minutes() {
     local threshold=$1
     local number=$(echo "$threshold" | sed -E 's/[^0-9]//g')
     local unit=$(echo "$threshold" | sed -E 's/[0-9]//g')
-    
+
     case $unit in
         m|min|mins)
             echo $number
@@ -59,15 +65,15 @@ echo "Threshold:    $THRESHOLD_MINUTES minutes"
 az devops configure --defaults project="$AZURE_DEVOPS_PROJECT" --output none
 setup_azure_auth
 
-# Get list of pipelines
-echo "Retrieving pipelines in project..."
-if ! az_with_retry az pipelines list --output json; then
-    echo "ERROR: Could not list pipelines."
+# Single-pass: fetch the project's builds ONCE (shared/cached across tasks).
+echo "Fetching project build dataset (single pass, window: ${RW_LOOKBACK_WINDOW})..."
+if ! build_count=$(fetch_project_builds "$AZURE_DEVOPS_PROJECT" "$BUILDS_FILE" "$RW_LOOKBACK_WINDOW"); then
+    echo "ERROR: Could not fetch builds for project."
     issues_json=$(echo "$issues_json" | jq \
-        --arg title "Failed to List Pipelines" \
-        --arg details "Azure DevOps API was unreachable or returned an error after $AZ_RETRY_COUNT retry attempts." \
+        --arg title "Failed to Fetch Builds" \
+        --arg details "The Build REST API was unreachable or returned an error while fetching the project build dataset." \
         --arg severity "3" \
-        --arg nextStep "Check if the project exists and you have the right permissions. Verify Azure DevOps API availability." \
+        --arg nextStep "Check if the project exists and you have Build (Read) permissions. Verify Azure DevOps API availability." \
         '. += [{
            "title": $title,
            "details": $details,
@@ -77,205 +83,61 @@ if ! az_with_retry az pipelines list --output json; then
     echo "$issues_json" > "$OUTPUT_FILE"
     exit 1
 fi
-pipelines="$AZ_RESULT"
+echo "Fetched $build_count builds. Deriving long-running pipelines..."
 
-# Save pipelines to a file to avoid subshell issues
-echo "$pipelines" > pipelines.json
+NOW_EPOCH=$(date +%s)
 
-# Get the number of pipelines
-pipeline_count=$(jq '. | length' pipelines.json)
+# Derive both in-flight (inProgress) and completed long-running builds from the
+# single dataset in one jq pass. Severities preserved: in-flight = sev 3,
+# completed-over-threshold = sev 2.
+issues_json=$(jq \
+    --argjson now "$NOW_EPOCH" \
+    --argjson thr "$THRESHOLD_MINUTES" \
+    --arg threshold_label "$THRESHOLD_MINUTES" \
+    --arg project "$AZURE_DEVOPS_PROJECT" '
+    def parsedate: (sub("\\.[0-9]+";"") | sub("(Z|[+-][0-9][0-9]:?[0-9][0-9])$";"")) + "Z" | fromdateiso8601;
+    def fmt(m): if m >= 1440 then "\(m/1440|floor)d \((m%1440)/60|floor)h \(m%60)m"
+                elif m >= 60 then "\(m/60|floor)h \(m%60)m"
+                else "\(m)m" end;
+    def common:
+      (.definition.name // "Unknown Pipeline") as $pname
+      | ((.sourceBranch // "unknown") | sub("refs/heads/";"")) as $branch
+      | {pname:$pname, branch:$branch, url:(._links.web.href // .url // ""),
+         pid:((.definition.id // "") | tostring), rid:((.id // "") | tostring)};
+    (
+      # In-flight builds running past the threshold (current duration).
+      [ .[]
+        | select(.status == "inProgress" and (.startTime // null) != null)
+        | (($now - (.startTime | parsedate)) / 60 | floor) as $dm
+        | select($dm >= $thr)
+        | common as $c
+        | {
+            title: "Long Running Pipeline: `\($c.pname)` (Branch: `\($c.branch)`)",
+            details: "Pipeline has been running for \(fmt($dm)) (exceeds threshold of \($threshold_label) minutes)",
+            next_steps: "Investigate why pipeline `\($c.pname)` in project `\($project)` is taking longer than expected. Check for resource constraints or inefficient tasks.",
+            severity: 3,
+            resource_url: $c.url, duration: fmt($dm), duration_minutes: $dm,
+            pipeline_id: $c.pid, run_id: $c.rid, branch: $c.branch
+          } ]
+      +
+      # Completed builds whose run time exceeded the threshold.
+      [ .[]
+        | select(.status == "completed" and (.startTime // null) != null and (.finishTime // null) != null)
+        | (((.finishTime | parsedate) - (.startTime | parsedate)) / 60 | floor) as $dm
+        | select($dm >= $thr)
+        | common as $c
+        | {
+            title: "Long Running Completed Pipeline: `\($c.pname)` (Branch: `\($c.branch)`)",
+            details: "Pipeline run completed in \(fmt($dm)) (exceeds threshold of \($threshold_label) minutes)",
+            next_steps: "Review pipeline `\($c.pname)` in project `\($project)` for optimization opportunities. Consider parallelizing tasks or upgrading agent resources.",
+            severity: 2,
+            resource_url: $c.url, duration: fmt($dm), duration_minutes: $dm,
+            pipeline_id: $c.pid, run_id: $c.rid, branch: $c.branch
+          } ]
+    )
+    ' "$BUILDS_FILE")
 
-# Process each pipeline using a for loop instead of pipe to while
-for ((i=0; i<pipeline_count; i++)); do
-    pipeline_json=$(jq -c ".[${i}]" pipelines.json)
-    
-    # Extract values from JSON using jq
-    pipeline_id=$(echo "$pipeline_json" | jq -r '.id')
-    pipeline_name=$(echo "$pipeline_json" | jq -r '.name')
-    
-    echo "Processing Pipeline: $pipeline_name (ID: $pipeline_id)"
-    
-    # # Calculate date for filtering runs (in ISO format)
-    # from_date=$(date -d "$DAYS_TO_LOOK_BACK days ago" -u +"%Y-%m-%dT%H:%M:%SZ")
-    
-    # Get recent pipeline runs
-    if ! az_with_retry az pipelines runs list --pipeline-id "$pipeline_id" --output json; then
-        issues_json=$(echo "$issues_json" | jq \
-            --arg title "Failed to List Runs for Pipeline $pipeline_name" \
-            --arg details "Could not retrieve runs after $AZ_RETRY_COUNT attempts." \
-            --arg severity "3" \
-            --arg nextStep "Check if you have sufficient permissions to view pipeline runs. Verify Azure DevOps API availability." \
-            '. += [{
-               "title": $title,
-               "details": $details,
-               "next_steps": $nextStep,
-               "severity": ($severity | tonumber)
-             }]')
-        continue
-    fi
-    runs="$AZ_RESULT"
-    
-    # Save runs to a file to avoid subshell issues
-    echo "$runs" > runs.json
-    
-    # Get the number of runs
-    run_count=$(jq '. | length' runs.json)
-    
-    # Check for currently running pipelines
-    for ((j=0; j<run_count; j++)); do
-        run_json=$(jq -c ".[${j}]" runs.json)
-        
-        # Check if run is in progress
-        run_state=$(echo "$run_json" | jq -r '.status')
-        if [[ "$run_state" != "inProgress" ]]; then
-            continue
-        fi
-        
-        run_id=$(echo "$run_json" | jq -r '.id')
-        run_name=$(echo "$run_json" | jq -r '.name // "Run #\(.id)"')
-        web_url=$(echo "$run_json" | jq -r '.url')
-        branch=$(echo "$run_json" | jq -r '.sourceBranch // "unknown"' | sed 's|refs/heads/||')
-        created_date=$(echo "$run_json" | jq -r '.startTime')
-        
-        # Calculate run duration in minutes
-        created_timestamp=$(date -d "$created_date" +%s)
-        current_timestamp=$(date +%s)
-        duration_seconds=$((current_timestamp - created_timestamp))
-        duration_minutes=$((duration_seconds / 60))
-        
-        # Format duration for display
-        if [ $duration_minutes -ge 1440 ]; then
-            days=$((duration_minutes / 1440))
-            hours=$(((duration_minutes % 1440) / 60))
-            mins=$((duration_minutes % 60))
-            formatted_duration="${days}d ${hours}h ${mins}m"
-        elif [ $duration_minutes -ge 60 ]; then
-            hours=$((duration_minutes / 60))
-            mins=$((duration_minutes % 60))
-            formatted_duration="${hours}h ${mins}m"
-        else
-            formatted_duration="${duration_minutes}m"
-        fi
-        
-        echo "  Checking running pipeline: $run_name (ID: $run_id, Branch: $branch, Duration: $formatted_duration)"
-        
-        # Check if duration exceeds threshold
-        if [ $duration_minutes -ge $THRESHOLD_MINUTES ]; then
-            issues_json=$(echo "$issues_json" | jq \
-                --arg title "Long Running Pipeline: \`$pipeline_name\` (Branch: \`$branch\`)" \
-                --arg details "Pipeline has been running for $formatted_duration (exceeds threshold of $THRESHOLD_MINUTES minutes)" \
-                --arg severity "3" \
-                --arg nextStep "Investigate why pipeline \`$pipeline_name\` in project \`$AZURE_DEVOPS_PROJECT\` is taking longer than expected. Check for resource constraints or inefficient tasks." \
-                --arg resource_url "$web_url" \
-                --arg duration "$formatted_duration" \
-                --arg duration_minutes "$duration_minutes" \
-                --arg pipeline_id "$pipeline_id" \
-                --arg run_id "$run_id" \
-                --arg branch "$branch" \
-                '. += [{
-                   "title": $title,
-                   "details": $details,
-                   "next_steps": $nextStep,
-                   "severity": ($severity | tonumber),
-                   "resource_url": $resource_url,
-                   "duration": $duration,
-                   "duration_minutes": ($duration_minutes | tonumber),
-                   "pipeline_id": $pipeline_id,
-                   "run_id": $run_id,
-                   "branch": $branch
-                 }]')
-        fi
-    done
-    
-    # Also check for completed runs that took longer than the threshold
-    for ((j=0; j<run_count; j++)); do
-        run_json=$(jq -c ".[${j}]" runs.json)
-        
-        # Check if run is completed
-        run_state=$(echo "$run_json" | jq -r '.status')
-        if [[ "$run_state" != "completed" ]]; then
-            continue
-        fi
-        
-        run_id=$(echo "$run_json" | jq -r '.id')
-        run_name=$(echo "$run_json" | jq -r '.name // "Run #\(.id)"')
-        web_url=$(echo "$run_json" | jq -r '.url')
-        branch=$(echo "$run_json" | jq -r '.sourceBranch // "unknown"' | sed 's|refs/heads/||')
-        
-        # Get start and finish times
-        start_time=$(echo "$run_json" | jq -r '.startTime')
-        finish_time=$(echo "$run_json" | jq -r '.finishTime')
-        
-        # Check if both times are valid
-        if [ "$start_time" != "null" ] && [ -n "$start_time" ] && [ "$finish_time" != "null" ] && [ -n "$finish_time" ]; then
-            # Convert ISO timestamps to Unix timestamps using date
-            start_timestamp=$(date -d "$start_time" +%s 2>/dev/null || echo 0)
-            finish_timestamp=$(date -d "$finish_time" +%s 2>/dev/null || echo 0)
-            
-            # Calculate duration in seconds
-            if [ "$start_timestamp" -gt 0 ] && [ "$finish_timestamp" -gt 0 ]; then
-                duration_seconds=$((finish_timestamp - start_timestamp))
-            else
-                duration_seconds=0
-                echo "  Warning: Could not parse timestamps for run $run_id"
-            fi
-        else
-            duration_seconds=0
-            echo "  Warning: Missing start or finish time for run $run_id"
-        fi
-        
-        duration_minutes=$((duration_seconds / 60))
-        
-        # Format duration for display
-        if [ $duration_minutes -ge 1440 ]; then
-            days=$((duration_minutes / 1440))
-            hours=$(((duration_minutes % 1440) / 60))
-            mins=$((duration_minutes % 60))
-            formatted_duration="${days}d ${hours}h ${mins}m"
-        elif [ $duration_minutes -ge 60 ]; then
-            hours=$((duration_minutes / 60))
-            mins=$((duration_minutes % 60))
-            formatted_duration="${hours}h ${mins}m"
-        else
-            formatted_duration="${duration_minutes}m"
-        fi
-        
-        # Check if duration exceeds threshold
-        if [ $duration_minutes -ge $THRESHOLD_MINUTES ]; then
-            echo "  Found long-running completed pipeline: $run_name (ID: $run_id, Branch: $branch, Duration: $formatted_duration)"
-            
-            issues_json=$(echo "$issues_json" | jq \
-                --arg title "Long Running Completed Pipeline: \`$pipeline_name\` (Branch: \`$branch\`)" \
-                --arg details "Pipeline run completed in $formatted_duration (exceeds threshold of $THRESHOLD_MINUTES minutes)" \
-                --arg severity "2" \
-                --arg nextStep "Review pipeline \`$pipeline_name\` in project \`$AZURE_DEVOPS_PROJECT\` for optimization opportunities. Consider parallelizing tasks or upgrading agent resources." \
-                --arg resource_url "$web_url" \
-                --arg duration "$formatted_duration" \
-                --arg duration_minutes "$duration_minutes" \
-                --arg pipeline_id "$pipeline_id" \
-                --arg run_id "$run_id" \
-                --arg branch "$branch" \
-                '. += [{
-                   "title": $title,
-                   "details": $details,
-                   "next_steps": $nextStep,
-                   "severity": ($severity | tonumber),
-                   "resource_url": $resource_url,
-                   "duration": $duration,
-                   "duration_minutes": ($duration_minutes | tonumber),
-                   "pipeline_id": $pipeline_id,
-                   "run_id": $run_id,
-                   "branch": $branch
-                 }]')
-        fi
-    done
-    
-    # Clean up runs file
-    rm -f runs.json
-done
-
-# Clean up pipelines file
-rm -f pipelines.json
+echo "$issues_json" | jq -r '.[] | "  \(.title) — \(.duration)"' 2>/dev/null || true
 
 # Write final JSON
 echo "$issues_json" > "$OUTPUT_FILE"

--- a/codebundles/azure-devops-project-health/long-running-pipelines.sh
+++ b/codebundles/azure-devops-project-health/long-running-pipelines.sh
@@ -95,7 +95,7 @@ issues_json=$(jq \
     --argjson thr "$THRESHOLD_MINUTES" \
     --arg threshold_label "$THRESHOLD_MINUTES" \
     --arg project "$AZURE_DEVOPS_PROJECT" '
-    def parsedate: (sub("\\.[0-9]+";"") | sub("(Z|[+-][0-9][0-9]:?[0-9][0-9])$";"")) + "Z" | fromdateiso8601;
+    def parsedate: (sub("\\.[0-9]+";"") | sub("(Z|[+-][0-9][0-9]:?[0-9][0-9])$";"")) + "Z" | (try fromdateiso8601 catch null);
     def fmt(m): if m >= 1440 then "\(m/1440|floor)d \((m%1440)/60|floor)h \(m%60)m"
                 elif m >= 60 then "\(m/60|floor)h \(m%60)m"
                 else "\(m)m" end;
@@ -108,7 +108,9 @@ issues_json=$(jq \
       # In-flight builds running past the threshold (current duration).
       [ .[]
         | select(.status == "inProgress" and (.startTime // null) != null)
-        | (($now - (.startTime | parsedate)) / 60 | floor) as $dm
+        | (.startTime | parsedate) as $st
+        | select($st != null)
+        | (($now - $st) / 60 | floor) as $dm
         | select($dm >= $thr)
         | common as $c
         | {
@@ -123,7 +125,10 @@ issues_json=$(jq \
       # Completed builds whose run time exceeded the threshold.
       [ .[]
         | select(.status == "completed" and (.startTime // null) != null and (.finishTime // null) != null)
-        | (((.finishTime | parsedate) - (.startTime | parsedate)) / 60 | floor) as $dm
+        | (.startTime | parsedate) as $st
+        | (.finishTime | parsedate) as $ft
+        | select($st != null and $ft != null)
+        | (($ft - $st) / 60 | floor) as $dm
         | select($dm >= $thr)
         | common as $c
         | {

--- a/codebundles/azure-devops-project-health/long-running-pipelines.sh
+++ b/codebundles/azure-devops-project-health/long-running-pipelines.sh
@@ -26,7 +26,7 @@ set -euo pipefail
 : "${DURATION_THRESHOLD:=60m}"
 : "${RW_LOOKBACK_WINDOW:=24h}"
 : "${AUTH_TYPE:=service_principal}"
-AZURE_DEVOPS_PAT="${AZURE_DEVOPS_PAT:-$azure_devops_pat}"
+AZURE_DEVOPS_PAT="${AZURE_DEVOPS_PAT:-${azure_devops_pat:-}}"
 export AZURE_DEVOPS_EXT_PAT="${AZURE_DEVOPS_PAT}"
 
 source "$(dirname "$0")/_az_helpers.sh"

--- a/codebundles/azure-devops-project-health/meta.yaml
+++ b/codebundles/azure-devops-project-health/meta.yaml
@@ -51,6 +51,21 @@ spec:
       required: false
       default: "30m"
       example: "1h"
+    - name: RW_LOOKBACK_WINDOW
+      description: "Runbook: set via taskset configProvided (24h) for the single-pass build dataset. SLI: injected by the platform from intervalSeconds as seconds (do not put RW_LOOKBACK_WINDOW in the SLI template); sli.robot imports it with Import Platform Variable and formats via Normalize Lookback Window (format 2). Point-in-time SLI signals (queue, long-running) ignore it."
+      required: false
+      default: "24h"
+      example: "30d"
+    - name: MAX_FAILURES_TO_INVESTIGATE
+      description: "Maximum number of failed builds whose logs/commits are deep-investigated per task (the only genuine per-item work left after the single-pass refactor). Most-recent failures first."
+      required: false
+      default: "10"
+      example: "25"
+    - name: MAX_REPOS
+      description: "Maximum number of repositories whose commit history is fetched in repository activity analysis (bounds per-repo work; PR and policy data are fetched project-wide in a single call regardless)."
+      required: false
+      default: "50"
+      example: "100"
     - name: EPHEMERAL_OFFLINE_RATIO
       description: "Percentage of offline agents above which a pool that still has online capacity is treated as an elastic/ephemeral (VMSS/AKS/container) pool, so transient offline agents are not flagged as outages"
       required: false
@@ -61,6 +76,21 @@ spec:
       required: false
       default: "20"
       example: "24"
+    - name: SLI_MAX_FAILURE_RATIO
+      description: "SLI only. Maximum failed/total completed-build ratio within the platform-injected SLI window before pipeline_failure_ratio_ok drops to 0. A window with 0 completed runs scores 1 (cannot measure = healthy)."
+      required: false
+      default: "0.50"
+      example: "0.30"
+    - name: SLI_MAX_LONGRUNNING
+      description: "SLI only. Maximum number of in-flight builds older than DURATION_THRESHOLD allowed before the long_running_ok sub-score drops to 0 (point-in-time)."
+      required: false
+      default: "1"
+      example: "2"
+    - name: SLI_PROTECTED_BRANCH_PATTERN
+      description: "SLI only. Regex matching protected source branches. The protected_branch_failures_ok sub-score drops to 0 only when a pipeline on one of these branches fails 100% of its runs within the SLI window (chronic flaky PR/scheduled pipelines are kept report-only in the runbook, not scored)."
+      required: false
+      default: "^refs/heads/(main|master|develop|release/)"
+      example: "^refs/heads/(main|release/)"
   secrets:
     - name: azure_credentials
       description: "Azure service principal credentials for authentication"

--- a/codebundles/azure-devops-project-health/pipeline-failure-investigation.sh
+++ b/codebundles/azure-devops-project-health/pipeline-failure-investigation.sh
@@ -29,7 +29,7 @@ set -euo pipefail
 : "${RW_LOOKBACK_WINDOW:=24h}"
 : "${MAX_FAILURES_TO_INVESTIGATE:=10}"
 : "${AUTH_TYPE:=service_principal}"
-AZURE_DEVOPS_PAT="${AZURE_DEVOPS_PAT:-$azure_devops_pat}"
+AZURE_DEVOPS_PAT="${AZURE_DEVOPS_PAT:-${azure_devops_pat:-}}"
 export AZURE_DEVOPS_EXT_PAT="${AZURE_DEVOPS_PAT}"
 
 source "$(dirname "$0")/_az_helpers.sh"

--- a/codebundles/azure-devops-project-health/pipeline-failure-investigation.sh
+++ b/codebundles/azure-devops-project-health/pipeline-failure-investigation.sh
@@ -8,15 +8,26 @@ set -euo pipefail
 #   AZURE_DEVOPS_ORG
 #   AZURE_DEVOPS_PROJECT
 #
-# This script:
-#   1) Gets failed pipeline runs from the last 24 hours
-#   2) Analyzes commit history for each failure
-#   3) Correlates failures with recent changes
-#   4) Provides detailed investigation output
+# OPTIONAL ENV VARS:
+#   RW_LOOKBACK_WINDOW            - window for failed builds (default 24h)
+#   MAX_FAILURES_TO_INVESTIGATE   - cap on failed builds whose commits are
+#                                   correlated (deep per-item work; default 10)
+#
+# This script (Phase 0 single-pass refactor):
+#   1) Fetches the project's builds ONCE via the Build REST API (fetch_project_builds).
+#   2) Derives failed builds AND the per-definition "similar failures in window"
+#      count from that SINGLE dataset with jq -- removing the per-failure
+#      `az pipelines runs list --pipeline-id` call that previously ran inside the
+#      loop.
+#   3) Correlates each failure with its commit, CAPPED to
+#      MAX_FAILURES_TO_INVESTIGATE (commit lookups are genuine per-item work).
+#   4) Outputs results in JSON format.
 # -----------------------------------------------------------------------------
 
 : "${AZURE_DEVOPS_ORG:?Must set AZURE_DEVOPS_ORG}"
 : "${AZURE_DEVOPS_PROJECT:?Must set AZURE_DEVOPS_PROJECT}"
+: "${RW_LOOKBACK_WINDOW:=24h}"
+: "${MAX_FAILURES_TO_INVESTIGATE:=10}"
 : "${AUTH_TYPE:=service_principal}"
 AZURE_DEVOPS_PAT="${AZURE_DEVOPS_PAT:-$azure_devops_pat}"
 export AZURE_DEVOPS_EXT_PAT="${AZURE_DEVOPS_PAT}"
@@ -24,6 +35,7 @@ export AZURE_DEVOPS_EXT_PAT="${AZURE_DEVOPS_PAT}"
 source "$(dirname "$0")/_az_helpers.sh"
 
 OUTPUT_FILE="pipeline_failure_investigation.json"
+BUILDS_FILE="builds_dataset.json"
 investigation_json='[]'
 
 echo "Deep Pipeline Failure Investigation..."
@@ -33,68 +45,77 @@ echo "Project:      $AZURE_DEVOPS_PROJECT"
 az devops configure --defaults project="$AZURE_DEVOPS_PROJECT" --output none
 setup_azure_auth
 
-# Get failed pipeline runs from last 24 hours
-echo "Getting failed pipeline runs from last 24 hours..."
-from_date=$(date -d "24 hours ago" -u +"%Y-%m-%dT%H:%M:%SZ")
-
-if ! az_with_retry az pipelines runs list --query "[?result=='failed' && finishTime >= '$from_date']" --output json; then
-    echo "ERROR: Could not get failed pipeline runs."
+# Single-pass: fetch the project's builds ONCE (shared/cached across tasks).
+echo "Fetching project build dataset (single pass, window: ${RW_LOOKBACK_WINDOW})..."
+if ! build_count=$(fetch_project_builds "$AZURE_DEVOPS_PROJECT" "$BUILDS_FILE" "$RW_LOOKBACK_WINDOW"); then
+    echo "ERROR: Could not fetch builds for project."
     investigation_json=$(echo "$investigation_json" | jq \
-        --arg title "Failed to Get Pipeline Runs" \
-        --arg details "Azure DevOps API was unreachable or returned an error after $AZ_RETRY_COUNT retry attempts." \
+        --arg title "Failed to Fetch Builds" \
+        --arg details "The Build REST API was unreachable or returned an error while fetching the project build dataset." \
         --arg severity "3" \
         '. += [{
            "title": $title,
            "details": $details,
-           "severity": ($severity | tonumber)
+           "severity": ($severity | tonumber),
+           "next_steps": "Verify Build API access for this project, check network connectivity to dev.azure.com, and confirm the lookback window is appropriate."
         }]')
     echo "$investigation_json" > "$OUTPUT_FILE"
     exit 1
 fi
-failed_runs="$AZ_RESULT"
 
-echo "$failed_runs" > failed_runs.json
-failed_count=$(jq '. | length' failed_runs.json)
+# Derive failed builds (newest first) and attach the per-definition similar-failure
+# count -- all from the single dataset (no per-pipeline calls).
+jq -c '
+    ([ .[] | select(.result == "failed") ]
+      | group_by(.definition.id)
+      | map({key: (.[0].definition.id | tostring), value: length})
+      | from_entries) as $bydef
+    | [ .[] | select(.result == "failed")
+        | . + {similar_failures_count: ($bydef[(.definition.id | tostring)] // 1)} ]
+    | sort_by(.finishTime // .queueTime // "") | reverse
+' "$BUILDS_FILE" > failed_builds.json
+
+failed_count=$(jq 'length' failed_builds.json)
 
 if [ "$failed_count" -eq 0 ]; then
-    echo "No failed pipeline runs found in the last 24 hours."
-    investigation_json='[{"title": "No Recent Failures", "details": "No failed pipeline runs found in the last 24 hours", "severity": 1}]'
+    echo "No failed pipeline runs found in the last ${RW_LOOKBACK_WINDOW}."
+    investigation_json='[{"title": "No Recent Failures", "details": "No failed pipeline runs found in the lookback window", "severity": 1, "next_steps": "No action required."}]'
     echo "$investigation_json" > "$OUTPUT_FILE"
+    rm -f failed_builds.json
     exit 0
 fi
 
-echo "Found $failed_count failed pipeline runs. Investigating..."
+echo "Found $failed_count failed builds. Investigating up to $MAX_FAILURES_TO_INVESTIGATE with commit correlation..."
 
-# Process each failed run
-for ((i=0; i<failed_count; i++)); do
-    run_json=$(jq -c ".[${i}]" failed_runs.json)
-    
+investigate_count=$failed_count
+if [ "$investigate_count" -gt "$MAX_FAILURES_TO_INVESTIGATE" ]; then
+    investigate_count=$MAX_FAILURES_TO_INVESTIGATE
+fi
+
+for ((i=0; i<investigate_count; i++)); do
+    run_json=$(jq -c ".[${i}]" failed_builds.json)
+
     run_id=$(echo "$run_json" | jq -r '.id')
-    pipeline_name=$(echo "$run_json" | jq -r '.name')
-    source_version=$(echo "$run_json" | jq -r '.sourceVersion')
+    pipeline_name=$(echo "$run_json" | jq -r '.definition.name // .buildNumber // "Unknown Pipeline"')
+    source_version=$(echo "$run_json" | jq -r '.sourceVersion // ""')
     source_branch=$(echo "$run_json" | jq -r '.sourceBranch // "unknown"' | sed 's|refs/heads/||')
-    finish_time=$(echo "$run_json" | jq -r '.finishTime')
-    
-    echo "Investigating failed run: $pipeline_name (ID: $run_id)"
-    
-    # Get commit details
+    finish_time=$(echo "$run_json" | jq -r '.finishTime // ""')
+    pipeline_reason=$(echo "$run_json" | jq -r '.reason // "Unknown"')
+    similar_count=$(echo "$run_json" | jq -r '.similar_failures_count // 1')
+
+    echo "Investigating failed run: $pipeline_name (Build ID: $run_id)"
+
+    # Get commit details (deep per-item work; capped above).
     if [ "$source_version" != "null" ] && [ -n "$source_version" ]; then
         echo "  Getting commit details for: $source_version"
         if commit_details=$(az repos commit show --commit-id "$source_version" --output json 2>commit_err.log); then
             commit_author=$(echo "$commit_details" | jq -r '.author.name')
             commit_message=$(echo "$commit_details" | jq -r '.comment')
             commit_date=$(echo "$commit_details" | jq -r '.author.date')
-            
-            # Get commit changes
             changes_count=$(echo "$commit_details" | jq -r '.changes | length')
             changed_files=$(echo "$commit_details" | jq -r '.changes[].item.path' | head -10 | tr '\n' ', ' | sed 's/,$//')
-            
-            echo "    Commit by: $commit_author"
-            echo "    Commit message: $commit_message"
-            echo "    Files changed: $changes_count ($changed_files)"
         else
-            err_msg=$(cat commit_err.log)
-            echo "    Warning: Could not get commit details: $err_msg"
+            echo "    Warning: Could not get commit details"
             commit_author="Unknown"
             commit_message="Could not retrieve commit details"
             commit_date="Unknown"
@@ -109,7 +130,7 @@ for ((i=0; i<failed_count; i++)); do
         changes_count=0
         changed_files="Unknown"
     fi
-    
+
     # Get recent commits on the same branch (last 5)
     echo "  Getting recent commit history on branch: $source_branch"
     if recent_commits=$(az repos commit list --branch "$source_branch" --top 5 --output json 2>recent_commits_err.log); then
@@ -119,28 +140,7 @@ for ((i=0; i<failed_count; i++)); do
         recent_commit_summary="Could not retrieve recent commits"
     fi
     rm -f recent_commits_err.log
-    
-    # Get pipeline logs for this specific failure
-    echo "  Getting pipeline logs for failed run..."
-    if pipeline_logs=$(az pipelines runs show --id "$run_id" --output json 2>pipeline_logs_err.log); then
-        pipeline_reason=$(echo "$pipeline_logs" | jq -r '.reason // "Unknown"')
-        pipeline_result=$(echo "$pipeline_logs" | jq -r '.result // "Unknown"')
-    else
-        pipeline_reason="Unknown"
-        pipeline_result="Unknown"
-    fi
-    rm -f pipeline_logs_err.log
-    
-    # Check for similar recent failures in the same pipeline
-    echo "  Checking for pattern of failures..."
-    pipeline_id=$(echo "$run_json" | jq -r '.definition.id')
-    if similar_failures=$(az pipelines runs list --pipeline-id "$pipeline_id" --query "[?result=='failed' && finishTime >= '$from_date']" --output json 2>similar_err.log); then
-        similar_count=$(echo "$similar_failures" | jq '. | length')
-    else
-        similar_count=0
-    fi
-    rm -f similar_err.log
-    
+
     # Build investigation summary
     investigation_json=$(echo "$investigation_json" | jq \
         --arg title "Pipeline Failure Investigation: $pipeline_name" \
@@ -172,14 +172,23 @@ for ((i=0; i<failed_count; i++)); do
            "similar_failures_count": ($similar_count | tonumber),
            "finish_time": $finish_time,
            "severity": ($severity | tonumber),
-           "details": "Pipeline \($pipeline_name) failed on branch \($source_branch). Last commit by \($commit_author): \($commit_message). Changed files: \($changed_files). \($changes_count) files changed total. \($similar_count) similar failures in last 24h. Trigger reason: \($pipeline_reason). Recent activity on branch: \($recent_commits)",
+           "details": "Pipeline \($pipeline_name) failed on branch \($source_branch). Last commit by \($commit_author): \($commit_message). Changed files: \($changed_files). \($changes_count) files changed total. \($similar_count) similar failures in window. Trigger reason: \($pipeline_reason). Recent activity on branch: \($recent_commits)",
            "next_steps": "Review the commit by \($commit_author) (\($commit_message)) on branch \($source_branch) that triggered this failure. Check the \($changes_count) changed files (\($changed_files)) for breaking changes. If \($similar_count) similar failures exist, investigate a systemic issue with the pipeline configuration or branch.",
            "investigation_summary": "Commit: \($commit_message) by \($commit_author). Files: \($changed_files). Recent activity: \($recent_commits)"
          }]')
 done
 
-# Clean up temporary files
-rm -f failed_runs.json
+# Note if more failures existed than we deep-investigated (report-only).
+if [ "$failed_count" -gt "$investigate_count" ]; then
+    investigation_json=$(echo "$investigation_json" | jq \
+        --arg title "Additional Failed Runs Not Correlated" \
+        --arg details "Found $failed_count failed builds in the last ${RW_LOOKBACK_WINDOW}; commit correlation ran for the $investigate_count most recent (MAX_FAILURES_TO_INVESTIGATE=$MAX_FAILURES_TO_INVESTIGATE)." \
+        --arg severity "4" \
+        --arg next_steps "Increase MAX_FAILURES_TO_INVESTIGATE if deeper correlation coverage is required." \
+        '. += [{"title": $title, "details": $details, "severity": ($severity | tonumber), "next_steps": $next_steps}]')
+fi
+
+rm -f failed_builds.json
 
 # Write final JSON
 echo "$investigation_json" > "$OUTPUT_FILE"
@@ -188,4 +197,4 @@ echo "Pipeline failure investigation completed. Results saved to $OUTPUT_FILE"
 # Output summary to stdout
 echo ""
 echo "=== INVESTIGATION SUMMARY ==="
-echo "$investigation_json" | jq -r '.[] | "Pipeline: \(.pipeline_name)\nAuthor: \(.commit_author)\nMessage: \(.commit_message)\nFiles Changed: \(.changes_count)\nSimilar Failures: \(.similar_failures_count)\n---"' 
+echo "$investigation_json" | jq -r '.[] | "Pipeline: \(.pipeline_name // .title)\nAuthor: \(.commit_author // "n/a")\nMessage: \(.commit_message // "n/a")\nFiles Changed: \(.changes_count // 0)\nSimilar Failures: \(.similar_failures_count // 0)\n---"'

--- a/codebundles/azure-devops-project-health/pipeline-logs.sh
+++ b/codebundles/azure-devops-project-health/pipeline-logs.sh
@@ -68,7 +68,7 @@ fi
 # first, and capped to MAX_FAILURES_TO_INVESTIGATE for the deep log fetch.
 echo "$build_count builds fetched. Deriving failed builds..."
 jq -c '
-    def parsedate: (sub("\\.[0-9]+";"") | sub("(Z|[+-][0-9][0-9]:?[0-9][0-9])$";"")) + "Z" | fromdateiso8601;
+    def parsedate: (sub("\\.[0-9]+";"") | sub("(Z|[+-][0-9][0-9]:?[0-9][0-9])$";"")) + "Z" | (try fromdateiso8601 catch null);
     [ .[] | select(.result == "failed") ]
     | sort_by(.finishTime // .queueTime // "") | reverse
 ' "$BUILDS_FILE" > failed_builds.json

--- a/codebundles/azure-devops-project-health/pipeline-logs.sh
+++ b/codebundles/azure-devops-project-health/pipeline-logs.sh
@@ -28,7 +28,7 @@ set -euo pipefail
 : "${RW_LOOKBACK_WINDOW:=24h}"
 : "${MAX_FAILURES_TO_INVESTIGATE:=10}"
 : "${AUTH_TYPE:=service_principal}"
-AZURE_DEVOPS_PAT="${AZURE_DEVOPS_PAT:-$azure_devops_pat}"
+AZURE_DEVOPS_PAT="${AZURE_DEVOPS_PAT:-${azure_devops_pat:-}}"
 export AZURE_DEVOPS_EXT_PAT="${AZURE_DEVOPS_PAT}"
 
 source "$(dirname "$0")/_az_helpers.sh"

--- a/codebundles/azure-devops-project-health/pipeline-logs.sh
+++ b/codebundles/azure-devops-project-health/pipeline-logs.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#set -euo pipefail
+set -euo pipefail
 # NOTE: `set -x` is intentionally NOT used (it leaks AZURE_DEVOPS_PAT into logs
 # and bloats output). Set AZ_DEBUG=1 to opt in to tracing for local debugging.
 [ "${AZ_DEBUG:-0}" = "1" ] && set -x
@@ -8,15 +8,25 @@
 #   AZURE_DEVOPS_ORG
 #   AZURE_DEVOPS_PROJECT
 #
+# OPTIONAL ENV VARS:
+#   RW_LOOKBACK_WINDOW            - window for failed builds (default 24h)
+#   MAX_FAILURES_TO_INVESTIGATE   - cap on the number of failed builds whose logs
+#                                   are fetched (deep per-item work; default 10)
 #
-# This script:
-#   1) Lists all pipelines in the specified Azure DevOps project
-#   2) Retrieves logs for each failed run
-#   3) Outputs results in JSON format
+# This script (Phase 0 single-pass refactor):
+#   1) Fetches the project's builds ONCE via the Build REST API (fetch_project_builds).
+#   2) Derives the failed builds from that single dataset with jq -- with NO
+#      per-pipeline `az pipelines runs list` calls (which timed out at 180s).
+#   3) Fetches LOGS only for the failed builds actually flagged, CAPPED to
+#      MAX_FAILURES_TO_INVESTIGATE (log fetching is genuine per-item work that
+#      cannot be bulk-fetched).
+#   4) Outputs results in JSON format.
 # -----------------------------------------------------------------------------
 
 : "${AZURE_DEVOPS_ORG:?Must set AZURE_DEVOPS_ORG}"
 : "${AZURE_DEVOPS_PROJECT:?Must set AZURE_DEVOPS_PROJECT}"
+: "${RW_LOOKBACK_WINDOW:=24h}"
+: "${MAX_FAILURES_TO_INVESTIGATE:=10}"
 : "${AUTH_TYPE:=service_principal}"
 AZURE_DEVOPS_PAT="${AZURE_DEVOPS_PAT:-$azure_devops_pat}"
 export AZURE_DEVOPS_EXT_PAT="${AZURE_DEVOPS_PAT}"
@@ -24,6 +34,7 @@ export AZURE_DEVOPS_EXT_PAT="${AZURE_DEVOPS_PAT}"
 source "$(dirname "$0")/_az_helpers.sh"
 
 OUTPUT_FILE="pipeline_logs_issues.json"
+BUILDS_FILE="builds_dataset.json"
 TEMP_LOG_FILE="pipeline_log_temp.json"
 issues_json='[]'
 
@@ -34,15 +45,15 @@ echo "Project:      $AZURE_DEVOPS_PROJECT"
 az devops configure --defaults project="$AZURE_DEVOPS_PROJECT" --output none
 setup_azure_auth
 
-# Get list of pipelines
-echo "Retrieving pipelines in project..."
-if ! az_with_retry az pipelines list --output json; then
-    echo "ERROR: Could not list pipelines."
+# Single-pass: fetch the project's builds ONCE (shared/cached across tasks).
+echo "Fetching project build dataset (single pass, window: ${RW_LOOKBACK_WINDOW})..."
+if ! build_count=$(fetch_project_builds "$AZURE_DEVOPS_PROJECT" "$BUILDS_FILE" "$RW_LOOKBACK_WINDOW"); then
+    echo "ERROR: Could not fetch builds for project."
     issues_json=$(echo "$issues_json" | jq \
-        --arg title "Failed to List Pipelines" \
-        --arg details "Azure DevOps API was unreachable or returned an error after $AZ_RETRY_COUNT retry attempts." \
+        --arg title "Failed to Fetch Builds" \
+        --arg details "The Build REST API was unreachable or returned an error while fetching the project build dataset." \
         --arg severity "3" \
-        --arg nextStep "Check if the project exists and you have the right permissions. Verify Azure DevOps API availability." \
+        --arg nextStep "Check if the project exists and you have Build (Read) permissions. Verify Azure DevOps API availability." \
         '. += [{
            "title": $title,
            "details": $details,
@@ -52,127 +63,44 @@ if ! az_with_retry az pipelines list --output json; then
     echo "$issues_json" > "$OUTPUT_FILE"
     exit 1
 fi
-pipelines="$AZ_RESULT"
 
-# Save pipelines to a file to avoid subshell issues
-echo "$pipelines" > pipelines.json
+# Derive failed builds from the single dataset (no per-pipeline calls). Newest
+# first, and capped to MAX_FAILURES_TO_INVESTIGATE for the deep log fetch.
+echo "$build_count builds fetched. Deriving failed builds..."
+jq -c '
+    def parsedate: (sub("\\.[0-9]+";"") | sub("(Z|[+-][0-9][0-9]:?[0-9][0-9])$";"")) + "Z" | fromdateiso8601;
+    [ .[] | select(.result == "failed") ]
+    | sort_by(.finishTime // .queueTime // "") | reverse
+' "$BUILDS_FILE" > failed_builds.json
+failed_count=$(jq 'length' failed_builds.json)
+echo "Found $failed_count failed builds in window (investigating up to $MAX_FAILURES_TO_INVESTIGATE)."
 
-# Get the number of pipelines
-pipeline_count=$(jq '. | length' pipelines.json)
+investigate_count=$failed_count
+if [ "$investigate_count" -gt "$MAX_FAILURES_TO_INVESTIGATE" ]; then
+    investigate_count=$MAX_FAILURES_TO_INVESTIGATE
+fi
 
-# Process each pipeline using a for loop instead of pipe to while
-for ((i=0; i<pipeline_count; i++)); do
-    pipeline_json=$(jq -c ".[${i}]" pipelines.json)
-    
-    # Extract values from JSON using jq
-    pipeline_id=$(echo "$pipeline_json" | jq -r '.id')
-    pipeline_name=$(echo "$pipeline_json" | jq -r '.name')
-    
-    echo "Processing Pipeline: $pipeline_name (ID: $pipeline_id)"
-    
-    # Get recent pipeline runs
-    if ! az_with_retry az pipelines runs list --pipeline-id "$pipeline_id" --output json; then
-        issues_json=$(echo "$issues_json" | jq \
-            --arg title "Failed to List Runs for Pipeline $pipeline_name" \
-            --arg details "Could not retrieve runs after $AZ_RETRY_COUNT attempts." \
-            --arg severity "3" \
-            --arg nextStep "Check if you have sufficient permissions to view pipeline runs. Verify Azure DevOps API availability." \
-            '. += [{
-               "title": $title,
-               "details": $details,
-               "next_steps": $nextStep,
-               "severity": ($severity | tonumber)
-             }]')
-        continue
-    fi
-    runs="$AZ_RESULT"
-    
-    # Save runs to a file to avoid subshell issues
-    echo "$runs" > runs.json
-    
-    # Get the number of runs
-    run_count=$(jq '. | length' runs.json)
-    
-    # Check for failed runs
-    for ((j=0; j<run_count; j++)); do
-        run_json=$(jq -c ".[${j}]" runs.json)
-        
-        # Check if run is failed
-        run_result=$(echo "$run_json" | jq -r '.result')
-        if [[ "$run_result" != "failed" ]]; then
-            continue
-        fi
-        
-        run_id=$(echo "$run_json" | jq -r '.id')
-        run_name=$(echo "$run_json" | jq -r '.name // "Run #\(.id)"')
-        web_url=$(echo "$run_json" | jq -r '.url')
-        branch=$(echo "$run_json" | jq -r '.sourceBranch // "unknown"' | sed 's|refs/heads/||')
-        
-        # Extract project ID from web_url
-        project_id=$(echo "$web_url" | grep -o '/[^/]*/[^/]*/_apis' | cut -d'/' -f2)
-        
-        echo "  Checking failed run: $run_name (ID: $run_id, Branch: $branch)"
-        
-        # Get all logs for the run using the new API
-        if ! all_logs=$(az devops invoke --org "https://dev.azure.com/$AZURE_DEVOPS_ORG" --area pipelines --resource logs --route-parameters project="$AZURE_DEVOPS_PROJECT" pipelineId="$pipeline_id" runId="$run_id" --api-version=7.0 --output json 2>logs_err.log); then
-            err_msg=$(cat logs_err.log)
-            rm -f logs_err.log
-            
-            issues_json=$(echo "$issues_json" | jq \
-                --arg title "Failed to Get Logs for Run $run_name in Pipeline $pipeline_name" \
-                --arg details "$err_msg" \
-                --arg severity "3" \
-                --arg nextStep "Check if you have sufficient permissions to view pipeline logs." \
-                --arg resource_url "$web_url" \
-                '. += [{
-                   "title": $title,
-                   "details": $details,
-                   "next_steps": $nextStep,
-                   "severity": ($severity | tonumber),
-                   "resource_url": $resource_url
-                 }]')
-            continue
-        fi
+for ((i=0; i<investigate_count; i++)); do
+    run_json=$(jq -c ".[${i}]" failed_builds.json)
+
+    run_id=$(echo "$run_json" | jq -r '.id')
+    pipeline_id=$(echo "$run_json" | jq -r '.definition.id')
+    pipeline_name=$(echo "$run_json" | jq -r '.definition.name // .buildNumber // "Unknown Pipeline"')
+    web_url=$(echo "$run_json" | jq -r '._links.web.href // .url // ""')
+    branch=$(echo "$run_json" | jq -r '.sourceBranch // "unknown"' | sed 's|refs/heads/||')
+
+    echo "  Investigating failed build: $pipeline_name (Build ID: $run_id, Branch: $branch)"
+
+    # Get all logs for the run (deep per-item work; capped above).
+    if ! all_logs=$(az devops invoke --org "https://dev.azure.com/$AZURE_DEVOPS_ORG" --area build --resource logs --route-parameters project="$AZURE_DEVOPS_PROJECT" buildId="$run_id" --api-version=7.0 --output json 2>logs_err.log); then
+        err_msg=$(cat logs_err.log)
         rm -f logs_err.log
-        
-        # Save all logs to a file for processing
-        echo "$all_logs" > all_logs.json
-        
-        # Get log with highest line count
-        if ! log_info=$(jq -c '.logs[] | {id: .id, lineCount: .lineCount}' all_logs.json | sort -r -k2,2 | head -1); then
-            echo "Failed to find logs with line count information"
-            continue
-        fi
-        
-        # Extract log ID with highest line count
-        log_id=$(echo "$log_info" | jq -r '.id')
-        echo "    Selected log ID with highest line count: $log_id"
-        
-        # Get detailed log content for the selected log
-        if ! log_content=$(az devops invoke --org "https://dev.azure.com/$AZURE_DEVOPS_ORG" --area build --resource logs --route-parameters project="$AZURE_DEVOPS_PROJECT" buildId="$run_id" logId="$log_id" --api-version=7.0 --output json --only-show-errors 2>log_content_err.log); then
-            echo "      Failed to get log content for log ID $log_id, skipping..."
-            continue
-        fi
-        
-        # Save log content to temp file for processing
-        echo "$log_content" > "$TEMP_LOG_FILE"
-        
-        # Extract all log lines and join them with newlines
-        log_details=$(jq -r '.value | join("\n")' "$TEMP_LOG_FILE")
-        
-        # Construct the correct log URL format
-        error_log_url="https://dev.azure.com/$AZURE_DEVOPS_ORG/$project_id/_apis/build/builds/$run_id/logs/$log_id"
-        
-        # Clean up temp files
-        rm -f "$TEMP_LOG_FILE" all_logs.json
-        
-        # Add an issue with the full log content
         issues_json=$(echo "$issues_json" | jq \
-            --arg title "Failed Pipeline Run: \`$pipeline_name\` (Branch: \`$branch\`)" \
-            --arg details "$log_details" \
+            --arg title "Failed to Get Logs for Run $run_id in Pipeline $pipeline_name" \
+            --arg details "$err_msg" \
             --arg severity "3" \
-            --arg nextStep "Review pipeline configuration for \`$pipeline_name\` in project \`$AZURE_DEVOPS_PROJECT\`. Check branch \`$branch\` for recent changes that might have caused the failure." \
-            --arg resource_url "$error_log_url" \
+            --arg nextStep "Check if you have sufficient permissions to view pipeline logs." \
+            --arg resource_url "$web_url" \
             '. += [{
                "title": $title,
                "details": $details,
@@ -180,14 +108,73 @@ for ((i=0; i<pipeline_count; i++)); do
                "severity": ($severity | tonumber),
                "resource_url": $resource_url
              }]')
-    done
-    
-    # Clean up runs file
-    rm -f runs.json
+        continue
+    fi
+    rm -f logs_err.log
+
+    echo "$all_logs" > all_logs.json
+
+    # Get log with highest line count
+    if ! log_info=$(jq -c '(.value // .logs // [])[] | {id: .id, lineCount: .lineCount}' all_logs.json | sort -r -k2,2 | head -1); then
+        echo "    Failed to find logs with line count information"
+        rm -f all_logs.json
+        continue
+    fi
+    log_id=$(echo "$log_info" | jq -r '.id')
+    if [ -z "$log_id" ] || [ "$log_id" = "null" ]; then
+        echo "    No log id available for build $run_id, skipping..."
+        rm -f all_logs.json
+        continue
+    fi
+    echo "    Selected log ID with highest line count: $log_id"
+
+    # Get detailed log content for the selected log
+    if ! log_content=$(az devops invoke --org "https://dev.azure.com/$AZURE_DEVOPS_ORG" --area build --resource logs --route-parameters project="$AZURE_DEVOPS_PROJECT" buildId="$run_id" logId="$log_id" --api-version=7.0 --output json --only-show-errors 2>log_content_err.log); then
+        echo "      Failed to get log content for log ID $log_id, skipping..."
+        rm -f all_logs.json log_content_err.log
+        continue
+    fi
+    rm -f log_content_err.log
+
+    echo "$log_content" > "$TEMP_LOG_FILE"
+    log_details=$(jq -r '.value | join("\n")' "$TEMP_LOG_FILE")
+
+    PROJ_ENC=$(ado_urlencode "$AZURE_DEVOPS_PROJECT")
+    error_log_url="https://dev.azure.com/$AZURE_DEVOPS_ORG/$PROJ_ENC/_apis/build/builds/$run_id/logs/$log_id"
+
+    rm -f "$TEMP_LOG_FILE" all_logs.json
+
+    issues_json=$(echo "$issues_json" | jq \
+        --arg title "Failed Pipeline Run: \`$pipeline_name\` (Branch: \`$branch\`)" \
+        --arg details "$log_details" \
+        --arg severity "3" \
+        --arg nextStep "Review pipeline configuration for \`$pipeline_name\` in project \`$AZURE_DEVOPS_PROJECT\`. Check branch \`$branch\` for recent changes that might have caused the failure." \
+        --arg resource_url "$error_log_url" \
+        '. += [{
+           "title": $title,
+           "details": $details,
+           "next_steps": $nextStep,
+           "severity": ($severity | tonumber),
+           "resource_url": $resource_url
+         }]')
 done
 
-# Clean up pipelines file
-rm -f pipelines.json
+# If there were more failures than we investigated, note the cap (report-only).
+if [ "$failed_count" -gt "$investigate_count" ]; then
+    issues_json=$(echo "$issues_json" | jq \
+        --arg title "Additional Failed Pipeline Runs Not Investigated" \
+        --arg details "Found $failed_count failed builds in the last ${RW_LOOKBACK_WINDOW}; logs were fetched for the $investigate_count most recent (MAX_FAILURES_TO_INVESTIGATE=$MAX_FAILURES_TO_INVESTIGATE). Raise MAX_FAILURES_TO_INVESTIGATE to investigate more." \
+        --arg severity "4" \
+        --arg nextStep "Review the most recent failures first. Increase MAX_FAILURES_TO_INVESTIGATE if deeper coverage is required." \
+        '. += [{
+           "title": $title,
+           "details": $details,
+           "next_steps": $nextStep,
+           "severity": ($severity | tonumber)
+         }]')
+fi
+
+rm -f failed_builds.json
 
 # Write final JSON
 echo "$issues_json" > "$OUTPUT_FILE"

--- a/codebundles/azure-devops-project-health/pipeline-performance-analysis.sh
+++ b/codebundles/azure-devops-project-health/pipeline-performance-analysis.sh
@@ -73,7 +73,7 @@ echo "Fetched $build_count builds. Deriving per-definition performance..."
 analysis_json=$(jq \
     --arg project "$AZURE_DEVOPS_PROJECT" \
     --arg window "$RW_LOOKBACK_WINDOW" '
-    def parsedate: (sub("\\.[0-9]+";"") | sub("(Z|[+-][0-9][0-9]:?[0-9][0-9])$";"")) + "Z" | fromdateiso8601;
+    def parsedate: (sub("\\.[0-9]+";"") | sub("(Z|[+-][0-9][0-9]:?[0-9][0-9])$";"")) + "Z" | (try fromdateiso8601 catch null);
     def stats(a):
       (a | length) as $n
       | if $n == 0 then null
@@ -91,9 +91,11 @@ analysis_json=$(jq \
       | [ .[] | select(.result == "succeeded") ] as $succ
       | ($succ | length) as $succ_n
       | stats([ $succ[] | select(.startTime != null and .finishTime != null)
-                | ((.finishTime | parsedate) - (.startTime | parsedate)) ]) as $dur
+                | (.startTime | parsedate) as $st | (.finishTime | parsedate) as $ft
+                | select($st != null and $ft != null) | ($ft - $st) ]) as $dur
       | stats([ $succ[] | select(.queueTime != null and .startTime != null)
-                | ((.startTime | parsedate) - (.queueTime | parsedate)) ]) as $q
+                | (.queueTime | parsedate) as $qt | (.startTime | parsedate) as $st
+                | select($qt != null and $st != null) | ($st - $qt) ]) as $q
       | ($dur.avg // 0) as $avg_d | ($dur.min // 0) as $min_d | ($dur.max // 0) as $max_d | ($dur.median // 0) as $med_d
       | ($q.avg // 0) as $avg_q | ($q.max // 0) as $max_q
       | (if $total > 0 then (($succ_n * 1000 / $total | floor) / 10) else 0 end) as $success_rate

--- a/codebundles/azure-devops-project-health/pipeline-performance-analysis.sh
+++ b/codebundles/azure-devops-project-health/pipeline-performance-analysis.sh
@@ -8,15 +8,23 @@ set -euo pipefail
 #   AZURE_DEVOPS_ORG
 #   AZURE_DEVOPS_PROJECT
 #
-# This script:
-#   1) Analyzes pipeline performance trends
-#   2) Identifies performance bottlenecks
-#   3) Compares current vs historical performance
-#   4) Provides optimization recommendations
+# OPTIONAL ENV VARS:
+#   RW_LOOKBACK_WINDOW   - window for performance trend analysis (default 24h;
+#                          the deep runbook typically sets 30d)
+#
+# This script (Phase 0 single-pass refactor):
+#   1) Fetches the project's builds ONCE via the Build REST API (fetch_project_builds).
+#   2) Derives per-definition performance (duration avg/min/max/median, queue
+#      times, success rate) with a SINGLE jq group_by(.definition.id) pass --
+#      with NO per-pipeline API calls (previously it issued TWO
+#      `az pipelines runs list --pipeline-id <id>` calls per pipeline, which
+#      regressed into a 180s timeout).
+#   3) Outputs results in JSON format.
 # -----------------------------------------------------------------------------
 
 : "${AZURE_DEVOPS_ORG:?Must set AZURE_DEVOPS_ORG}"
 : "${AZURE_DEVOPS_PROJECT:?Must set AZURE_DEVOPS_PROJECT}"
+: "${RW_LOOKBACK_WINDOW:=24h}"
 : "${AUTH_TYPE:=service_principal}"
 AZURE_DEVOPS_PAT="${AZURE_DEVOPS_PAT:-$azure_devops_pat}"
 export AZURE_DEVOPS_EXT_PAT="${AZURE_DEVOPS_PAT}"
@@ -24,6 +32,7 @@ export AZURE_DEVOPS_EXT_PAT="${AZURE_DEVOPS_PAT}"
 source "$(dirname "$0")/_az_helpers.sh"
 
 OUTPUT_FILE="pipeline_performance_analysis.json"
+BUILDS_FILE="builds_dataset.json"
 analysis_json='[]'
 
 echo "Pipeline Performance Analysis..."
@@ -33,253 +42,98 @@ echo "Project:      $AZURE_DEVOPS_PROJECT"
 az devops configure --defaults project="$AZURE_DEVOPS_PROJECT" --output none
 setup_azure_auth
 
-# Get list of pipelines
-echo "Getting pipelines in project..."
-if ! az_with_retry az pipelines list --output json; then
-    echo "ERROR: Could not list pipelines."
+# Single-pass: fetch the project's builds ONCE (shared/cached across tasks).
+echo "Fetching project build dataset (single pass, window: ${RW_LOOKBACK_WINDOW})..."
+if ! build_count=$(fetch_project_builds "$AZURE_DEVOPS_PROJECT" "$BUILDS_FILE" "$RW_LOOKBACK_WINDOW"); then
+    echo "ERROR: Could not fetch builds for project."
     analysis_json=$(echo "$analysis_json" | jq \
-        --arg title "Failed to List Pipelines" \
-        --arg details "Azure DevOps API was unreachable or returned an error after $AZ_RETRY_COUNT retry attempts." \
+        --arg title "Failed to Fetch Builds" \
+        --arg details "The Build REST API was unreachable or returned an error while fetching the project build dataset." \
         --arg severity "3" \
         '. += [{
            "title": $title,
            "details": $details,
-           "severity": ($severity | tonumber)
+           "severity": ($severity | tonumber),
+           "next_steps": "Verify Build API access for this project, check network connectivity to dev.azure.com, and confirm the lookback window is appropriate."
         }]')
     echo "$analysis_json" > "$OUTPUT_FILE"
     exit 1
 fi
-pipelines="$AZ_RESULT"
 
-echo "$pipelines" > pipelines.json
-pipeline_count=$(jq '. | length' pipelines.json)
-
-if [ "$pipeline_count" -eq 0 ]; then
-    echo "No pipelines found in project."
-    analysis_json='[{"title": "No Pipelines Found", "details": "No pipelines found in the project", "severity": 2}]'
+if [ "$build_count" -eq 0 ]; then
+    echo "No builds found in window for project."
+    analysis_json='[{"title": "No Pipeline Activity Found", "details": "No builds found in the lookback window for the project", "severity": 2, "next_steps": "Confirm pipelines have run recently or widen RW_LOOKBACK_WINDOW for the runbook; no action required if the project is idle."}]'
     echo "$analysis_json" > "$OUTPUT_FILE"
     exit 0
 fi
 
-echo "Found $pipeline_count pipelines. Analyzing performance..."
+echo "Fetched $build_count builds. Deriving per-definition performance..."
 
-# Analyze each pipeline
-for ((i=0; i<pipeline_count; i++)); do
-    pipeline_json=$(jq -c ".[${i}]" pipelines.json)
-    
-    pipeline_id=$(echo "$pipeline_json" | jq -r '.id')
-    pipeline_name=$(echo "$pipeline_json" | jq -r '.name')
-    
-    echo "Analyzing pipeline: $pipeline_name (ID: $pipeline_id)"
-    
-    # Get recent successful runs (last 30 days)
-    from_date=$(date -d "30 days ago" -u +"%Y-%m-%dT%H:%M:%SZ")
-    echo "  Getting recent successful runs..."
-    
-    if recent_runs=$(az pipelines runs list --pipeline-id "$pipeline_id" --query "[?result=='succeeded' && finishTime >= '$from_date']" --output json 2>runs_err.log); then
-        run_count=$(echo "$recent_runs" | jq '. | length')
-        
-        if [ "$run_count" -gt 0 ]; then
-            echo "    Found $run_count successful runs for analysis"
-            
-            # Calculate performance metrics
-            echo "    Calculating performance metrics..."
-            
-            # Extract durations (in seconds)
-            # ADO timestamps carry fractional seconds and a numeric UTC offset
-            # (e.g. 2026-05-29T10:04:46.231362+00:00), which jq's fromdateiso8601
-            # (%Y-%m-%dT%H:%M:%SZ) cannot parse. Normalise to ...Z first. Durations
-            # are deltas of same-offset timestamps, so dropping the offset is safe.
-            durations=$(echo "$recent_runs" | jq -r '
-                def parsedate: (sub("\\.[0-9]+";"") | sub("(Z|[+-][0-9][0-9]:?[0-9][0-9])$";"")) + "Z" | fromdateiso8601;
-                .[] | select(.startTime != null and .finishTime != null)
-                | ((.finishTime | parsedate) - (.startTime | parsedate))')
-            
-            if [ -n "$durations" ] && [ "$(echo "$durations" | wc -l)" -gt 0 ]; then
-                # Calculate statistics
-                avg_duration=$(echo "$durations" | awk '{sum+=$1} END {print sum/NR}' | xargs printf "%.0f")
-                min_duration=$(echo "$durations" | sort -n | head -1 | xargs printf "%.0f")
-                max_duration=$(echo "$durations" | sort -n | tail -1 | xargs printf "%.0f")
-                
-                # Calculate median
-                sorted_durations=$(echo "$durations" | sort -n)
-                median_duration=$(echo "$sorted_durations" | awk '{a[NR]=$1} END {print (NR%2==1) ? a[(NR+1)/2] : (a[NR/2]+a[NR/2+1])/2}' | xargs printf "%.0f")
-                
-                # Convert to human readable format
-                avg_duration_min=$((avg_duration / 60))
-                min_duration_min=$((min_duration / 60))
-                max_duration_min=$((max_duration / 60))
-                median_duration_min=$((median_duration / 60))
-                
-                echo "      Average: ${avg_duration_min}m, Min: ${min_duration_min}m, Max: ${max_duration_min}m, Median: ${median_duration_min}m"
-                
-                # Check for performance issues
-                performance_issues=()
-                severity=1
-                
-                # Check for high variability (max > 3x min)
-                if [ "$max_duration" -gt $((min_duration * 3)) ] && [ "$min_duration" -gt 60 ]; then
-                    performance_issues+=("High duration variability: ${min_duration_min}m to ${max_duration_min}m")
-                    severity=2
-                fi
-                
-                # Check for long average duration (>30 minutes)
-                if [ "$avg_duration" -gt 1800 ]; then
-                    performance_issues+=("Long average duration: ${avg_duration_min} minutes")
-                    severity=2
-                fi
-                
-                # Check for very long maximum duration (>2 hours)
-                if [ "$max_duration" -gt 7200 ]; then
-                    performance_issues+=("Very long maximum duration: ${max_duration_min} minutes")
-                    severity=3
-                fi
-                
-                # Get queue time analysis
-                echo "    Analyzing queue times..."
-                queue_times=$(echo "$recent_runs" | jq -r '
-                    def parsedate: (sub("\\.[0-9]+";"") | sub("(Z|[+-][0-9][0-9]:?[0-9][0-9])$";"")) + "Z" | fromdateiso8601;
-                    .[] | select(.queueTime != null and .startTime != null)
-                    | ((.startTime | parsedate) - (.queueTime | parsedate))')
-                
-                if [ -n "$queue_times" ] && [ "$(echo "$queue_times" | wc -l)" -gt 0 ]; then
-                    avg_queue_time=$(echo "$queue_times" | awk '{sum+=$1} END {print sum/NR}' | xargs printf "%.0f")
-                    max_queue_time=$(echo "$queue_times" | sort -n | tail -1 | xargs printf "%.0f")
-                    
-                    avg_queue_time_min=$((avg_queue_time / 60))
-                    max_queue_time_min=$((max_queue_time / 60))
-                    
-                    echo "      Average queue time: ${avg_queue_time_min}m, Max: ${max_queue_time_min}m"
-                    
-                    # Check for long queue times
-                    if [ "$avg_queue_time" -gt 300 ]; then  # 5 minutes
-                        performance_issues+=("Long average queue time: ${avg_queue_time_min} minutes")
-                        severity=2
-                    fi
-                    
-                    if [ "$max_queue_time" -gt 1800 ]; then  # 30 minutes
-                        performance_issues+=("Very long maximum queue time: ${max_queue_time_min} minutes")
-                        severity=3
-                    fi
-                else
-                    avg_queue_time=0
-                    max_queue_time=0
-                    avg_queue_time_min=0
-                    max_queue_time_min=0
-                fi
-                
-                # Analyze success rate
-                echo "    Analyzing success rate..."
-                all_runs=$(az pipelines runs list --pipeline-id "$pipeline_id" --query "[?finishTime >= '$from_date']" --output json 2>/dev/null || echo '[]')
-                total_runs=$(echo "$all_runs" | jq '. | length')
-                
-                if [ "$total_runs" -gt 0 ]; then
-                    success_rate=$(echo "scale=1; $run_count * 100 / $total_runs" | bc -l 2>/dev/null || echo "0")
-                    echo "      Success rate: ${success_rate}% ($run_count/$total_runs)"
-                    
-                    # Check for low success rate
-                    if (( $(echo "$success_rate < 80" | bc -l) )); then
-                        performance_issues+=("Low success rate: ${success_rate}%")
-                        severity=3
-                    fi
-                else
-                    success_rate="0"
-                fi
-                
-                # Build performance summary
-                if [ ${#performance_issues[@]} -eq 0 ]; then
-                    issues_summary="Performance appears normal"
-                    title="Pipeline Performance: $pipeline_name - Normal"
-                else
-                    issues_summary=$(IFS='; '; echo "${performance_issues[*]}")
-                    title="Pipeline Performance: $pipeline_name - Issues Found"
-                fi
-                
-            else
-                echo "      No valid duration data found"
-                avg_duration=0
-                min_duration=0
-                max_duration=0
-                median_duration=0
-                avg_queue_time=0
-                max_queue_time=0
-                success_rate="0"
-                issues_summary="No performance data available"
-                title="Pipeline Performance: $pipeline_name - No Data"
-                severity=2
-            fi
+# Derive per-definition performance from the single dataset in one jq pass.
+analysis_json=$(jq \
+    --arg project "$AZURE_DEVOPS_PROJECT" \
+    --arg window "$RW_LOOKBACK_WINDOW" '
+    def parsedate: (sub("\\.[0-9]+";"") | sub("(Z|[+-][0-9][0-9]:?[0-9][0-9])$";"")) + "Z" | fromdateiso8601;
+    def stats(a):
+      (a | length) as $n
+      | if $n == 0 then null
         else
-            echo "    No successful runs found in the last 30 days"
-            avg_duration=0
-            min_duration=0
-            max_duration=0
-            median_duration=0
-            avg_queue_time=0
-            max_queue_time=0
-            success_rate="0"
-            issues_summary="No successful runs in last 30 days"
-            title="Pipeline Performance: $pipeline_name - No Recent Success"
-            severity=3
-        fi
-    else
-        echo "    Warning: Could not get pipeline runs"
-        run_count=0
-        avg_duration=0
-        min_duration=0
-        max_duration=0
-        median_duration=0
-        avg_queue_time=0
-        max_queue_time=0
-        success_rate="0"
-        issues_summary="Could not retrieve performance data"
-        title="Pipeline Performance: $pipeline_name - Data Unavailable"
-        severity=2
-    fi
-    rm -f runs_err.log
-    
-    # Build next_steps based on issues found
-    next_steps_text="No action required - pipeline performance is within acceptable parameters."
-    if [ "$severity" -gt 1 ]; then
-        next_steps_text="Review pipeline \`$pipeline_name\` performance: $issues_summary. Consider optimizing slow stages, adding caching, parallelizing tasks, or scaling agent pools to improve throughput."
-    fi
+          (a | add / $n) as $avg | (a | min) as $mn | (a | max) as $mx
+          | (a | sort) as $s
+          | (if ($n % 2) == 1 then $s[($n-1)/2] else (($s[$n/2-1] + $s[$n/2]) / 2) end) as $med
+          | {n: $n, avg: ($avg|floor), min: ($mn|floor), max: ($mx|floor), median: ($med|floor)}
+        end;
 
-    # Add to analysis results
-    analysis_json=$(echo "$analysis_json" | jq \
-        --arg title "$title" \
-        --arg pipeline_name "$pipeline_name" \
-        --arg pipeline_id "$pipeline_id" \
-        --arg run_count "$run_count" \
-        --arg avg_duration "$avg_duration" \
-        --arg min_duration "$min_duration" \
-        --arg max_duration "$max_duration" \
-        --arg median_duration "$median_duration" \
-        --arg avg_queue_time "$avg_queue_time" \
-        --arg max_queue_time "$max_queue_time" \
-        --arg success_rate "$success_rate" \
-        --arg issues_summary "$issues_summary" \
-        --arg severity "$severity" \
-        --arg next_steps "$next_steps_text" \
-        '. += [{
-           "title": $title,
-           "pipeline_name": $pipeline_name,
-           "pipeline_id": $pipeline_id,
-           "successful_runs": ($run_count | tonumber),
-           "avg_duration_seconds": ($avg_duration | tonumber),
-           "min_duration_seconds": ($min_duration | tonumber),
-           "max_duration_seconds": ($max_duration | tonumber),
-           "median_duration_seconds": ($median_duration | tonumber),
-           "avg_queue_time_seconds": ($avg_queue_time | tonumber),
-           "max_queue_time_seconds": ($max_queue_time | tonumber),
-           "success_rate_percent": $success_rate,
-           "issues_summary": $issues_summary,
-           "severity": ($severity | tonumber),
-           "next_steps": $next_steps,
-           "details": "Pipeline \($pipeline_name): \($run_count) successful runs, avg duration \(($avg_duration | tonumber) / 60)m, success rate \($success_rate)%. Issues: \($issues_summary)"
-         }]')
-done
-
-# Clean up temporary files
-rm -f pipelines.json
+    [ group_by(.definition.id)[]
+      | (.[0].definition.id // "unknown") as $pid
+      | (.[0].definition.name // "Unknown Pipeline") as $pname
+      | length as $total
+      | [ .[] | select(.result == "succeeded") ] as $succ
+      | ($succ | length) as $succ_n
+      | stats([ $succ[] | select(.startTime != null and .finishTime != null)
+                | ((.finishTime | parsedate) - (.startTime | parsedate)) ]) as $dur
+      | stats([ $succ[] | select(.queueTime != null and .startTime != null)
+                | ((.startTime | parsedate) - (.queueTime | parsedate)) ]) as $q
+      | ($dur.avg // 0) as $avg_d | ($dur.min // 0) as $min_d | ($dur.max // 0) as $max_d | ($dur.median // 0) as $med_d
+      | ($q.avg // 0) as $avg_q | ($q.max // 0) as $max_q
+      | (if $total > 0 then (($succ_n * 1000 / $total | floor) / 10) else 0 end) as $success_rate
+      # Build the list of performance findings + the worst (highest-number, i.e.
+      # most escalated in this script local 1..3 scale) severity among them.
+      | ([ ( if ($max_d > ($min_d * 3) and $min_d > 60) then {m:"High duration variability: \($min_d/60|floor)m to \($max_d/60|floor)m", s:2} else empty end ),
+           ( if $avg_d > 1800 then {m:"Long average duration: \($avg_d/60|floor) minutes", s:2} else empty end ),
+           ( if $max_d > 7200 then {m:"Very long maximum duration: \($max_d/60|floor) minutes", s:3} else empty end ),
+           ( if $avg_q > 300  then {m:"Long average queue time: \($avg_q/60|floor) minutes", s:2} else empty end ),
+           ( if $max_q > 1800 then {m:"Very long maximum queue time: \($max_q/60|floor) minutes", s:3} else empty end ),
+           ( if ($total > 0 and $success_rate < 80) then {m:"Low success rate: \($success_rate)%", s:3} else empty end ),
+           ( if $succ_n == 0 then {m:"No successful runs in window", s:3} else empty end )
+         ]) as $findings
+      | (if ($findings | length) == 0 then 1 else ([ $findings[].s ] | max) end) as $severity
+      | (if ($findings | length) == 0 then "Performance appears normal"
+         else ([ $findings[].m ] | join("; ")) end) as $issues_summary
+      | (if $severity > 1
+         then "Pipeline Performance: \($pname) - Issues Found"
+         else "Pipeline Performance: \($pname) - Normal" end) as $title
+      | {
+          title: $title,
+          pipeline_name: $pname,
+          pipeline_id: ($pid | tostring),
+          successful_runs: $succ_n,
+          total_runs: $total,
+          avg_duration_seconds: $avg_d,
+          min_duration_seconds: $min_d,
+          max_duration_seconds: $max_d,
+          median_duration_seconds: $med_d,
+          avg_queue_time_seconds: $avg_q,
+          max_queue_time_seconds: $max_q,
+          success_rate_percent: ($success_rate | tostring),
+          issues_summary: $issues_summary,
+          severity: $severity,
+          next_steps: (if $severity > 1
+            then "Review pipeline `\($pname)` performance: \($issues_summary). Consider optimizing slow stages, adding caching, parallelizing tasks, or scaling agent pools to improve throughput."
+            else "No action required - pipeline performance is within acceptable parameters." end),
+          details: "Pipeline \($pname): \($succ_n) successful of \($total) runs in \($window), avg duration \($avg_d/60|floor)m, success rate \($success_rate)%. Issues: \($issues_summary)"
+        } ]
+    ' "$BUILDS_FILE")
 
 # Write final JSON
 echo "$analysis_json" > "$OUTPUT_FILE"
@@ -288,4 +142,4 @@ echo "Pipeline performance analysis completed. Results saved to $OUTPUT_FILE"
 # Output summary to stdout
 echo ""
 echo "=== PIPELINE PERFORMANCE SUMMARY ==="
-echo "$analysis_json" | jq -r '.[] | "Pipeline: \(.pipeline_name)\nRuns: \(.successful_runs), Avg Duration: \((.avg_duration_seconds / 60) | floor)m\nSuccess Rate: \(.success_rate_percent)%\nIssues: \(.issues_summary)\n---"' 
+echo "$analysis_json" | jq -r '.[] | "Pipeline: \(.pipeline_name)\nRuns: \(.successful_runs)/\(.total_runs), Avg Duration: \((.avg_duration_seconds / 60) | floor)m\nSuccess Rate: \(.success_rate_percent)%\nIssues: \(.issues_summary)\n---"'

--- a/codebundles/azure-devops-project-health/pipeline-performance-analysis.sh
+++ b/codebundles/azure-devops-project-health/pipeline-performance-analysis.sh
@@ -26,7 +26,7 @@ set -euo pipefail
 : "${AZURE_DEVOPS_PROJECT:?Must set AZURE_DEVOPS_PROJECT}"
 : "${RW_LOOKBACK_WINDOW:=24h}"
 : "${AUTH_TYPE:=service_principal}"
-AZURE_DEVOPS_PAT="${AZURE_DEVOPS_PAT:-$azure_devops_pat}"
+AZURE_DEVOPS_PAT="${AZURE_DEVOPS_PAT:-${azure_devops_pat:-}}"
 export AZURE_DEVOPS_EXT_PAT="${AZURE_DEVOPS_PAT}"
 
 source "$(dirname "$0")/_az_helpers.sh"

--- a/codebundles/azure-devops-project-health/preflight-check.sh
+++ b/codebundles/azure-devops-project-health/preflight-check.sh
@@ -49,20 +49,26 @@ blocking=0
 #   $2 = required PAT scope
 #   $3 = required Azure DevOps role
 #   $4 = "core" or "optional" (core failures block the run)
-#   $5.. = the command to run
+#   $5 = REST endpoint actually exercised (for the report, e.g. "GET /_apis/projects")
+#   $6.. = the command to run
 probe() {
-    local name="$1" scope="$2" role="$3" tier="$4"; shift 4
-    local err status detail
+    local name="$1" scope="$2" role="$3" tier="$4" endpoint="$5"; shift 5
+    local err status detail http_status=""
     err=$("$@" 2>&1 >/dev/null)
     local rc=$?
 
     if [ $rc -eq 0 ]; then
         status="OK"; detail="Accessible."
-        echo "  [OK]     $name"
+        printf '  [OK]      %-42s %s\n' "$name" "$endpoint"
     else
         local lc; lc=$(echo "$err" | tr '[:upper:]' '[:lower:]')
+        # Extract a concrete HTTP status when present so the report can say
+        # exactly what the API returned. Prefer the numeric HTTP code; any
+        # TF###### code stays visible in the captured detail string below.
+        http_status=$(printf '%s' "$err" | grep -oiE '\b(401|403|404|409|429|500|502|503)\b' | head -n1)
         if echo "$lc" | grep -Eq 'denied|not authorized|forbidden|do not have|tf400813|403|unauthorized|401'; then
             status="DENIED"
+            [ -z "$http_status" ] && http_status="403"
         elif echo "$lc" | grep -Eq 'timed out|timeout|could not resolve|connection|network|unreachable'; then
             status="NETWORK"
         else
@@ -70,13 +76,16 @@ probe() {
         fi
         detail=$(echo "$err" | head -c 300 | tr '\n' ' ')
         [ "$tier" = "core" ] && blocking=$((blocking + 1))
-        echo "  [$status] $name -> needs PAT scope '$scope' / role '$role'"
+        local httptxt=""; [ -n "$http_status" ] && httptxt=" (HTTP ${http_status})"
+        printf '  [%-7s] %-42s %s%s\n' "$status" "$name" "$endpoint" "$httptxt"
+        printf '            -> needs PAT scope %s / role %s\n' "$scope" "$role"
     fi
 
     capabilities=$(echo "$capabilities" | jq \
         --arg name "$name" --arg scope "$scope" --arg role "$role" \
         --arg tier "$tier" --arg status "$status" --arg detail "$detail" \
-        '. += [{capability:$name, status:$status, tier:$tier, required_pat_scope:$scope, required_role:$role, detail:$detail}]')
+        --arg endpoint "$endpoint" --arg http "$http_status" \
+        '. += [{capability:$name, status:$status, tier:$tier, required_pat_scope:$scope, required_role:$role, endpoint:$endpoint, http_status:$http, detail:$detail}]')
 }
 
 # =========================================================================
@@ -101,23 +110,28 @@ echo ""
 echo "=== Capability Probes ==="
 probe "Projects (read)" "vso.project (Project and Team: Read)" \
     "Project-level Reader (or member of Project Valid Users)" "core" \
+    "GET /_apis/projects" \
     az devops project list --org "$ORG_URL" --top 1 --output json
 
 probe "Agent Pools (read)" "vso.agentpools (Agent Pools: Read)" \
     "Reader on Organization Settings > Agent pools" "core" \
+    "GET /_apis/distributedtask/pools" \
     az pipelines pool list --org "$ORG_URL" --output json
 
 if [ -n "$PRIMARY_PROJECT" ]; then
     probe "Pipelines/Builds (read) [$PRIMARY_PROJECT]" "vso.build (Build: Read)" \
         "Build Reader (Readers group) on the project" "core" \
+        "GET /{project}/_apis/build/builds" \
         az pipelines build list --project "$PRIMARY_PROJECT" --org "$ORG_URL" --top 1 --output json
 
     probe "Repositories (read) [$PRIMARY_PROJECT]" "vso.code (Code: Read)" \
         "Reader/Contributor on the project's repositories" "core" \
+        "GET /{project}/_apis/git/repositories" \
         az repos list --project "$PRIMARY_PROJECT" --org "$ORG_URL" --output json
 
     probe "Service Connections (read) [$PRIMARY_PROJECT]" "vso.serviceendpoint (Service Connections: Read)" \
         "Reader on the project's service connections" "optional" \
+        "GET /{project}/_apis/serviceendpoint/endpoints" \
         az devops service-endpoint list --project "$PRIMARY_PROJECT" --org "$ORG_URL" --output json
 fi
 
@@ -127,33 +141,96 @@ fi
 echo ""
 echo "=== Preflight Summary ==="
 
+# Guard: ado_identity_json should always return a JSON object, but a transient
+# failure (or an older helper) could echo an empty string, which would make the
+# final `jq -n --argjson identity ""` abort and leave preflight_results.json
+# missing/empty — the exact bug that made a fully-accessible run report
+# "Insufficient Azure DevOps Access" with no detail. Never trust it blindly.
+if ! echo "$identity_json" | jq -e . >/dev/null 2>&1; then
+    identity_json='{"name":"unknown","id":"unknown","email":"","auth_type":"'"${AUTH_TYPE:-service_principal}"'","confirmed":false}'
+fi
+
+case "${AUTH_TYPE:-service_principal}" in
+    pat) auth_mode="Personal Access Token (PAT)" ;;
+    *)   auth_mode="Service Principal" ;;
+esac
+
 total=$(echo "$capabilities" | jq 'length')
 ok=$(echo "$capabilities" | jq '[.[] | select(.status=="OK")] | length')
-identity_name=$(echo "$identity_json" | jq -r '.name')
+identity_confirmed=$(echo "$identity_json" | jq -r '.confirmed // false')
+identity_name=$(echo "$identity_json" | jq -r '.name // "unknown"')
+if [ "$identity_confirmed" = "true" ]; then
+    identity_line="${identity_name} (id=$(echo "$identity_json" | jq -r '.id // "unknown"'))"
+else
+    identity_line="could not be resolved (connectionData blocked by proxy or PAT lacks vso.profile) — capability probes below are authoritative"
+fi
 optional_missing=$(echo "$capabilities" | jq -r '[.[] | select(.status!="OK" and .tier=="optional") | "\(.capability) (needs \(.required_pat_scope) / \(.required_role))"] | join("; ")')
 
 if [ "$blocking" -eq 0 ]; then
     access_ok=true
     if [ -n "$optional_missing" ]; then
-        summary="Access OK for core tasks ($ok/$total capabilities) as identity '${identity_name}'. Limited: ${optional_missing} — related tasks will be partial until granted."
+        summary="Access OK for core tasks ($ok/$total capabilities) via ${auth_mode} as identity '${identity_name}'. Limited: ${optional_missing} — related tasks will be partial until granted."
     else
-        summary="Access OK: identity '${identity_name}' can perform all required Azure DevOps reads ($ok/$total capabilities). Project health tasks should run normally."
+        summary="Access OK: identity '${identity_name}' (${auth_mode}) can perform all required Azure DevOps reads ($ok/$total capabilities). Project health tasks should run normally."
     fi
 else
     access_ok=false
     missing=$(echo "$capabilities" | jq -r '[.[] | select(.status!="OK" and .tier=="core") | "\(.capability) (needs \(.required_pat_scope) / \(.required_role))"] | join("; ")')
-    summary="INSUFFICIENT ACCESS: identity '${identity_name}' is missing $blocking required capability(ies): ${missing}. Grant the listed PAT scopes/roles and re-run; affected tasks will return empty or partial results until then."
+    summary="INSUFFICIENT ACCESS: identity '${identity_name}' (${auth_mode}) is missing $blocking required capability(ies): ${missing}. Grant the listed PAT scopes/roles and re-run; affected tasks will return empty or partial results until then."
 fi
 
 echo "$summary"
 
+# Build a single, self-contained, actionable report block. This is what the
+# runbook drops verbatim into the issue_details so a human or a troubleshooting
+# agent sees EXACTLY which capability failed, on which endpoint, with what
+# status, and precisely what scope/role to grant — without needing the raw log.
+report=$(echo "$capabilities" | jq -r \
+    --arg org "$AZURE_DEVOPS_ORG" \
+    --arg auth "$auth_mode" \
+    --arg ident "$identity_line" \
+    --arg summary "$summary" '
+    [
+      "Azure DevOps preflight access check",
+      "Organization : \($org)",
+      "Auth mode    : \($auth)",
+      "Identity     : \($ident)",
+      "Result       : \($summary)",
+      "",
+      "Capability matrix (capability -> endpoint -> result):"
+    ]
+    + [ .[] | "  [\(.status)] \(.capability)  ->  \(.endpoint)" + (if (.http_status // "") != "" then "  (HTTP \(.http_status))" else "" end) ]
+    + (
+        [ .[] | select(.status != "OK") ] as $bad
+        | if ($bad | length) == 0 then []
+          else
+            ["", "How to grant the missing access:"]
+            + ( $bad | to_entries | map(
+                "  \(.key + 1). \(.value.capability) [\(.value.tier)] returned \(.value.status)\(if (.value.http_status // "") != "" then " (HTTP \(.value.http_status))" else "" end) on \(.value.endpoint)."
+                + "\n       - Add PAT scope: \(.value.required_pat_scope)  (User settings > Personal access tokens > Edit > Scopes)."
+                + "\n       - Ensure role : \(.value.required_role)."
+                + (if (.value.detail // "") != "" and .value.detail != "Accessible." then "\n       - API said    : \(.value.detail)" else "" end)
+              ))
+          end
+      )
+    | join("\n")')
+
 result_json=$(jq -n \
     --arg org "$AZURE_DEVOPS_ORG" \
+    --arg auth_mode "$auth_mode" \
     --argjson identity "$identity_json" \
     --argjson capabilities "$capabilities" \
     --argjson access_ok "$access_ok" \
     --arg summary "$summary" \
-    '{organization:$org, identity:$identity, capabilities:$capabilities, access_ok:$access_ok, summary:$summary}')
+    --arg report "$report" \
+    '{organization:$org, auth_mode:$auth_mode, identity:$identity, capabilities:$capabilities, access_ok:$access_ok, summary:$summary, report:$report}')
+
+# Last-resort guard: the results file must ALWAYS be valid JSON so the runbook
+# never has to fall back to a contentless "results unavailable" placeholder.
+if [ -z "$result_json" ] || ! echo "$result_json" | jq -e . >/dev/null 2>&1; then
+    result_json=$(jq -n --arg s "$summary" --arg r "${report:-$summary}" --argjson ok "${access_ok:-false}" \
+        '{access_ok:$ok, summary:$s, report:$r}')
+fi
 
 echo "$result_json" > "$OUTPUT_FILE"
 echo "Results saved to $OUTPUT_FILE"

--- a/codebundles/azure-devops-project-health/queued-pipelines.sh
+++ b/codebundles/azure-devops-project-health/queued-pipelines.sh
@@ -9,16 +9,22 @@ set -euo pipefail
 #   AZURE_DEVOPS_PROJECT
 #
 # OPTIONAL ENV VARS:
+#   QUEUE_THRESHOLD      - queue age threshold (e.g. "30m", "1h"; default 30m)
+#   RW_LOOKBACK_WINDOW   - build dataset window (default 24h)
 #
-# This script:
-#   1) Lists all pipelines in the specified Azure DevOps project
-#   2) Checks for runs that are queued longer than the specified threshold
-#   3) Outputs results in JSON format
+# This script (Phase 0 single-pass refactor):
+#   1) Fetches the project's builds ONCE via the Build REST API (fetch_project_builds),
+#      including the currently-queued (notStarted) builds (point-in-time set).
+#   2) Derives, with jq, every build queued longer than the threshold -- with NO
+#      per-pipeline API calls (previously it looped over every pipeline issuing
+#      `az pipelines runs list --pipeline-id <id>`, which timed out at 180s).
+#   3) Outputs results in JSON format.
 # -----------------------------------------------------------------------------
 
 : "${AZURE_DEVOPS_ORG:?Must set AZURE_DEVOPS_ORG}"
 : "${AZURE_DEVOPS_PROJECT:?Must set AZURE_DEVOPS_PROJECT}"
-: "${QUEUE_THRESHOLD:=1m}"
+: "${QUEUE_THRESHOLD:=30m}"
+: "${RW_LOOKBACK_WINDOW:=24h}"
 : "${AUTH_TYPE:=service_principal}"
 AZURE_DEVOPS_PAT="${AZURE_DEVOPS_PAT:-$azure_devops_pat}"
 export AZURE_DEVOPS_EXT_PAT="${AZURE_DEVOPS_PAT}"
@@ -26,6 +32,7 @@ export AZURE_DEVOPS_EXT_PAT="${AZURE_DEVOPS_PAT}"
 source "$(dirname "$0")/_az_helpers.sh"
 
 OUTPUT_FILE="queued_pipelines.json"
+BUILDS_FILE="builds_dataset.json"
 issues_json='[]'
 
 # Convert duration threshold to minutes
@@ -33,7 +40,7 @@ convert_to_minutes() {
     local threshold=$1
     local number=$(echo "$threshold" | sed -E 's/[^0-9]//g')
     local unit=$(echo "$threshold" | sed -E 's/[0-9]//g')
-    
+
     case $unit in
         m|min|mins)
             echo $number
@@ -58,15 +65,15 @@ echo "Threshold:    $THRESHOLD_MINUTES minutes"
 az devops configure --defaults project="$AZURE_DEVOPS_PROJECT" --output none
 setup_azure_auth
 
-# Get list of pipelines
-echo "Retrieving pipelines in project..."
-if ! az_with_retry az pipelines list --output json; then
-    echo "ERROR: Could not list pipelines."
+# Single-pass: fetch the project's builds ONCE (shared/cached across tasks).
+echo "Fetching project build dataset (single pass, window: ${RW_LOOKBACK_WINDOW})..."
+if ! build_count=$(fetch_project_builds "$AZURE_DEVOPS_PROJECT" "$BUILDS_FILE" "$RW_LOOKBACK_WINDOW"); then
+    echo "ERROR: Could not fetch builds for project."
     issues_json=$(echo "$issues_json" | jq \
-        --arg title "Failed to List Pipelines" \
-        --arg details "Azure DevOps API was unreachable or returned an error after $AZ_RETRY_COUNT retry attempts." \
+        --arg title "Failed to Fetch Builds" \
+        --arg details "The Build REST API was unreachable or returned an error while fetching the project build dataset." \
         --arg severity "3" \
-        --arg nextStep "Check if the project exists and you have the right permissions. Verify Azure DevOps API availability." \
+        --arg nextStep "Check if the project exists and you have Build (Read) permissions. Verify Azure DevOps API availability." \
         '. += [{
            "title": $title,
            "details": $details,
@@ -76,145 +83,47 @@ if ! az_with_retry az pipelines list --output json; then
     echo "$issues_json" > "$OUTPUT_FILE"
     exit 1
 fi
-pipelines="$AZ_RESULT"
+echo "Fetched $build_count builds. Deriving queued pipelines..."
 
-# Save pipelines to a file to avoid subshell issues
-echo "$pipelines" > pipelines.json
+NOW_EPOCH=$(date +%s)
 
-# Get the number of pipelines
-pipeline_count=$(jq '. | length' pipelines.json)
+# Derive every queued (notStarted) build aging past the threshold directly from
+# the single dataset -- one jq pass, zero per-pipeline calls.
+issues_json=$(jq \
+    --argjson now "$NOW_EPOCH" \
+    --argjson thr "$THRESHOLD_MINUTES" \
+    --arg threshold_label "$THRESHOLD_MINUTES" '
+    def parsedate: (sub("\\.[0-9]+";"") | sub("(Z|[+-][0-9][0-9]:?[0-9][0-9])$";"")) + "Z" | fromdateiso8601;
+    def fmt(m): if m >= 1440 then "\(m/1440|floor)d \((m%1440)/60|floor)h \(m%60)m"
+                elif m >= 60 then "\(m/60|floor)h \(m%60)m"
+                else "\(m)m" end;
+    [ .[]
+      | select(.status == "notStarted" and (.queueTime // null) != null)
+      | (($now - (.queueTime | parsedate)) / 60 | floor) as $qm
+      | select($qm >= $thr)
+      | (.definition.name // "Unknown Pipeline") as $pname
+      | ((.sourceBranch // "unknown") | sub("refs/heads/";"")) as $branch
+      | (._links.web.href // .url // "") as $url
+      | ((.definition.id // "") | tostring) as $pid
+      | ((.id // "") | tostring) as $rid
+      | (if (.reason // null) != null then "Trigger reason: \(.reason)" else "Unknown" end) as $qreason
+      | {
+          title: "Pipeline Queued Too Long: `\($pname)` (Branch: `\($branch)`)",
+          details: "Pipeline has been queued for \(fmt($qm)) (exceeds threshold of \($threshold_label) minutes). \($qreason)",
+          next_steps: "Check agent pool capacity and availability. Consider adding more agents or optimizing pipeline concurrency limits.",
+          severity: 3,
+          resource_url: $url,
+          queue_time: fmt($qm),
+          queue_minutes: $qm,
+          pipeline_id: $pid,
+          run_id: $rid,
+          branch: $branch,
+          queue_reason: $qreason
+        } ]
+    ' "$BUILDS_FILE")
 
-# Process each pipeline using a for loop instead of pipe to while
-for ((i=0; i<pipeline_count; i++)); do
-    pipeline_json=$(jq -c ".[${i}]" pipelines.json)
-    
-    # Extract values from JSON using jq
-    pipeline_id=$(echo "$pipeline_json" | jq -r '.id')
-    pipeline_name=$(echo "$pipeline_json" | jq -r '.name')
-    
-    echo "Processing Pipeline: $pipeline_name (ID: $pipeline_id)"
-    
-    # Get queued runs for this pipeline
-    if ! az_with_retry az pipelines runs list --pipeline-id "$pipeline_id" --output json; then
-        issues_json=$(echo "$issues_json" | jq \
-            --arg title "Failed to List Runs for Pipeline $pipeline_name" \
-            --arg details "Could not retrieve runs after $AZ_RETRY_COUNT attempts." \
-            --arg severity "3" \
-            --arg nextStep "Check if you have sufficient permissions to view pipeline runs. Verify Azure DevOps API availability." \
-            '. += [{
-               "title": $title,
-               "details": $details,
-               "next_steps": $nextStep,
-               "severity": ($severity | tonumber)
-             }]')
-        continue
-    fi
-    runs="$AZ_RESULT"
-    
-    # Save runs to a file to avoid subshell issues
-    echo "$runs" > runs.json
-    
-    # Get the number of runs
-    run_count=$(jq '. | length' runs.json)
-    
-    # Check for queued runs
-    for ((j=0; j<run_count; j++)); do
-        run_json=$(jq -c ".[${j}]" runs.json)
-        
-        # Check if run is queued (notStarted)
-        run_state=$(echo "$run_json" | jq -r '.status')
-        if [[ "$run_state" != "notStarted" ]]; then
-            continue
-        fi
-        
-        run_id=$(echo "$run_json" | jq -r '.id')
-        run_name=$(echo "$run_json" | jq -r '.name // "Run #\(.id)"')
-        web_url=$(echo "$run_json" | jq -r '.url')
-        branch=$(echo "$run_json" | jq -r '.sourceBranch // "unknown"' | sed 's|refs/heads/||')
-        created_date=$(echo "$run_json" | jq -r '.queueTime')
-        
-        # Calculate queue time in minutes
-        created_timestamp=$(date -d "$created_date" +%s)
-        current_timestamp=$(date +%s)
-        queue_seconds=$((current_timestamp - created_timestamp))
-        queue_minutes=$((queue_seconds / 60))
-        
-        # Format queue time for display
-        if [ $queue_minutes -ge 1440 ]; then
-            days=$((queue_minutes / 1440))
-            hours=$(((queue_minutes % 1440) / 60))
-            mins=$((queue_minutes % 60))
-            formatted_queue_time="${days}d ${hours}h ${mins}m"
-        elif [ $queue_minutes -ge 60 ]; then
-            hours=$((queue_minutes / 60))
-            mins=$((queue_minutes % 60))
-            formatted_queue_time="${hours}h ${mins}m"
-        else
-            formatted_queue_time="${queue_minutes}m"
-        fi
-        
-        echo "  Checking queued pipeline: $run_name (ID: $run_id, Branch: $branch, Queue Time: $formatted_queue_time)"
-        
-        # Check if queue time exceeds threshold
-        if [ $queue_minutes -ge $THRESHOLD_MINUTES ]; then
-            # Try to get more details about why it's queued
-            queue_reason="Unknown"
-            if ! run_details=$(az pipelines runs show --id "$run_id" --output json 2>/dev/null); then
-                queue_reason="Could not retrieve detailed information"
-            else
-                # Save run details to a file
-                echo "$run_details" > run_details.json
-                
-                # Extract queue position if available
-                queue_position=$(jq -r '.queuePosition // "Unknown"' run_details.json)
-                if [ "$queue_position" != "null" ] && [ "$queue_position" != "Unknown" ]; then
-                    queue_reason="Queue position: $queue_position"
-                fi
-                
-                # Try to extract any waiting reason
-                waiting_reason=$(jq -r '.reason // "Unknown"' run_details.json)
-                if [ "$waiting_reason" != "null" ] && [ "$waiting_reason" != "Unknown" ]; then
-                    queue_reason="$queue_reason, Reason: $waiting_reason"
-                fi
-                
-                # Clean up run details file
-                rm -f run_details.json
-            fi
-            
-            issues_json=$(echo "$issues_json" | jq \
-                --arg title "Pipeline Queued Too Long: \`$pipeline_name\` (Branch: \`$branch\`)" \
-                --arg details "Pipeline has been queued for $formatted_queue_time (exceeds threshold of $THRESHOLD_MINUTES minutes). $queue_reason" \
-                --arg severity "3" \
-                --arg nextStep "Check agent pool capacity and availability. Consider adding more agents or optimizing pipeline concurrency limits." \
-                --arg resource_url "$web_url" \
-                --arg queue_time "$formatted_queue_time" \
-                --arg queue_minutes "$queue_minutes" \
-                --arg pipeline_id "$pipeline_id" \
-                --arg run_id "$run_id" \
-                --arg branch "$branch" \
-                --arg queue_reason "$queue_reason" \
-                '. += [{
-                   "title": $title,
-                   "details": $details,
-                   "next_steps": $nextStep,
-                   "severity": ($severity | tonumber),
-                   "resource_url": $resource_url,
-                   "queue_time": $queue_time,
-                   "queue_minutes": ($queue_minutes | tonumber),
-                   "pipeline_id": $pipeline_id,
-                   "run_id": $run_id,
-                   "branch": $branch,
-                   "queue_reason": $queue_reason
-                 }]')
-        fi
-    done
-    
-    # Clean up runs file
-    rm -f runs.json
-done
-
-# Clean up pipelines file
-rm -f pipelines.json
+# Log a short per-build trace for transparency (no extra API calls).
+echo "$issues_json" | jq -r '.[] | "  Queued: \(.title) — \(.queue_time)"' 2>/dev/null || true
 
 # Write final JSON
 echo "$issues_json" > "$OUTPUT_FILE"

--- a/codebundles/azure-devops-project-health/queued-pipelines.sh
+++ b/codebundles/azure-devops-project-health/queued-pipelines.sh
@@ -93,13 +93,15 @@ issues_json=$(jq \
     --argjson now "$NOW_EPOCH" \
     --argjson thr "$THRESHOLD_MINUTES" \
     --arg threshold_label "$THRESHOLD_MINUTES" '
-    def parsedate: (sub("\\.[0-9]+";"") | sub("(Z|[+-][0-9][0-9]:?[0-9][0-9])$";"")) + "Z" | fromdateiso8601;
+    def parsedate: (sub("\\.[0-9]+";"") | sub("(Z|[+-][0-9][0-9]:?[0-9][0-9])$";"")) + "Z" | (try fromdateiso8601 catch null);
     def fmt(m): if m >= 1440 then "\(m/1440|floor)d \((m%1440)/60|floor)h \(m%60)m"
                 elif m >= 60 then "\(m/60|floor)h \(m%60)m"
                 else "\(m)m" end;
     [ .[]
       | select(.status == "notStarted" and (.queueTime // null) != null)
-      | (($now - (.queueTime | parsedate)) / 60 | floor) as $qm
+      | (.queueTime | parsedate) as $qt
+      | select($qt != null)
+      | (($now - $qt) / 60 | floor) as $qm
       | select($qm >= $thr)
       | (.definition.name // "Unknown Pipeline") as $pname
       | ((.sourceBranch // "unknown") | sub("refs/heads/";"")) as $branch

--- a/codebundles/azure-devops-project-health/queued-pipelines.sh
+++ b/codebundles/azure-devops-project-health/queued-pipelines.sh
@@ -26,7 +26,7 @@ set -euo pipefail
 : "${QUEUE_THRESHOLD:=30m}"
 : "${RW_LOOKBACK_WINDOW:=24h}"
 : "${AUTH_TYPE:=service_principal}"
-AZURE_DEVOPS_PAT="${AZURE_DEVOPS_PAT:-$azure_devops_pat}"
+AZURE_DEVOPS_PAT="${AZURE_DEVOPS_PAT:-${azure_devops_pat:-}}"
 export AZURE_DEVOPS_EXT_PAT="${AZURE_DEVOPS_PAT}"
 
 source "$(dirname "$0")/_az_helpers.sh"

--- a/codebundles/azure-devops-project-health/repo-policies.sh
+++ b/codebundles/azure-devops-project-health/repo-policies.sh
@@ -129,6 +129,19 @@ for ((p=0; p<project_count; p++)); do
     # Get the number of repos
     repo_count=$(jq '. | length' repos.json)
     echo "Found $repo_count repositories in project $project_name"
+
+    # Single-pass: fetch ALL policy configurations for the project ONCE, instead
+    # of one `az repos policy list --repository-id <id>` call per repository (the
+    # per-repo loop that drove the 180s timeout). Each repo's effective policies
+    # are then derived in-memory by filtering this set on the policy scope.
+    if ! az_with_retry az repos policy list --project "$project_name" --org "$ORG_URL" --output json; then
+        echo "  WARNING: Could not list project-wide branch policies for $project_name; marking project as inaccessible for policy analysis."
+        access_denied_repos+=("$project_name")
+        rm -f repos.json
+        continue
+    fi
+    all_policies_json="$AZ_RESULT"
+    echo "  Fetched $(echo "$all_policies_json" | jq 'length') policy configurations for project $project_name (single call)."
     
     # Process each repository
     for ((r=0; r<repo_count; r++)); do
@@ -156,13 +169,20 @@ for ((p=0; p<project_count; p++)); do
             fi
         fi
         
-        # Get branch policies for the default branch
+        # Derive this repo's effective branch policies for its default branch from
+        # the project-wide set fetched above. A policy applies when its scope
+        # targets this repository (or is project-wide, repositoryId null) and the
+        # default branch (or any ref, refName null).
         default_branch_id="refs/heads/$repo_default_branch"
-        if ! az_with_retry az repos policy list --repository-id "$repo_id" --branch "$default_branch_id" --project "$project_name" --org "$ORG_URL" --output json; then
-            access_denied_repos+=("$project_name/$repo_name")
-            continue
-        fi
-        policies_json="$AZ_RESULT"
+        policies_json=$(echo "$all_policies_json" | jq \
+            --arg rid "$repo_id" --arg ref "$default_branch_id" '
+            [ .[] | select(
+                ((.settings.scope // []) | length) == 0
+                or ((.settings.scope // []) | any(
+                    ((.repositoryId // null) == null or .repositoryId == $rid)
+                    and ((.refName // null) == null or .refName == $ref)
+                ))
+            ) ]')
         
         # Check if default branch is locked
         if [[ $(echo "$policy_standards" | jq -r '.branchPolicies.defaultBranch.isLocked') == "true" ]]; then

--- a/codebundles/azure-devops-project-health/repo-policies.sh
+++ b/codebundles/azure-devops-project-health/repo-policies.sh
@@ -15,7 +15,7 @@
 
 : "${AZURE_DEVOPS_ORG:?Must set AZURE_DEVOPS_ORG}"
 : "${AUTH_TYPE:=service_principal}"
-AZURE_DEVOPS_PAT="${AZURE_DEVOPS_PAT:-$azure_devops_pat}"
+AZURE_DEVOPS_PAT="${AZURE_DEVOPS_PAT:-${azure_devops_pat:-}}"
 export AZURE_DEVOPS_EXT_PAT="${AZURE_DEVOPS_PAT}"
 
 source "$(dirname "$0")/_az_helpers.sh"

--- a/codebundles/azure-devops-project-health/repository-health-analysis.sh
+++ b/codebundles/azure-devops-project-health/repository-health-analysis.sh
@@ -8,15 +8,26 @@ set -euo pipefail
 #   AZURE_DEVOPS_ORG
 #   AZURE_DEVOPS_PROJECT
 #
-# This script:
-#   1) Analyzes repository commit patterns
-#   2) Checks branch health and protection
-#   3) Reviews pull request status
-#   4) Identifies potential repository issues
+# OPTIONAL ENV VARS:
+#   RW_LOOKBACK_WINDOW   - window for recent commit activity (default 24h; the
+#                          deep runbook typically sets 30d)
+#   MAX_REPOS            - cap on repos whose commit history is fetched (deep
+#                          per-item work; default 50)
+#
+# This script (Phase 0 single-pass refactor):
+#   1) Lists repositories ONCE.
+#   2) Fetches active pull requests and branch policies PROJECT-WIDE in ONE call
+#      each (instead of one PR-list + one policy-list call per repository) and
+#      derives per-repo counts with jq.
+#   3) Fetches recent commit activity per repo (the one signal with no bulk API),
+#      windowed by RW_LOOKBACK_WINDOW and CAPPED to MAX_REPOS repositories.
+#   4) Outputs results in JSON format.
 # -----------------------------------------------------------------------------
 
 : "${AZURE_DEVOPS_ORG:?Must set AZURE_DEVOPS_ORG}"
 : "${AZURE_DEVOPS_PROJECT:?Must set AZURE_DEVOPS_PROJECT}"
+: "${RW_LOOKBACK_WINDOW:=24h}"
+: "${MAX_REPOS:=50}"
 : "${AUTH_TYPE:=service_principal}"
 AZURE_DEVOPS_PAT="${AZURE_DEVOPS_PAT:-$azure_devops_pat}"
 export AZURE_DEVOPS_EXT_PAT="${AZURE_DEVOPS_PAT}"
@@ -33,7 +44,7 @@ echo "Project:      $AZURE_DEVOPS_PROJECT"
 az devops configure --defaults project="$AZURE_DEVOPS_PROJECT" --output none
 setup_azure_auth
 
-# Get list of repositories
+# Get list of repositories (single call)
 echo "Getting repositories in project..."
 if ! az_with_retry az repos list --output json; then
     echo "ERROR: Could not list repositories."
@@ -58,119 +69,116 @@ if [ "$repo_count" -eq 0 ]; then
     echo "No repositories found in project."
     analysis_json='[{"title": "No Repositories Found", "details": "No repositories found in the project", "severity": 2}]'
     echo "$analysis_json" > "$OUTPUT_FILE"
+    rm -f repos.json
     exit 0
 fi
 
-echo "Found $repo_count repositories. Analyzing..."
+echo "Found $repo_count repositories. Fetching project-wide PRs and policies (single pass)..."
+
+# Single-pass: all active PRs for the project in ONE call (was 1 call per repo).
+if az_with_retry az repos pr list --status active --output json; then
+    echo "$AZ_RESULT" > prs_all.json
+    echo "  Fetched $(jq 'length' prs_all.json) active pull requests project-wide."
+else
+    echo "  WARNING: Could not list project-wide pull requests; PR counts will be 0."
+    echo '[]' > prs_all.json
+fi
+
+# Single-pass: all branch policy configurations for the project in ONE call.
+if az_with_retry az repos policy list --output json; then
+    echo "$AZ_RESULT" > policies_all.json
+    echo "  Fetched $(jq 'length' policies_all.json) policy configurations project-wide."
+else
+    echo "  WARNING: Could not list project-wide branch policies; policy counts will be 0."
+    echo '[]' > policies_all.json
+fi
+
+from_date=$(window_to_min_time "$RW_LOOKBACK_WINDOW")
+old_pr_date=$(date -d '14 days ago' -u +"%Y-%m-%dT%H:%M:%SZ")
+echo "Commit activity window: since ${from_date} (RW_LOOKBACK_WINDOW=${RW_LOOKBACK_WINDOW}). Commit fetch capped to ${MAX_REPOS} repos."
 
 # Analyze each repository
 for ((i=0; i<repo_count; i++)); do
     repo_json=$(jq -c ".[${i}]" repos.json)
-    
+
     repo_id=$(echo "$repo_json" | jq -r '.id')
     repo_name=$(echo "$repo_json" | jq -r '.name')
     default_branch=$(echo "$repo_json" | jq -r '.defaultBranch // "main"' | sed 's|refs/heads/||')
     repo_size=$(echo "$repo_json" | jq -r '.size // 0')
-    
+
     echo "Analyzing repository: $repo_name"
-    
-    # Get recent commit activity (last 7 days)
-    from_date=$(date -d "7 days ago" -u +"%Y-%m-%dT%H:%M:%SZ")
-    echo "  Checking recent commit activity..."
-    
-    if recent_commits=$(az repos commit list --repository "$repo_name" --query "[?author.date >= '$from_date']" --output json 2>commits_err.log); then
-        commit_count=$(echo "$recent_commits" | jq '. | length')
-        
-        if [ "$commit_count" -gt 0 ]; then
-            # Analyze commit patterns
-            unique_authors=$(echo "$recent_commits" | jq -r '.[].author.name' | sort -u | wc -l)
-            avg_commits_per_day=$(echo "scale=1; $commit_count / 7" | bc -l 2>/dev/null || echo "0")
-            
-            # Get most active author
-            most_active_author=$(echo "$recent_commits" | jq -r '.[].author.name' | sort | uniq -c | sort -nr | head -1 | awk '{print $2" "$3" "$4}' | sed 's/^ *//')
-            
-            echo "    Recent activity: $commit_count commits by $unique_authors authors"
+
+    # PR counts derived from the project-wide PR set (no per-repo call).
+    open_pr_count=$(jq --arg rid "$repo_id" '[ .[] | select(.repository.id == $rid) ] | length' prs_all.json)
+    old_prs=$(jq --arg rid "$repo_id" --arg old "$old_pr_date" \
+        '[ .[] | select(.repository.id == $rid and .creationDate < $old) ] | length' prs_all.json)
+
+    # Branch policies derived from the project-wide policy set (no per-repo call).
+    default_branch_id="refs/heads/$default_branch"
+    policy_count=$(jq --arg rid "$repo_id" --arg ref "$default_branch_id" \
+        '[ .[] | select(((.settings.scope // []) | length) == 0
+            or ((.settings.scope // []) | any(((.repositoryId // null) == null or .repositoryId == $rid)
+                and ((.refName // null) == null or .refName == $ref)))) ] | length' policies_all.json)
+    enabled_policies=$(jq --arg rid "$repo_id" --arg ref "$default_branch_id" \
+        '[ .[] | select((.isEnabled == true) and (((.settings.scope // []) | length) == 0
+            or ((.settings.scope // []) | any(((.repositoryId // null) == null or .repositoryId == $rid)
+                and ((.refName // null) == null or .refName == $ref))))) ] | length' policies_all.json)
+
+    # Recent commit activity: the only signal with no bulk API. Windowed and
+    # capped to MAX_REPOS to keep the task bounded.
+    commit_count=0; unique_authors=0; avg_commits_per_day="0"; most_active_author="None"
+    if [ "$i" -lt "$MAX_REPOS" ]; then
+        echo "  Checking recent commit activity (since $from_date)..."
+        if recent_commits=$(az repos commit list --repository "$repo_name" --query "[?author.date >= '$from_date']" --output json 2>commits_err.log); then
+            commit_count=$(echo "$recent_commits" | jq '. | length')
+            if [ "$commit_count" -gt 0 ]; then
+                unique_authors=$(echo "$recent_commits" | jq -r '.[].author.name' | sort -u | wc -l)
+                avg_commits_per_day=$(echo "scale=1; $commit_count / 7" | bc -l 2>/dev/null || echo "0")
+                most_active_author=$(echo "$recent_commits" | jq -r '.[].author.name' | sort | uniq -c | sort -nr | head -1 | awk '{print $2" "$3" "$4}' | sed 's/^ *//')
+                echo "    Recent activity: $commit_count commits by $unique_authors authors"
+            else
+                echo "    No recent commit activity"
+            fi
         else
-            unique_authors=0
-            avg_commits_per_day="0"
-            most_active_author="None"
-            echo "    No recent commit activity"
+            echo "    Warning: Could not get recent commits"
+            most_active_author="Unknown"
         fi
+        rm -f commits_err.log
     else
-        echo "    Warning: Could not get recent commits"
-        commit_count=0
-        unique_authors=0
-        avg_commits_per_day="0"
-        most_active_author="Unknown"
+        most_active_author="Not analyzed (MAX_REPOS cap)"
+        echo "  Skipping commit fetch for $repo_name (beyond MAX_REPOS=$MAX_REPOS cap)"
     fi
-    rm -f commits_err.log
-    
-    # Check pull request status
-    echo "  Checking pull request status..."
-    if open_prs=$(az repos pr list --repository "$repo_name" --status active --output json 2>pr_err.log); then
-        open_pr_count=$(echo "$open_prs" | jq '. | length')
-        
-        if [ "$open_pr_count" -gt 0 ]; then
-            # Analyze PR age
-            old_prs=$(echo "$open_prs" | jq --arg old_date "$(date -d '14 days ago' -u +"%Y-%m-%dT%H:%M:%SZ")" '[.[] | select(.creationDate < $old_date)] | length')
-            echo "    Open PRs: $open_pr_count (${old_prs} older than 14 days)"
-        else
-            old_prs=0
-            echo "    No open pull requests"
-        fi
-    else
-        echo "    Warning: Could not get pull request status"
-        open_pr_count=0
-        old_prs=0
-    fi
-    rm -f pr_err.log
-    
-    # Check branch policies
-    echo "  Checking branch policies..."
-    if branch_policies=$(az repos policy list --repository-id "$repo_id" --branch "$default_branch" --output json 2>policy_err.log); then
-        policy_count=$(echo "$branch_policies" | jq '. | length')
-        enabled_policies=$(echo "$branch_policies" | jq '[.[] | select(.isEnabled == true)] | length')
-        echo "    Branch policies: $enabled_policies enabled out of $policy_count total"
-    else
-        echo "    Warning: Could not get branch policies"
-        policy_count=0
-        enabled_policies=0
-    fi
-    rm -f policy_err.log
-    
+
     # Determine health status and issues
     issues_found=()
     severity=1
-    
-    # Check for low activity
-    if [ "$commit_count" -eq 0 ]; then
-        issues_found+=("No commits in last 7 days")
-        severity=2
-    elif [ "$commit_count" -lt 3 ] && [ "$unique_authors" -eq 1 ]; then
-        issues_found+=("Low commit activity (only $commit_count commits by 1 author)")
-        severity=2
+
+    if [ "$i" -lt "$MAX_REPOS" ]; then
+        if [ "$commit_count" -eq 0 ]; then
+            issues_found+=("No commits in window")
+            severity=2
+        elif [ "$commit_count" -lt 3 ] && [ "$unique_authors" -eq 1 ]; then
+            issues_found+=("Low commit activity (only $commit_count commits by 1 author)")
+            severity=2
+        fi
     fi
-    
-    # Check for stale PRs
+
     if [ "$old_prs" -gt 0 ]; then
         issues_found+=("$old_prs pull requests older than 14 days")
         severity=2
     fi
-    
-    # Check for missing branch protection
+
     if [ "$enabled_policies" -eq 0 ]; then
         issues_found+=("No branch protection policies enabled")
         severity=2
     fi
-    
-    # Check for very large repositories
+
     if [ "$repo_size" -gt 1000000000 ]; then  # 1GB
         repo_size_mb=$((repo_size / 1024 / 1024))
         issues_found+=("Large repository size: ${repo_size_mb}MB")
         severity=2
     fi
-    
-    # Build analysis summary
+
     if [ ${#issues_found[@]} -eq 0 ]; then
         issues_summary="Repository appears healthy"
         title="Repository Health: $repo_name - Healthy"
@@ -180,7 +188,7 @@ for ((i=0; i<repo_count; i++)); do
         title="Repository Health: $repo_name - Issues Found"
         next_steps_text="Address the following for repository $repo_name: $issues_summary. Review branch policies, ensure active code review participation, and clean up stale pull requests."
     fi
-    
+
     analysis_json=$(echo "$analysis_json" | jq \
         --arg title "$title" \
         --arg repo_name "$repo_name" \
@@ -215,12 +223,12 @@ for ((i=0; i<repo_count; i++)); do
            "issues_summary": $issues_summary,
            "severity": ($severity | tonumber),
            "next_steps": $next_steps,
-           "details": "Repository \($repo_name): \($commit_count) commits in 7 days by \($unique_authors) authors (most active: \($most_active_author)). \($open_pr_count) open PRs (\($old_prs) stale). \($enabled_policies)/\($policy_count) branch policies enabled. Issues: \($issues_summary)"
+           "details": "Repository \($repo_name): \($commit_count) commits in window by \($unique_authors) authors (most active: \($most_active_author)). \($open_pr_count) open PRs (\($old_prs) stale). \($enabled_policies)/\($policy_count) branch policies enabled. Issues: \($issues_summary)"
          }]')
 done
 
 # Clean up temporary files
-rm -f repos.json
+rm -f repos.json prs_all.json policies_all.json
 
 # Write final JSON
 echo "$analysis_json" > "$OUTPUT_FILE"
@@ -229,4 +237,4 @@ echo "Repository health analysis completed. Results saved to $OUTPUT_FILE"
 # Output summary to stdout
 echo ""
 echo "=== REPOSITORY HEALTH SUMMARY ==="
-echo "$analysis_json" | jq -r '.[] | "Repository: \(.repo_name)\nRecent Commits: \(.recent_commits) by \(.unique_authors) authors\nOpen PRs: \(.open_prs) (\(.stale_prs) stale)\nPolicies: \(.enabled_policies)/\(.total_policies) enabled\nIssues: \(.issues_summary)\n---"' 
+echo "$analysis_json" | jq -r '.[] | "Repository: \(.repo_name)\nRecent Commits: \(.recent_commits) by \(.unique_authors) authors\nOpen PRs: \(.open_prs) (\(.stale_prs) stale)\nPolicies: \(.enabled_policies)/\(.total_policies) enabled\nIssues: \(.issues_summary)\n---"'

--- a/codebundles/azure-devops-project-health/repository-health-analysis.sh
+++ b/codebundles/azure-devops-project-health/repository-health-analysis.sh
@@ -29,7 +29,7 @@ set -euo pipefail
 : "${RW_LOOKBACK_WINDOW:=24h}"
 : "${MAX_REPOS:=50}"
 : "${AUTH_TYPE:=service_principal}"
-AZURE_DEVOPS_PAT="${AZURE_DEVOPS_PAT:-$azure_devops_pat}"
+AZURE_DEVOPS_PAT="${AZURE_DEVOPS_PAT:-${azure_devops_pat:-}}"
 export AZURE_DEVOPS_EXT_PAT="${AZURE_DEVOPS_PAT}"
 
 source "$(dirname "$0")/_az_helpers.sh"

--- a/codebundles/azure-devops-project-health/runbook.robot
+++ b/codebundles/azure-devops-project-health/runbook.robot
@@ -25,15 +25,15 @@ Validate Azure DevOps Access for Organization `${AZURE_DEVOPS_ORG}`
         RW.Core.Add Issue
         ...    severity=2
         ...    expected=The configured identity has the PAT scopes / Azure DevOps roles required for project health checks in `${AZURE_DEVOPS_ORG}`
-        ...    actual=Preflight reported insufficient access for organization `${AZURE_DEVOPS_ORG}`; downstream checks may be incomplete or fail
+        ...    actual=${PREFLIGHT_SUMMARY}
         ...    title=Insufficient Azure DevOps Access for Organization `${AZURE_DEVOPS_ORG}`
         ...    reproduce_hint=preflight-check.sh
-        ...    details=${PREFLIGHT_SUMMARY}
-        ...    next_steps=Grant the missing PAT scopes / Azure DevOps roles listed in the preflight output above, then re-run. See the codebundle troubleshooting docs for the required-access matrix.
+        ...    details=${PREFLIGHT_DETAILS}
+        ...    next_steps=For each capability marked DENIED/ERROR in the matrix above, grant the listed PAT scope (Azure DevOps > User settings > Personal access tokens > Edit > Scopes) and the listed organization/project role, then re-run. If the matrix shows all capabilities OK, the preflight script failed to record its result rather than a true permission gap — re-run and check the raw preflight output.
     END
 
     RW.Core.Add Pre To Report    Preflight Access Summary:
-    RW.Core.Add Pre To Report    ${PREFLIGHT_SUMMARY}
+    RW.Core.Add Pre To Report    ${PREFLIGHT_DETAILS}
 
 Check Agent Pool Availability Across Projects in `${AZURE_DEVOPS_ORG}`
     [Documentation]    Check agent pool health and capacity issues
@@ -379,14 +379,17 @@ Investigate Pipeline Performance Issues Across Projects in `${AZURE_DEVOPS_ORG}`
         
         IF    len(@{issue_list}) > 0
             FOR    ${issue}    IN    @{issue_list}
-                RW.Core.Add Issue
-                ...    severity=${issue['severity']}
-                ...    expected=Pipeline performance should be optimal in project `${project}`
-                ...    actual=Performance issues detected in project `${project}`
-                ...    title=${issue['title']} (Project: ${project})
-                ...    reproduce_hint=${performance_analysis.cmd}
-                ...    details=${issue['details']}
-                ...    next_steps=${issue['next_steps']}
+                IF    ${issue['severity']} > 1
+                    ${next_steps}=    Get From Dictionary    ${issue}    next_steps    Review pipeline performance metrics in the task output and tune stages, caching, or agent capacity as needed.
+                    RW.Core.Add Issue
+                    ...    severity=${issue['severity']}
+                    ...    expected=Pipeline performance should be optimal in project `${project}`
+                    ...    actual=Performance issues detected in project `${project}`
+                    ...    title=${issue['title']} (Project: ${project})
+                    ...    reproduce_hint=${performance_analysis.cmd}
+                    ...    details=${issue['details']}
+                    ...    next_steps=${next_steps}
+                END
             END
         END
         
@@ -430,14 +433,17 @@ Investigate Failed Pipeline Runs with Commit Correlation Across Projects in `${A
         
         IF    len(@{issue_list}) > 0
             FOR    ${issue}    IN    @{issue_list}
-                RW.Core.Add Issue
-                ...    severity=${issue['severity']}
-                ...    expected=Pipeline runs should succeed with no failing commits in project `${project}`
-                ...    actual=Pipeline failure correlated with recent commit changes in project `${project}`
-                ...    title=${issue['title']} (Project: ${project})
-                ...    reproduce_hint=${failure_investigation.cmd}
-                ...    details=${issue['details']}
-                ...    next_steps=${issue['next_steps']}
+                IF    ${issue['severity']} > 1
+                    ${next_steps}=    Get From Dictionary    ${issue}    next_steps    Review the failed run, recent commits on the branch, and pipeline configuration in Azure DevOps.
+                    RW.Core.Add Issue
+                    ...    severity=${issue['severity']}
+                    ...    expected=Pipeline runs should succeed with no failing commits in project `${project}`
+                    ...    actual=Pipeline failure correlated with recent commit changes in project `${project}`
+                    ...    title=${issue['title']} (Project: ${project})
+                    ...    reproduce_hint=${failure_investigation.cmd}
+                    ...    details=${issue['details']}
+                    ...    next_steps=${next_steps}
+                END
             END
         END
         
@@ -555,10 +561,15 @@ Suite Initialization
     ...    description=Threshold for queued pipelines (format: 10m, 1h)
     ...    default=30m
     ...    pattern=\w*
+    ${RW_LOOKBACK_WINDOW}=    RW.Core.Import User Variable    RW_LOOKBACK_WINDOW
+    ...    type=string
+    ...    description=Lookback window for the single-pass build dataset (failures, performance, completed long-running). Format: 24h, 7d, 30d. Point-in-time signals (queue/in-flight) ignore it.
+    ...    default=24h
+    ...    pattern=\w*
     
     Log    Processing project list...    INFO
     # Handle project list - either "All" or explicit CSV list
-    ${projects_all}=    Evaluate    "${AZURE_DEVOPS_PROJECTS}".strip().lower() == "all"
+    ${projects_all}=    Evaluate    "${AZURE_DEVOPS_PROJECTS}".strip().lower() in ("", "all")
     
     IF    ${projects_all}
         Log    Auto-discovering all projects in organization...    INFO
@@ -596,14 +607,18 @@ Suite Initialization
     Set Suite Variable    ${PROJECT_LIST}    ${PROJECT_LIST}
     Set Suite Variable    ${DURATION_THRESHOLD}    ${DURATION_THRESHOLD}
     Set Suite Variable    ${QUEUE_THRESHOLD}    ${QUEUE_THRESHOLD}
+    Set Suite Variable    ${RW_LOOKBACK_WINDOW}    ${RW_LOOKBACK_WINDOW}
 
     Set Suite Variable    ${AZURE_DEVOPS_CONFIG_DIR}    %{CODEBUNDLE_TEMP_DIR}/.azure-devops
 
-    # Create the env dictionary for bash scripts
+    # Create the env dictionary for bash scripts. RW_LOOKBACK_WINDOW drives the
+    # single-pass build dataset window shared across the pipeline tasks; the
+    # build dataset is fetched once per project (cached) and reused by every task.
     ${env_dict}=    Create Dictionary
     ...    AZURE_DEVOPS_ORG=${AZURE_DEVOPS_ORG}
     ...    DURATION_THRESHOLD=${DURATION_THRESHOLD}
     ...    QUEUE_THRESHOLD=${QUEUE_THRESHOLD}
+    ...    RW_LOOKBACK_WINDOW=${RW_LOOKBACK_WINDOW}
     ...    AUTH_TYPE=${AUTH_TYPE}
     ...    AZURE_CONFIG_DIR=${AZURE_DEVOPS_CONFIG_DIR}
     Set Suite Variable    ${env}    ${env_dict}
@@ -629,15 +644,24 @@ Suite Initialization
     TRY
         ${preflight_data}=    Evaluate    json.loads(r'''${preflight_json_raw.stdout}''')    json
         ${preflight_summary}=    Set Variable    ${preflight_data['summary']}
+        # Prefer the script's full, actionable report (capability matrix + the
+        # exact scope/role/endpoint remediation). Fall back to the raw stdout so
+        # the matrix still reaches the issue even on an older results file.
+        ${preflight_details}=    Evaluate    $preflight_data.get('report') or $preflight_data.get('summary') or r'''${preflight.stdout}'''
         Log    Preflight result: ${preflight_summary}    INFO
     EXCEPT
         Log    WARNING: Could not parse preflight results. Raw output: ${preflight.stdout}    WARN
-        ${preflight_data}=    Evaluate    {"summary": "Preflight parse failed", "access_ok": False, "identity": {"name": "unknown"}}
-        ${preflight_summary}=    Set Variable    Preflight results unavailable
+        # Do NOT swallow this: a missing/invalid results file means the access
+        # probe could not be recorded, so surface it as a real (access_ok=False)
+        # finding and carry the raw probe output so it stays actionable.
+        ${preflight_data}=    Evaluate    {"summary": "Preflight access check did not complete (results file missing or invalid)", "access_ok": False, "identity": {"name": "unknown"}}
+        ${preflight_summary}=    Set Variable    Preflight access check did not complete (results file missing or invalid)
+        ${preflight_details}=    Set Variable    ${preflight.stdout}
     END
 
     Set Suite Variable    ${PREFLIGHT_DATA}    ${preflight_data}
     Set Suite Variable    ${PREFLIGHT_SUMMARY}    ${preflight_summary}
+    Set Suite Variable    ${PREFLIGHT_DETAILS}    ${preflight_details}
 
     RW.Core.Add Pre To Report    Preflight Access Check:
     RW.Core.Add Pre To Report    ${preflight.stdout}

--- a/codebundles/azure-devops-project-health/service-connections.sh
+++ b/codebundles/azure-devops-project-health/service-connections.sh
@@ -15,7 +15,7 @@ set -euo pipefail
 : "${AZURE_DEVOPS_ORG:?Must set AZURE_DEVOPS_ORG}"
 : "${AZURE_DEVOPS_PROJECT:?Must set AZURE_DEVOPS_PROJECT}"
 : "${AUTH_TYPE:=service_principal}"
-AZURE_DEVOPS_PAT="${AZURE_DEVOPS_PAT:-$azure_devops_pat}"
+AZURE_DEVOPS_PAT="${AZURE_DEVOPS_PAT:-${azure_devops_pat:-}}"
 export AZURE_DEVOPS_EXT_PAT="${AZURE_DEVOPS_PAT}"
 
 source "$(dirname "$0")/_az_helpers.sh"

--- a/codebundles/azure-devops-project-health/sli-project-health-score.sh
+++ b/codebundles/azure-devops-project-health/sli-project-health-score.sh
@@ -123,7 +123,7 @@ scores=$(jq -n \
     --argjson maxlr "$SLI_MAX_LONGRUNNING" \
     --arg maxratio "$SLI_MAX_FAILURE_RATIO" \
     --arg protpat "$SLI_PROTECTED_BRANCH_PATTERN" '
-    def parsedate: (sub("\\.[0-9]+";"") | sub("(Z|[+-][0-9][0-9]:?[0-9][0-9])$";"")) + "Z" | fromdateiso8601;
+    def parsedate: (sub("\\.[0-9]+";"") | sub("(Z|[+-][0-9][0-9]:?[0-9][0-9])$";"")) + "Z" | (try fromdateiso8601 catch null);
     ($builds[0] // []) as $b
     | ($maxratio | tonumber) as $maxr
     # --- windowed: completed builds in the lookback window -----------------
@@ -141,13 +141,17 @@ scores=$(jq -n \
     # --- point-in-time: queued (notStarted) builds aging past threshold ----
     | ([ $b[]
           | select(.status == "notStarted" and (.queueTime // null) != null)
-          | (($now - (.queueTime | parsedate)) / 60)
+          | (.queueTime | parsedate) as $qt
+          | select($qt != null)
+          | (($now - $qt) / 60)
           | select(. >= $qthr) ] | length) as $aged_q
     | (if $aged_q > 0 then 0 else 1 end) as $queue_ok
     # --- point-in-time: in-flight builds running past threshold ------------
     | ([ $b[]
           | select(.status == "inProgress" and (.startTime // null) != null)
-          | (($now - (.startTime | parsedate)) / 60)
+          | (.startTime | parsedate) as $st
+          | select($st != null)
+          | (($now - $st) / 60)
           | select(. >= $dthr) ] | length) as $lr
     | (if $lr <= $maxlr then 1 else 0 end) as $long_ok
     | {

--- a/codebundles/azure-devops-project-health/sli-project-health-score.sh
+++ b/codebundles/azure-devops-project-health/sli-project-health-score.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+set -uo pipefail
+# NOTE: `set -x` is intentionally NOT used (it leaks AZURE_DEVOPS_PAT into logs
+# and bloats output). Set AZ_DEBUG=1 to opt in to tracing for local debugging.
+[ "${AZ_DEBUG:-0}" = "1" ] && set -x
+# -----------------------------------------------------------------------------
+# Project-health SLI scoring (cheap, every ~30 min).
+#
+# Computes FOUR build-derived {0,1} sub-scores for a single project from ONE
+# build dataset (fetched once via fetch_project_builds -- a handful of bounded
+# Build-API calls, well under a minute). A fifth sub-score (data_collection_ok)
+# is computed by the robot from this script's build_query_ok flag AND the
+# preflight access result, so this script never re-implements access probing.
+#
+# Sub-scores (1 = healthy; convention: score 0 ONLY for what we measure and
+# confirm bad; score 1 for what we cannot measure):
+#   pipeline_failure_ratio_ok   failed/total completed builds in the window
+#                               <= SLI_MAX_FAILURE_RATIO (0 runs => 1)
+#   protected_branch_failures_ok no protected-branch (main/master/develop/
+#                               release/*) pipeline failing 100% of its runs
+#                               in the window
+#   queue_aging_ok              no build queued (notStarted) longer than
+#                               QUEUE_THRESHOLD (point-in-time). A scaled-to-zero
+#                               elastic/ephemeral pool with NO queued work shows
+#                               no aging build, so it is NOT penalised here --
+#                               consistent with the landed agent-pool fix.
+#   long_running_ok             in-flight builds older than DURATION_THRESHOLD
+#                               <= SLI_MAX_LONGRUNNING (point-in-time)
+#
+# The two WINDOWED sub-scores (failure ratio, protected branch) use
+# RW_LOOKBACK_WINDOW (default ~45m, i.e. scrape interval x~1.5). The point-in-time
+# sub-scores (queue aging, long running) ignore it. Org-singleton data
+# (license, the 473-pool scan) is intentionally NOT pulled in here.
+#
+# REQUIRED ENV VARS:
+#   AZURE_DEVOPS_ORG
+#   AZURE_DEVOPS_PROJECT
+#
+# OPTIONAL ENV VARS:
+#   RW_LOOKBACK_WINDOW          windowed-sub-score lookback (default 45m)
+#   SLI_MAX_FAILURE_RATIO       max failed/total ratio (default 0.50)
+#   QUEUE_THRESHOLD             queued-build aging threshold (default 30m)
+#   DURATION_THRESHOLD          in-flight long-running threshold (default 60m)
+#   SLI_MAX_LONGRUNNING         allowed in-flight long-running builds (default 1)
+#   SLI_PROTECTED_BRANCH_PATTERN regex of protected branches
+#                               (default ^refs/heads/(main|master|develop|release/))
+#   SLI_BUILDS_DATASET          test hook: path to a pre-seeded builds JSON array;
+#                               when set & valid, auth/fetch is skipped and the
+#                               scores are computed directly from it.
+#
+# Writes sli_project_health_score.json and echoes it to stdout.
+# -----------------------------------------------------------------------------
+
+: "${AZURE_DEVOPS_ORG:?Must set AZURE_DEVOPS_ORG}"
+: "${AZURE_DEVOPS_PROJECT:?Must set AZURE_DEVOPS_PROJECT}"
+: "${RW_LOOKBACK_WINDOW:=45m}"
+: "${SLI_MAX_FAILURE_RATIO:=0.50}"
+: "${QUEUE_THRESHOLD:=30m}"
+: "${DURATION_THRESHOLD:=60m}"
+: "${SLI_MAX_LONGRUNNING:=1}"
+: "${SLI_PROTECTED_BRANCH_PATTERN:=^refs/heads/(main|master|develop|release/)}"
+: "${AUTH_TYPE:=service_principal}"
+AZURE_DEVOPS_PAT="${AZURE_DEVOPS_PAT:-${azure_devops_pat:-}}"
+export AZURE_DEVOPS_EXT_PAT="${AZURE_DEVOPS_PAT}"
+
+source "$(dirname "$0")/_az_helpers.sh"
+
+OUTPUT_FILE="sli_project_health_score.json"
+BUILDS_FILE="builds_dataset.json"
+
+# Convert a duration like "30m" / "1h" to integer minutes.
+convert_to_minutes() {
+    local threshold="$1"
+    local number unit
+    number=$(printf '%s' "$threshold" | sed -E 's/[^0-9].*$//')
+    unit=$(printf '%s' "$threshold" | sed -E 's/^[0-9]*//' | tr '[:upper:]' '[:lower:]')
+    [ -z "$number" ] && number=0
+    case "$unit" in
+        m|min|mins|minute|minutes|"") echo "$number" ;;
+        h|hr|hrs|hour|hours)          echo $((number * 60)) ;;
+        d|day|days)                   echo $((number * 1440)) ;;
+        *)                            echo "$number" ;;
+    esac
+}
+
+QUEUE_MIN=$(convert_to_minutes "$QUEUE_THRESHOLD")
+DURATION_MIN=$(convert_to_minutes "$DURATION_THRESHOLD")
+
+build_query_ok=0
+
+# ---- obtain the builds dataset -------------------------------------------
+if [ -n "${SLI_BUILDS_DATASET:-}" ] && [ -s "${SLI_BUILDS_DATASET}" ] \
+        && jq -e 'type == "array"' "${SLI_BUILDS_DATASET}" >/dev/null 2>&1; then
+    echo "Using seeded builds dataset: ${SLI_BUILDS_DATASET} (skipping live fetch)." >&2
+    cp "${SLI_BUILDS_DATASET}" "$BUILDS_FILE"
+    build_query_ok=1
+else
+    echo "Scoring project '${AZURE_DEVOPS_PROJECT}' in org '${AZURE_DEVOPS_ORG}' (window ${RW_LOOKBACK_WINDOW})." >&2
+    az devops configure --defaults project="$AZURE_DEVOPS_PROJECT" --output none 2>/dev/null || true
+    setup_azure_auth >&2 || true
+    if build_count=$(fetch_project_builds "$AZURE_DEVOPS_PROJECT" "$BUILDS_FILE" "$RW_LOOKBACK_WINDOW" 2>>/dev/stderr); then
+        if [ -s "$BUILDS_FILE" ] && jq -e 'type == "array"' "$BUILDS_FILE" >/dev/null 2>&1; then
+            build_query_ok=1
+        fi
+    fi
+fi
+
+# When the build query failed, emit a valid payload with build_query_ok=0 and
+# neutral (1) sub-scores for the build-derived signals -- the robot will floor
+# data_collection_ok to 0, which is the single honest "we couldn't measure"
+# signal. We do NOT fabricate failures from a missing dataset.
+if [ "$build_query_ok" -eq 0 ]; then
+    echo '[]' > "$BUILDS_FILE"
+fi
+
+NOW_EPOCH=$(date +%s)
+
+scores=$(jq -n \
+    --argjson now "$NOW_EPOCH" \
+    --slurpfile builds "$BUILDS_FILE" \
+    --argjson qthr "$QUEUE_MIN" \
+    --argjson dthr "$DURATION_MIN" \
+    --argjson maxlr "$SLI_MAX_LONGRUNNING" \
+    --arg maxratio "$SLI_MAX_FAILURE_RATIO" \
+    --arg protpat "$SLI_PROTECTED_BRANCH_PATTERN" '
+    def parsedate: (sub("\\.[0-9]+";"") | sub("(Z|[+-][0-9][0-9]:?[0-9][0-9])$";"")) + "Z" | fromdateiso8601;
+    ($builds[0] // []) as $b
+    | ($maxratio | tonumber) as $maxr
+    # --- windowed: completed builds in the lookback window -----------------
+    | ([ $b[] | select(.status == "completed" and (.result != null)) ]) as $done
+    | ($done | length) as $total
+    | ([ $done[] | select(.result == "failed") ] | length) as $failed
+    | (if $total == 0 then 0 else ($failed / $total) end) as $ratio
+    | (if $total == 0 then 1 elif $ratio <= $maxr then 1 else 0 end) as $failure_ratio_ok
+    # --- windowed: protected-branch pipelines failing 100% in window -------
+    | ([ $done[] | select((.sourceBranch // "") | test($protpat)) ]
+        | group_by(.definition.id)
+        | map({total: length, failed: (map(select(.result == "failed")) | length)})
+        | map(select(.total > 0 and .failed == .total))) as $prot_bad
+    | (if ($prot_bad | length) > 0 then 0 else 1 end) as $protected_ok
+    # --- point-in-time: queued (notStarted) builds aging past threshold ----
+    | ([ $b[]
+          | select(.status == "notStarted" and (.queueTime // null) != null)
+          | (($now - (.queueTime | parsedate)) / 60)
+          | select(. >= $qthr) ] | length) as $aged_q
+    | (if $aged_q > 0 then 0 else 1 end) as $queue_ok
+    # --- point-in-time: in-flight builds running past threshold ------------
+    | ([ $b[]
+          | select(.status == "inProgress" and (.startTime // null) != null)
+          | (($now - (.startTime | parsedate)) / 60)
+          | select(. >= $dthr) ] | length) as $lr
+    | (if $lr <= $maxlr then 1 else 0 end) as $long_ok
+    | {
+        pipeline_failure_ratio_ok:    $failure_ratio_ok,
+        protected_branch_failures_ok: $protected_ok,
+        queue_aging_ok:               $queue_ok,
+        long_running_ok:              $long_ok,
+        details: {
+          build_count:          ($b | length),
+          completed_in_window:  $total,
+          failed_in_window:     $failed,
+          failure_ratio:        (($ratio * 1000 | floor) / 1000),
+          max_failure_ratio:    $maxr,
+          protected_pipelines_failing_100pct: ($prot_bad | length),
+          queued_aging_builds:  $aged_q,
+          queue_threshold_min:  $qthr,
+          longrunning_inflight: $lr,
+          duration_threshold_min: $dthr,
+          max_longrunning:      $maxlr,
+          window:               "'"$RW_LOOKBACK_WINDOW"'"
+        }
+      }
+    ' 2>/dev/null)
+
+# Defensive fallback: if jq somehow produced nothing, emit neutral build-derived
+# scores so the robot still gets a parseable payload (data_collection_ok will be
+# floored to 0 via build_query_ok).
+if [ -z "$scores" ] || ! echo "$scores" | jq -e . >/dev/null 2>&1; then
+    scores='{"pipeline_failure_ratio_ok":1,"protected_branch_failures_ok":1,"queue_aging_ok":1,"long_running_ok":1,"details":{"error":"score computation failed"}}'
+    build_query_ok=0
+fi
+
+result=$(echo "$scores" | jq --argjson bq "$build_query_ok" '. + {build_query_ok: $bq}')
+
+echo "$result" > "$OUTPUT_FILE"
+echo "$result"

--- a/codebundles/azure-devops-project-health/sli.robot
+++ b/codebundles/azure-devops-project-health/sli.robot
@@ -1,0 +1,266 @@
+*** Settings ***
+Documentation       Cheap Azure DevOps project-health SLI. Fetches the project's builds ONCE for a short window (RW_LOOKBACK_WINDOW ~= scrape interval x1.5) and derives five binary {0,1} sub-scores — data collection OK, pipeline failure ratio within budget, no protected-branch pipeline failing 100%, no build queued past threshold, and in-flight long-running builds within budget — then averages them into a primary health score between 0 (failing) and 1 (healthy). Designed to run every ~30 min and to recover within ~one interval once a transient failure ages out of the window. Its SLO breach triggers this SLX's investigation runbook.
+Metadata            Author    runwhen
+Metadata            Display Name    Azure DevOps Project Health SLI
+Metadata            Supports    Azure    DevOps    Projects    Health    SLI
+
+Library             String
+Library             BuiltIn
+Library             Collections
+Library             RW.Core
+Library             RW.CLI
+Library             RW.platform
+
+Suite Setup         Suite Initialization
+
+
+*** Tasks ***
+Score Azure DevOps Project Pipeline Health for `${AZURE_DEVOPS_PROJECT}` in `${AZURE_DEVOPS_ORG}`
+    [Documentation]    Runs the single-pass build-dataset scorer and pushes the four build-derived sub-scores plus data_collection_ok. data_collection_ok = 1 only when the preflight access matrix is OK AND the build query returned a valid dataset (not an error marker); convention is "score 0 only for what we measure and confirm bad, 1 for what we cannot measure".
+    [Tags]    DevOps    Azure    Pipelines    sli    access:read-only    data:metrics
+    ${failure_ratio_ok}=    Set Variable    1
+    ${protected_ok}=    Set Variable    1
+    ${queue_ok}=    Set Variable    1
+    ${long_ok}=    Set Variable    1
+    ${build_query_ok}=    Set Variable    1
+    ${details}=    Create Dictionary
+    FOR    ${project}    IN    @{PROJECT_LIST}
+        ${score_env}=    Create Dictionary
+        ...    AZURE_DEVOPS_ORG=${AZURE_DEVOPS_ORG}
+        ...    AZURE_DEVOPS_PROJECT=${project}
+        ...    RW_LOOKBACK_WINDOW=${RW_LOOKBACK_WINDOW}
+        ...    SLI_MAX_FAILURE_RATIO=${SLI_MAX_FAILURE_RATIO}
+        ...    QUEUE_THRESHOLD=${QUEUE_THRESHOLD}
+        ...    DURATION_THRESHOLD=${DURATION_THRESHOLD}
+        ...    SLI_MAX_LONGRUNNING=${SLI_MAX_LONGRUNNING}
+        ...    SLI_PROTECTED_BRANCH_PATTERN=${SLI_PROTECTED_BRANCH_PATTERN}
+        ...    AUTH_TYPE=${AUTH_TYPE}
+        ...    AZURE_CONFIG_DIR=${AZURE_DEVOPS_CONFIG_DIR}
+        ${data}=    Create Dictionary
+        ...    pipeline_failure_ratio_ok=1    protected_branch_failures_ok=1
+        ...    queue_aging_ok=1    long_running_ok=1    build_query_ok=0    details=${{ {} }}
+        TRY
+            ${out}=    RW.CLI.Run Bash File
+            ...    bash_file=sli-project-health-score.sh
+            ...    env=${score_env}
+            ...    secret__azure_devops_pat=${AZURE_DEVOPS_PAT}
+            ...    timeout_seconds=120
+            ...    include_in_history=false
+            ${score_json_raw}=    RW.CLI.Run Cli
+            ...    cmd=cat sli_project_health_score.json 2>/dev/null || echo '{}'
+            TRY
+                ${data}=    Evaluate    json.loads(r'''${score_json_raw.stdout}''')    json
+            EXCEPT
+                ${data}=    Evaluate    json.loads(r'''${out.stdout}''')    json
+            END
+        EXCEPT    AS    ${err}
+            Log    Project SLI scoring failed for ${project}: ${err}    WARN
+        END
+        ${failure_ratio_ok}=    Evaluate    min(int(${failure_ratio_ok}), int(${data}.get('pipeline_failure_ratio_ok', 1)))    json
+        ${protected_ok}=    Evaluate    min(int(${protected_ok}), int(${data}.get('protected_branch_failures_ok', 1)))    json
+        ${queue_ok}=    Evaluate    min(int(${queue_ok}), int(${data}.get('queue_aging_ok', 1)))    json
+        ${long_ok}=    Evaluate    min(int(${long_ok}), int(${data}.get('long_running_ok', 1)))    json
+        ${build_query_ok}=    Evaluate    min(int(${build_query_ok}), int(${data}.get('build_query_ok', 0)))    json
+        ${d}=    Evaluate    ${data}.get('details', {})    json
+        ${ctx}=    Set Variable    Project `${project}` SLI: builds=${d.get('build_count', '-')}, failed=${d.get('failed_in_window', '-')} (ratio ${d.get('failure_ratio', '-')}), window=${d.get('window', '-')}
+        RW.Core.Add To Report    ${ctx}
+    END
+
+    # data_collection_ok folds the preflight access result with the build query
+    # result: both must be healthy to claim we actually measured the project.
+    ${data_collection_ok}=    Evaluate    1 if (${ACCESS_OK} and int(${build_query_ok}) == 1) else 0
+
+    Set Suite Variable    ${score_data_collection}    ${data_collection_ok}
+    Set Suite Variable    ${score_failure_ratio}    ${failure_ratio_ok}
+    Set Suite Variable    ${score_protected}    ${protected_ok}
+    Set Suite Variable    ${score_queue}    ${queue_ok}
+    Set Suite Variable    ${score_long_running}    ${long_ok}
+
+    RW.Core.Push Metric    ${data_collection_ok}    sub_name=data_collection_ok
+    RW.Core.Push Metric    ${failure_ratio_ok}    sub_name=pipeline_failure_ratio_ok
+    RW.Core.Push Metric    ${protected_ok}    sub_name=protected_branch_failures_ok
+    RW.Core.Push Metric    ${queue_ok}    sub_name=queue_aging_ok
+    RW.Core.Push Metric    ${long_ok}    sub_name=long_running_ok
+
+    ${summary}=    Set Variable    SLI scope `${AZURE_DEVOPS_PROJECT}` in `${AZURE_DEVOPS_ORG}`: access_ok=${ACCESS_OK}, build_query_ok=${build_query_ok}, failure_ratio_ok=${failure_ratio_ok}, protected_ok=${protected_ok}, queue_ok=${queue_ok}, long_running_ok=${long_ok}
+    RW.Core.Add To Report    ${summary}
+
+Generate Aggregate Azure DevOps Project Health Score for `${AZURE_DEVOPS_PROJECT}`
+    [Documentation]    Averages the five sub-scores (data_collection_ok, pipeline_failure_ratio_ok, protected_branch_failures_ok, queue_aging_ok, long_running_ok) into the primary SLI metric. A breach of this SLI's SLO triggers this SLX's runbook for a deep, longer-window investigation.
+    [Tags]    DevOps    Azure    Pipelines    sli    access:read-only    data:metrics
+    ${total}=    Evaluate    int(${score_data_collection}) + int(${score_failure_ratio}) + int(${score_protected}) + int(${score_queue}) + int(${score_long_running})
+    ${health_score}=    Evaluate    ${total} / 5.0
+    ${health_score}=    Convert To Number    ${health_score}    2
+    ${report_msg}=    Set Variable    Azure DevOps project health score: ${health_score} (data_collection=${score_data_collection}, failure_ratio_ok=${score_failure_ratio}, protected_branch_ok=${score_protected}, queue_aging_ok=${score_queue}, long_running_ok=${score_long_running})
+    RW.Core.Add To Report    ${report_msg}
+    RW.Core.Push Metric    ${health_score}
+
+
+*** Keywords ***
+Suite Initialization
+    Log    Starting Project SLI Suite Initialization...    INFO
+
+    # Support both Azure Service Principal and Azure DevOps PAT authentication
+    TRY
+        ${azure_credentials}=    RW.Core.Import Secret
+        ...    azure_credentials
+        ...    type=string
+        ...    description=The secret containing AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET, AZURE_SUBSCRIPTION_ID
+        ...    pattern=\w*
+        Set Suite Variable    ${AUTH_TYPE}    service_principal
+        Set Suite Variable    ${AZURE_DEVOPS_PAT}    ${EMPTY}
+    EXCEPT
+        Log    Azure credentials not found, trying Azure DevOps PAT...    INFO
+        TRY
+            ${azure_devops_pat}=    RW.Core.Import Secret
+            ...    azure_devops_pat
+            ...    type=string
+            ...    description=Azure DevOps Personal Access Token
+            ...    pattern=\w*
+            Set Suite Variable    ${AUTH_TYPE}    pat
+            Set Suite Variable    ${AZURE_DEVOPS_PAT}    ${azure_devops_pat}
+        EXCEPT
+            Log    No authentication method found, defaulting to service principal...    WARN
+            Set Suite Variable    ${AUTH_TYPE}    service_principal
+            Set Suite Variable    ${AZURE_DEVOPS_PAT}    ${EMPTY}
+        END
+    END
+
+    ${AZURE_DEVOPS_ORG}=    RW.Core.Import User Variable    AZURE_DEVOPS_ORG
+    ...    type=string
+    ...    description=Azure DevOps organization name.
+    ...    pattern=\w*
+    ${AZURE_DEVOPS_PROJECTS}=    RW.Core.Import User Variable    AZURE_DEVOPS_PROJECTS
+    ...    type=string
+    ...    description=Project to score, comma-separated list, or All/empty to discover and score every project in the org (local dev). Generated SLIs set a single project name.
+    ...    pattern=.*
+    ...    default=All
+    # Platform-injected in SLI context (seconds, derived from intervalSeconds). Do not set in the SLI template configProvided.
+    TRY
+        ${RW_LOOKBACK_WINDOW}=    RW.Core.Import Platform Variable    RW_LOOKBACK_WINDOW
+    EXCEPT
+        # Local `ro sli.robot` without platform injection: intervalSeconds 1800 × 1.5 → 45m window.
+        ${RW_LOOKBACK_WINDOW}=    Set Variable    2700
+    END
+    ${RW_LOOKBACK_WINDOW}=    RW.Core.Normalize Lookback Window    ${RW_LOOKBACK_WINDOW}    2
+    ${SLI_MAX_FAILURE_RATIO}=    RW.Core.Import User Variable    SLI_MAX_FAILURE_RATIO
+    ...    type=string
+    ...    description=Maximum failed/total completed-build ratio in the window before pipeline_failure_ratio_ok drops to 0. 0 runs in the window scores 1 (cannot measure = healthy).
+    ...    default=0.50
+    ...    pattern=^\d*\.?\d+$
+    ${QUEUE_THRESHOLD}=    RW.Core.Import User Variable    QUEUE_THRESHOLD
+    ...    type=string
+    ...    description=A build queued (notStarted) longer than this drops queue_aging_ok to 0 (point-in-time). Format: 30m, 1h.
+    ...    default=30m
+    ...    pattern=\w*
+    ${DURATION_THRESHOLD}=    RW.Core.Import User Variable    DURATION_THRESHOLD
+    ...    type=string
+    ...    description=In-flight builds running longer than this are counted as long-running (point-in-time). Format: 60m, 2h.
+    ...    default=60m
+    ...    pattern=\w*
+    ${SLI_MAX_LONGRUNNING}=    RW.Core.Import User Variable    SLI_MAX_LONGRUNNING
+    ...    type=string
+    ...    description=Maximum number of in-flight long-running builds allowed before long_running_ok drops to 0.
+    ...    default=1
+    ...    pattern=^\d+$
+    ${SLI_PROTECTED_BRANCH_PATTERN}=    RW.Core.Import User Variable    SLI_PROTECTED_BRANCH_PATTERN
+    ...    type=string
+    ...    description=Regex matching protected source branches. protected_branch_failures_ok scores 0 only when a pipeline on one of these branches fails 100% of its runs in the window.
+    ...    default=^refs/heads/(main|master|develop|release/)
+    ...    pattern=.*
+
+    # Resolve project scope: empty or All => discover every project (same as runbook).
+    ${projects_trimmed}=    Strip String    ${AZURE_DEVOPS_PROJECTS}
+    ${is_all}=    Evaluate    "${projects_trimmed}".lower() in ("", "all")
+    IF    ${is_all}
+        Log    AZURE_DEVOPS_PROJECTS empty/All — discovering all projects in organization...    INFO
+        ${PROJECT_LIST}=    Discover All Projects
+    ELSE
+        ${PROJECT_LIST}=    Split String    ${projects_trimmed}    ,
+        ${cleaned_projects}=    Create List
+        FOR    ${project}    IN    @{PROJECT_LIST}
+            ${project_trimmed}=    Strip String    ${project}
+            IF    "${project_trimmed}" != ""
+                Append To List    ${cleaned_projects}    ${project_trimmed}
+            END
+        END
+        ${PROJECT_LIST}=    Set Variable    ${cleaned_projects}
+    END
+    ${project_count}=    Get Length    ${PROJECT_LIST}
+    IF    ${project_count} == 0
+        Fail    No projects found or accessible in organization ${AZURE_DEVOPS_ORG}. Set AZURE_DEVOPS_PROJECTS to a project name, All, or leave empty to auto-discover.
+    END
+    IF    ${project_count} == 1
+        ${AZURE_DEVOPS_PROJECT}=    Set Variable    ${PROJECT_LIST}[0]
+    ELSE
+        ${AZURE_DEVOPS_PROJECT}=    Evaluate    str(len($PROJECT_LIST)) + " projects"
+    END
+    ${projects_csv}=    Evaluate    ",".join($PROJECT_LIST)
+
+    Set Suite Variable    ${AZURE_DEVOPS_ORG}    ${AZURE_DEVOPS_ORG}
+    Set Suite Variable    ${PROJECT_LIST}    ${PROJECT_LIST}
+    Set Suite Variable    ${AZURE_DEVOPS_PROJECT}    ${AZURE_DEVOPS_PROJECT}
+    Set Suite Variable    ${RW_LOOKBACK_WINDOW}    ${RW_LOOKBACK_WINDOW}
+    Set Suite Variable    ${SLI_MAX_FAILURE_RATIO}    ${SLI_MAX_FAILURE_RATIO}
+    Set Suite Variable    ${QUEUE_THRESHOLD}    ${QUEUE_THRESHOLD}
+    Set Suite Variable    ${DURATION_THRESHOLD}    ${DURATION_THRESHOLD}
+    Set Suite Variable    ${SLI_MAX_LONGRUNNING}    ${SLI_MAX_LONGRUNNING}
+    Set Suite Variable    ${SLI_PROTECTED_BRANCH_PATTERN}    ${SLI_PROTECTED_BRANCH_PATTERN}
+    Set Suite Variable    ${AZURE_DEVOPS_CONFIG_DIR}    %{CODEBUNDLE_TEMP_DIR}/.azure-devops
+
+    # Preflight access check (cheap capability matrix). Drives data_collection_ok.
+    ${preflight_env}=    Create Dictionary
+    ...    AZURE_DEVOPS_ORG=${AZURE_DEVOPS_ORG}
+    ...    AZURE_DEVOPS_PROJECTS=${projects_csv}
+    ...    AUTH_TYPE=${AUTH_TYPE}
+    ...    AZURE_CONFIG_DIR=${AZURE_DEVOPS_CONFIG_DIR}
+    ${access_ok}=    Set Variable    ${False}
+    TRY
+        ${preflight}=    RW.CLI.Run Bash File
+        ...    bash_file=preflight-check.sh
+        ...    env=${preflight_env}
+        ...    secret__azure_devops_pat=${AZURE_DEVOPS_PAT}
+        ...    timeout_seconds=120
+        ...    include_in_history=false
+        ${preflight_json_raw}=    RW.CLI.Run Cli
+        ...    cmd=cat preflight_results.json 2>/dev/null || echo '{"access_ok": false}'
+        ${preflight_data}=    Evaluate    json.loads(r'''${preflight_json_raw.stdout}''')    json
+        ${access_ok}=    Evaluate    bool(${preflight_data}.get('access_ok', False))
+    EXCEPT    AS    ${err}
+        Log    Preflight access check did not complete: ${err}    WARN
+    END
+    Set Suite Variable    ${ACCESS_OK}    ${access_ok}
+
+    Log    Project SLI Suite Initialization complete (scope=${AZURE_DEVOPS_PROJECT}, projects=${PROJECT_LIST}, access_ok=${ACCESS_OK}).    INFO
+
+
+Discover All Projects
+    [Documentation]    Auto-discover all projects in the Azure DevOps organization (same as runbook.robot).
+
+    ${temp_env}=    Create Dictionary
+    ...    AZURE_DEVOPS_ORG=${AZURE_DEVOPS_ORG}
+    ...    AUTH_TYPE=${AUTH_TYPE}
+    ${discover_projects}=    RW.CLI.Run Bash File
+    ...    bash_file=discover-projects.sh
+    ...    env=${temp_env}
+    ...    secret__azure_devops_pat=${AZURE_DEVOPS_PAT}
+    ...    timeout_seconds=60
+    ...    include_in_history=false
+    ${projects_result}=    RW.CLI.Run Cli
+    ...    cmd=cat discovered_projects.json
+    TRY
+        ${projects_data}=    Evaluate    json.loads(r'''${projects_result.stdout}''')    json
+        ${project_names}=    Evaluate    [project['name'] for project in ${projects_data}]
+        RETURN    ${project_names}
+    EXCEPT
+        Log    Failed to discover projects, using fallback method...    WARN
+        ${project_lines}=    Split To Lines    ${discover_projects.stdout}
+        ${project_names}=    Create List
+        FOR    ${line}    IN    @{project_lines}
+            ${line}=    Strip String    ${line}
+            IF    "${line}" != "" and not "${line}".startswith("#") and not "${line}".startswith("Analyzing")
+                Append To List    ${project_names}    ${line}
+            END
+        END
+        RETURN    ${project_names}
+    END


### PR DESCRIPTION
…d optimizations

- Introduced `ado_platform_incident_probe` in `_az_helpers.sh` to check Azure DevOps platform incidents using the official Status REST API, improving accuracy over previous numeric health codes.
- Updated `agent-pool-capacity.sh` to pre-fetch job-request queues for self-hosted pools, enhancing performance and ensuring accurate outage detection based on queued jobs.
- Refactored `cross-project-dependencies.sh` for a single-pass analysis of projects, reducing runtime and improving efficiency in identifying shared resources and potential dependency issues.
- Added new environment variables in `meta.yaml` for better configuration of project scanning limits and queue aging thresholds.
- Improved error handling and reporting across various scripts to provide clearer insights into issues related to agent pools and organization policies.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large behavioral change to monitoring (new SLI semantics, severity rules) and heavy API/refactor surface across org and project health bundles; misconfiguration of thresholds or auth could skew alerts until validated in target tenants.
> 
> **Overview**
> Replaces the **cron-scheduler placeholder** on org and project SLX templates with **real composite SLIs** (hourly org, 30‑min project) that point at new `sli.robot` / `sli-org-health-score.sh` flows and wire **Azure DevOps auth**, thresholds, and runbook-on-breach behavior.
> 
> **Shared `_az_helpers.sh`** gains corrected **platform status** probing (Status REST API + fixed portal numeric mapping), **queue-pressure** helpers and **parallel job-request prefetch** for agent pools, plus a **cached single-pass `fetch_project_builds`** path so pipeline tasks stop doing per-pipeline `az pipelines runs list` loops.
> 
> **Agent pool** scripts (org and project) now treat elastic/ephemeral **scale-to-zero as advisory** unless **aging queued work** or **assignedRequest on offline agents** warrants escalation; issue text explains classification and whether work is blocked.
> 
> **Org runbook** improvements: bounded **`MAX_PROJECTS`** cross-project scan (one pass per project), org-scoped **security group** listing, richer **preflight** capability matrix/reporting, and **service incident** checks using the shared probe.
> 
> **Project runbook** refactors **long-running** and **failure investigation** (and related meta/taskset vars like `RW_LOOKBACK_WINDOW`, SLI thresholds) to derive signals from the shared build dataset with caps on deep commit correlation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ca751756df387a77cd7f9655eaae269be41ee4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->