### PR TITLE
Enhance Azure DevOps organization health scripts for improved perform…

### DIFF
--- a/codebundles/azure-devops-organization-health/_az_helpers.sh
+++ b/codebundles/azure-devops-organization-health/_az_helpers.sh
@@ -691,12 +691,21 @@ fetch_pool_agents_parallel() {
 
     # Resolve auth once; pass via env to the parallel workers (keeps PAT out of argv).
     export ADO_AUTH_HDR; ADO_AUTH_HDR=$(ado_auth_header)
+    # TTL lets a second task in the SAME workdir reuse a fresh fetch instead of
+    # re-hitting the API for every pool (e.g. platform-issue-investigation after
+    # agent-pool-capacity in the org runbook).
+    export AGENT_CACHE_TTL="${AGENT_CACHE_TTL:-600}"
 
     echo "$pools_json" \
         | jq -r '.[] | select((.isHosted // false) == false) | .id' \
         | xargs -r -P "$max_par" -I {} bash -c '
             pool="$2"; out="$1/agents_$2.json"; err="$1/agents_$2.err"; raw="$1/agents_$2.raw"
             org="$3"
+            # Reuse a fresh, non-error cached result so a second consumer skips refetch.
+            if [ -s "$out" ] && ! grep -q "__fetch_error__" "$out" 2>/dev/null; then
+                mtime=$(stat -c %Y "$out" 2>/dev/null || echo 0)
+                if [ $(( $(date +%s) - mtime )) -lt "${AGENT_CACHE_TTL:-600}" ]; then exit 0; fi
+            fi
             mark_err() { echo "{\"__fetch_error__\": true}" >"$out"; }
             az_fetch() {
                 az pipelines agent list --pool-id "$pool" --org "$org" \
@@ -937,4 +946,23 @@ load_pool_job_requests_json() {
     else
         echo "[]"
     fi
+}
+
+# Echo (newline-separated) the subset of pool ids whose cached agents file shows
+# 0 ONLINE agents. The job-request queue probe is only consumed for pools at 0
+# online (to tell an idle scaled-to-zero pool from a real outage), so probing the
+# rest is wasted work. Pools with no readable cache are included (probe to be
+# safe); pools with a fetch-error marker are excluded (already reported).
+# Args: $1 = newline-separated non-hosted pool ids, $2 = agents cache dir
+pools_with_zero_online() {
+    local ids="$1" dir="$2" id f online
+    printf '%s\n' "$ids" | grep -E '^[0-9]+$' | while IFS= read -r id; do
+        f="$dir/agents_${id}.json"
+        if [ ! -s "$f" ]; then echo "$id"; continue; fi
+        if jq -e 'type == "object" and (.__fetch_error__ == true)' "$f" >/dev/null 2>&1; then
+            continue
+        fi
+        online=$(jq '[ .[] | select(((.status // "") | ascii_downcase) == "online") ] | length' "$f" 2>/dev/null || echo 0)
+        [ "${online:-0}" -eq 0 ] && echo "$id"
+    done
 }

--- a/codebundles/azure-devops-organization-health/agent-pool-capacity.sh
+++ b/codebundles/azure-devops-organization-health/agent-pool-capacity.sh
@@ -46,8 +46,13 @@ export AZURE_DEVOPS_EXT_PAT="${AZURE_DEVOPS_PAT}"
 source "$(dirname "$0")/_az_helpers.sh"
 
 OUTPUT_FILE="agent_pool_capacity.json"
-AGENT_CACHE_DIR="$(mktemp -d agentcap.XXXXXX)"
-trap 'rm -rf "$AGENT_CACHE_DIR" agent_pools.json' EXIT
+: "${MAX_POOLS:=500}"
+: "${AGENT_FETCH_PARALLELISM:=32}"
+# Stable, shared cache dir so a later task in the SAME workdir (platform-issue-
+# investigation) can reuse these agent fetches instead of re-scanning every pool.
+AGENT_CACHE_DIR="${ADO_AGENT_CACHE_DIR:-.ado_agent_cache}"
+mkdir -p "$AGENT_CACHE_DIR"
+trap 'rm -f agent_pools.json' EXIT
 capacity_json='[]'
 
 echo "Analyzing Agent Pool Capacity and Distribution..."
@@ -94,7 +99,23 @@ if [ "$pool_count" -eq 0 ]; then
     exit 0
 fi
 
-echo "Found $pool_count agent pools. Analyzing capacity..."
+# Bound the deep scan on very large orgs so the task completes within its
+# timeout. Microsoft-hosted pools are skipped for capacity analysis anyway, so
+# keep non-hosted pools first when capping.
+total_pool_count=$pool_count
+if [ "$pool_count" -gt "$MAX_POOLS" ]; then
+    agent_pools=$(echo "$agent_pools" | jq --argjson n "$MAX_POOLS" 'sort_by(.isHosted // false) | .[:$n]')
+    echo "$agent_pools" > agent_pools.json
+    pool_count=$(jq '. | length' agent_pools.json)
+    capacity_json=$(echo "$capacity_json" | jq \
+        --arg title "Agent Pool Scan Bounded (Large Organization)" \
+        --arg details "Organization has $total_pool_count agent pools; this run deep-scanned the first $pool_count (non-hosted first, MAX_POOLS=$MAX_POOLS) to stay within the task timeout. The hourly SLI covers org-wide capacity signal continuously." \
+        --arg severity "4" \
+        --arg nextStep "No action needed for monitoring. To deep-scan all $total_pool_count pools in one run, raise MAX_POOLS and the task timeout." \
+        '. += [{"title": $title, "details": $details, "severity": ($severity | tonumber), "next_steps": $nextStep}]')
+fi
+
+echo "Found $total_pool_count agent pools. Deep-scanning $pool_count. Analyzing capacity..."
 
 # Fetch agents for all non-hosted pools in parallel (major speedup for orgs
 # with hundreds of pools that previously ran one sequential call per pool).
@@ -108,8 +129,13 @@ fetch_pool_agents_parallel "$agent_pools" "$AGENT_CACHE_DIR"
 # making an inline serial call.
 if [ "${CHECK_QUEUE_ON_ZERO:-true}" = "true" ]; then
     nonhosted_pool_ids=$(echo "$agent_pools" | jq -r '.[] | select((.isHosted // false) == false) | .id')
-    echo "Pre-fetching job-request queues for self-hosted pools (parallelism: ${AGENT_FETCH_PARALLELISM:-20})..."
-    fetch_pool_job_requests_parallel "$nonhosted_pool_ids" "$AGENT_CACHE_DIR"
+    # The queue probe is only consumed for pools at 0 online agents (to tell an
+    # idle scaled-to-zero pool from a real outage), so restrict the potentially
+    # hundreds of job-request calls to just those pools.
+    queue_probe_ids=$(pools_with_zero_online "$nonhosted_pool_ids" "$AGENT_CACHE_DIR")
+    probe_n=$(printf '%s\n' "$queue_probe_ids" | grep -cE '^[0-9]+$' || true)
+    echo "Pre-fetching job-request queues for ${probe_n:-0} scaled-to-zero pool(s) (parallelism: ${AGENT_FETCH_PARALLELISM:-20})..."
+    [ -n "$queue_probe_ids" ] && fetch_pool_job_requests_parallel "$queue_probe_ids" "$AGENT_CACHE_DIR"
 fi
 
 # Initialize counters

--- a/codebundles/azure-devops-organization-health/platform-issue-investigation.sh
+++ b/codebundles/azure-devops-organization-health/platform-issue-investigation.sh
@@ -41,8 +41,13 @@ source "$(dirname "$0")/_az_helpers.sh"
 
 OUTPUT_FILE="platform_issue_investigation.json"
 investigation_json='[]'
-AGENT_CACHE_DIR="$(mktemp -d platforminv.XXXXXX)"
-trap 'rm -rf "$AGENT_CACHE_DIR"' EXIT
+: "${MAX_POOLS:=500}"
+: "${AGENT_FETCH_PARALLELISM:=32}"
+# Reuse the SAME stable cache dir as agent-pool-capacity.sh so this task (which
+# runs later in the org runbook) inherits its already-fetched pool agents within
+# the TTL instead of re-scanning every pool from scratch.
+AGENT_CACHE_DIR="${ADO_AGENT_CACHE_DIR:-.ado_agent_cache}"
+mkdir -p "$AGENT_CACHE_DIR"
 
 echo "Deep Platform Issue Investigation..."
 echo "Organization: $AZURE_DEVOPS_ORG"
@@ -57,17 +62,33 @@ echo "Investigating agent pool issues..."
 if agent_pools=$(az pipelines pool list --output json 2>/dev/null); then
     pool_count=$(echo "$agent_pools" | jq '. | length')
 
-    # Fetch all pool agents in parallel rather than one slow call per pool.
+    # Bound the deep scan on very large orgs so the task completes within its
+    # timeout (non-hosted pools first; hosted are skipped for this analysis).
+    total_pool_count=$pool_count
+    if [ "$pool_count" -gt "$MAX_POOLS" ]; then
+        agent_pools=$(echo "$agent_pools" | jq --argjson n "$MAX_POOLS" 'sort_by(.isHosted // false) | .[:$n]')
+        pool_count=$(echo "$agent_pools" | jq '. | length')
+        investigation_json=$(echo "$investigation_json" | jq \
+            --arg title "Platform Pool Scan Bounded (Large Organization)" \
+            --arg details "Organization has $total_pool_count agent pools; this run deep-scanned the first $pool_count (non-hosted first, MAX_POOLS=$MAX_POOLS) to stay within the task timeout." \
+            --arg severity "4" \
+            --arg nextStep "No action needed for monitoring. To deep-scan all $total_pool_count pools in one run, raise MAX_POOLS and the task timeout." \
+            '. += [{"title": $title, "details": $details, "severity": ($severity | tonumber), "next_steps": $nextStep}]')
+    fi
+
+    # Fetch all pool agents in parallel rather than one slow call per pool. Fresh
+    # files left by agent-pool-capacity.sh in the shared cache are reused (TTL).
     echo "  Fetching agents for $pool_count pools (parallelism: ${AGENT_FETCH_PARALLELISM:-20})..."
     fetch_pool_agents_parallel "$agent_pools" "$AGENT_CACHE_DIR"
 
-    # Pre-fetch each self-hosted pool's job-request queue in parallel, replacing
-    # the serial per-pool probe that ran inside the loop. Severity logic below is
-    # UNCHANGED; it just reads a pre-fetched file instead of an inline call.
+    # Pre-fetch job-request queues in parallel. The queue probe is only consumed
+    # for pools at 0 online agents, so restrict the calls to just those pools.
     if [ "${CHECK_QUEUE_ON_ZERO:-true}" = "true" ]; then
         nonhosted_pool_ids=$(echo "$agent_pools" | jq -r '.[] | select((.isHosted // false) == false) | .id')
-        echo "  Pre-fetching job-request queues for self-hosted pools (parallelism: ${AGENT_FETCH_PARALLELISM:-20})..."
-        fetch_pool_job_requests_parallel "$nonhosted_pool_ids" "$AGENT_CACHE_DIR"
+        queue_probe_ids=$(pools_with_zero_online "$nonhosted_pool_ids" "$AGENT_CACHE_DIR")
+        probe_n=$(printf '%s\n' "$queue_probe_ids" | grep -cE '^[0-9]+$' || true)
+        echo "  Pre-fetching job-request queues for ${probe_n:-0} scaled-to-zero pool(s) (parallelism: ${AGENT_FETCH_PARALLELISM:-20})..."
+        [ -n "$queue_probe_ids" ] && fetch_pool_job_requests_parallel "$queue_probe_ids" "$AGENT_CACHE_DIR"
     fi
 
     for ((i=0; i<pool_count; i++)); do

--- a/codebundles/azure-devops-organization-health/runbook.robot
+++ b/codebundles/azure-devops-organization-health/runbook.robot
@@ -81,7 +81,7 @@ Check Agent Pool Capacity and Utilization for Organization `${AZURE_DEVOPS_ORG}`
     ...    bash_file=agent-pool-capacity.sh
     ...    env=${env}
     ...    secret__azure_devops_pat=${AZURE_DEVOPS_PAT}
-    ...    timeout_seconds=300
+    ...    timeout_seconds=600
     ...    include_in_history=false
     ...    show_in_rwl_cheatsheet=true
     
@@ -279,7 +279,7 @@ Investigate Platform Issues for Organization `${AZURE_DEVOPS_ORG}`
     ...    bash_file=platform-issue-investigation.sh
     ...    env=${env}
     ...    secret__azure_devops_pat=${AZURE_DEVOPS_PAT}
-    ...    timeout_seconds=300
+    ...    timeout_seconds=600
     ...    include_in_history=false
     ...    show_in_rwl_cheatsheet=true
     
@@ -289,8 +289,16 @@ Investigate Platform Issues for Organization `${AZURE_DEVOPS_ORG}`
     TRY
         ${issue_list}=    Evaluate    json.loads(r'''${issues.stdout}''')    json
     EXCEPT
-        Log    Failed to load platform issues JSON payload, defaulting to empty list.    WARN
+        Log    Failed to load platform issues JSON payload — the script likely timed out or the API was unreachable.    WARN
         ${issue_list}=    Create List
+        RW.Core.Add Issue
+        ...    severity=3
+        ...    expected=Platform issue investigation data should be collected successfully from Azure DevOps API for organization `${AZURE_DEVOPS_ORG}`
+        ...    actual=Failed to collect platform investigation data — the script likely timed out or the Azure DevOps API was unreachable
+        ...    title=Platform Investigation Data Collection Failed for `${AZURE_DEVOPS_ORG}`
+        ...    reproduce_hint=${platform_investigation.cmd}
+        ...    details=The platform-issue-investigation.sh script did not produce valid JSON output. This typically indicates the Azure DevOps API was unresponsive or the script exceeded its ${{'600'}}s timeout while scanning organization agent pools.\n\nStdout: ${platform_investigation.stdout}
+        ...    next_steps=If this recurs, raise the task timeout or lower MAX_POOLS to bound the scan. Check Azure DevOps API availability and the identity's Agent Pools (Read) scope.
     END
     
     IF    len(@{issue_list}) > 0

--- a/codebundles/azure-devops-project-health/_az_helpers.sh
+++ b/codebundles/azure-devops-project-health/_az_helpers.sh
@@ -691,12 +691,21 @@ fetch_pool_agents_parallel() {
 
     # Resolve auth once; pass via env to the parallel workers (keeps PAT out of argv).
     export ADO_AUTH_HDR; ADO_AUTH_HDR=$(ado_auth_header)
+    # TTL lets a second task in the SAME workdir reuse a fresh fetch instead of
+    # re-hitting the API for every pool (e.g. platform-issue-investigation after
+    # agent-pool-capacity in the org runbook).
+    export AGENT_CACHE_TTL="${AGENT_CACHE_TTL:-600}"
 
     echo "$pools_json" \
         | jq -r '.[] | select((.isHosted // false) == false) | .id' \
         | xargs -r -P "$max_par" -I {} bash -c '
             pool="$2"; out="$1/agents_$2.json"; err="$1/agents_$2.err"; raw="$1/agents_$2.raw"
             org="$3"
+            # Reuse a fresh, non-error cached result so a second consumer skips refetch.
+            if [ -s "$out" ] && ! grep -q "__fetch_error__" "$out" 2>/dev/null; then
+                mtime=$(stat -c %Y "$out" 2>/dev/null || echo 0)
+                if [ $(( $(date +%s) - mtime )) -lt "${AGENT_CACHE_TTL:-600}" ]; then exit 0; fi
+            fi
             mark_err() { echo "{\"__fetch_error__\": true}" >"$out"; }
             az_fetch() {
                 az pipelines agent list --pool-id "$pool" --org "$org" \
@@ -937,4 +946,23 @@ load_pool_job_requests_json() {
     else
         echo "[]"
     fi
+}
+
+# Echo (newline-separated) the subset of pool ids whose cached agents file shows
+# 0 ONLINE agents. The job-request queue probe is only consumed for pools at 0
+# online (to tell an idle scaled-to-zero pool from a real outage), so probing the
+# rest is wasted work. Pools with no readable cache are included (probe to be
+# safe); pools with a fetch-error marker are excluded (already reported).
+# Args: $1 = newline-separated non-hosted pool ids, $2 = agents cache dir
+pools_with_zero_online() {
+    local ids="$1" dir="$2" id f online
+    printf '%s\n' "$ids" | grep -E '^[0-9]+$' | while IFS= read -r id; do
+        f="$dir/agents_${id}.json"
+        if [ ! -s "$f" ]; then echo "$id"; continue; fi
+        if jq -e 'type == "object" and (.__fetch_error__ == true)' "$f" >/dev/null 2>&1; then
+            continue
+        fi
+        online=$(jq '[ .[] | select(((.status // "") | ascii_downcase) == "online") ] | length' "$f" 2>/dev/null || echo 0)
+        [ "${online:-0}" -eq 0 ] && echo "$id"
+    done
 }

--- a/codebundles/azure-devops-project-health/agent-pools.sh
+++ b/codebundles/azure-devops-project-health/agent-pools.sh
@@ -41,6 +41,8 @@ source "$(dirname "$0")/_az_helpers.sh"
 OUTPUT_FILE="agent_pools_issues.json"
 issues_json='[]'
 ORG_URL="https://dev.azure.com/$AZURE_DEVOPS_ORG"
+: "${MAX_POOLS:=500}"
+: "${AGENT_FETCH_PARALLELISM:=32}"
 AGENT_CACHE_DIR="$(mktemp -d agentpools.XXXXXX)"
 trap 'rm -rf "$AGENT_CACHE_DIR" pools.json' EXIT
 
@@ -81,16 +83,35 @@ echo "$pools" > pools.json
 # Get the number of pools
 pool_count=$(jq '. | length' pools.json)
 
+# Bound the deep scan on very large orgs (this task scans org-wide pools) so it
+# completes within its timeout. Microsoft-hosted pools are skipped anyway, so
+# keep non-hosted pools first when capping.
+total_pool_count=$pool_count
+if [ "$pool_count" -gt "$MAX_POOLS" ]; then
+    pools=$(echo "$pools" | jq --argjson n "$MAX_POOLS" 'sort_by(.isHosted // false) | .[:$n]')
+    echo "$pools" > pools.json
+    pool_count=$(jq '. | length' pools.json)
+    issues_json=$(echo "$issues_json" | jq \
+        --arg title "Agent Pool Scan Bounded (Large Organization)" \
+        --arg details "Organization has $total_pool_count agent pools; this run deep-scanned the first $pool_count (non-hosted first, MAX_POOLS=$MAX_POOLS) to stay within the task timeout." \
+        --arg severity "4" \
+        --arg nextStep "No action needed for monitoring. To deep-scan all $total_pool_count pools in one run, raise MAX_POOLS and the task timeout." \
+        '. += [{"title": $title, "details": $details, "severity": ($severity | tonumber), "next_steps": $nextStep}]')
+fi
+
 # Fetch agents for all non-hosted pools in parallel (much faster than a
 # sequential call per pool when an organisation has many pools).
 echo "Fetching agents for all self-hosted pools (parallelism: ${AGENT_FETCH_PARALLELISM:-20})..."
 fetch_pool_agents_parallel "$pools" "$AGENT_CACHE_DIR"
 
-# Pre-fetch job-request queues in parallel (same pattern as org agent-pool-capacity).
+# Pre-fetch job-request queues in parallel. The queue probe is only consumed for
+# pools at 0 online agents, so restrict the calls to just those pools.
 if [[ "${CHECK_QUEUE_ON_ZERO:-true}" == "true" ]]; then
     nonhosted_pool_ids=$(jq -r '.[] | select((.isHosted // false) == false) | .id' pools.json)
-    echo "Pre-fetching job-request queues for self-hosted pools (parallelism: ${AGENT_FETCH_PARALLELISM:-20})..."
-    fetch_pool_job_requests_parallel "$nonhosted_pool_ids" "$AGENT_CACHE_DIR"
+    queue_probe_ids=$(pools_with_zero_online "$nonhosted_pool_ids" "$AGENT_CACHE_DIR")
+    probe_n=$(printf '%s\n' "$queue_probe_ids" | grep -cE '^[0-9]+$' || true)
+    echo "Pre-fetching job-request queues for ${probe_n:-0} scaled-to-zero pool(s) (parallelism: ${AGENT_FETCH_PARALLELISM:-20})..."
+    [ -n "$queue_probe_ids" ] && fetch_pool_job_requests_parallel "$queue_probe_ids" "$AGENT_CACHE_DIR"
 fi
 
 # Process each agent pool using a for loop instead of pipe to while

--- a/codebundles/azure-devops-project-health/pipeline-logs.sh
+++ b/codebundles/azure-devops-project-health/pipeline-logs.sh
@@ -166,11 +166,13 @@ if [ "$failed_count" -gt "$investigate_count" ]; then
         --arg details "Found $failed_count failed builds in the last ${RW_LOOKBACK_WINDOW}; logs were fetched for the $investigate_count most recent (MAX_FAILURES_TO_INVESTIGATE=$MAX_FAILURES_TO_INVESTIGATE). Raise MAX_FAILURES_TO_INVESTIGATE to investigate more." \
         --arg severity "4" \
         --arg nextStep "Review the most recent failures first. Increase MAX_FAILURES_TO_INVESTIGATE if deeper coverage is required." \
+        --arg resource_url "https://dev.azure.com/$AZURE_DEVOPS_ORG/$(ado_urlencode "$AZURE_DEVOPS_PROJECT")/_build" \
         '. += [{
            "title": $title,
            "details": $details,
            "next_steps": $nextStep,
-           "severity": ($severity | tonumber)
+           "severity": ($severity | tonumber),
+           "resource_url": $resource_url
          }]')
 fi
 

--- a/codebundles/azure-devops-project-health/repo-policies.sh
+++ b/codebundles/azure-devops-project-health/repo-policies.sh
@@ -15,6 +15,7 @@
 
 : "${AZURE_DEVOPS_ORG:?Must set AZURE_DEVOPS_ORG}"
 : "${AUTH_TYPE:=service_principal}"
+: "${MAX_REPOS:=200}"
 AZURE_DEVOPS_PAT="${AZURE_DEVOPS_PAT:-${azure_devops_pat:-}}"
 export AZURE_DEVOPS_EXT_PAT="${AZURE_DEVOPS_PAT}"
 
@@ -129,6 +130,20 @@ for ((p=0; p<project_count; p++)); do
     # Get the number of repos
     repo_count=$(jq '. | length' repos.json)
     echo "Found $repo_count repositories in project $project_name"
+
+    # Bound the per-repo loop so projects with very many repositories complete
+    # within the task timeout (the loop spawns several jq passes per repo).
+    total_repo_count=$repo_count
+    if [ "$repo_count" -gt "$MAX_REPOS" ]; then
+        repo_count=$MAX_REPOS
+        echo "  Project $project_name has $total_repo_count repositories; analyzing the first $repo_count (MAX_REPOS=$MAX_REPOS)."
+        issues_json=$(echo "$issues_json" | jq \
+            --arg title "Repository Policy Scan Bounded for Project \`$project_name\`" \
+            --arg details "Project has $total_repo_count repositories; this run analyzed the first $repo_count branch-policy sets (MAX_REPOS=$MAX_REPOS) to stay within the task timeout." \
+            --arg severity "4" \
+            --arg nextStep "No action needed for monitoring. To analyze all $total_repo_count repositories in one run, raise MAX_REPOS and the task timeout." \
+            '. += [{"title": $title, "details": $details, "severity": ($severity | tonumber), "next_steps": $nextStep}]')
+    fi
 
     # Single-pass: fetch ALL policy configurations for the project ONCE, instead
     # of one `az repos policy list --repository-id <id>` call per repository (the

--- a/codebundles/azure-devops-project-health/runbook.robot
+++ b/codebundles/azure-devops-project-health/runbook.robot
@@ -46,7 +46,7 @@ Check Agent Pool Availability Across Projects in `${AZURE_DEVOPS_ORG}`
     ...    bash_file=agent-pools.sh
     ...    env=${env}
     ...    secret__azure_devops_pat=${AZURE_DEVOPS_PAT}
-    ...    timeout_seconds=300
+    ...    timeout_seconds=600
     ...    include_in_history=false
     ...    show_in_rwl_cheatsheet=true
     
@@ -64,7 +64,7 @@ Check Agent Pool Availability Across Projects in `${AZURE_DEVOPS_ORG}`
         ...    actual=Failed to collect agent pool data — the script likely timed out or the Azure DevOps API was unreachable
         ...    title=Agent Pool Data Collection Failed for `${AZURE_DEVOPS_ORG}`
         ...    reproduce_hint=${agent_pool.cmd}
-        ...    details=The agent-pools.sh script did not produce valid JSON output. This typically indicates the Azure DevOps API was unresponsive or the script exceeded its ${{'300'}}s timeout while fetching agents for all organization pools.\n\nPreflight access check: ${PREFLIGHT_SUMMARY}\n\nStdout: ${agent_pool.stdout}
+        ...    details=The agent-pools.sh script did not produce valid JSON output. This typically indicates the Azure DevOps API was unresponsive or the script exceeded its ${{'600'}}s timeout while fetching agents for all organization pools. Lower MAX_POOLS to bound the scan.\n\nPreflight access check: ${PREFLIGHT_SUMMARY}\n\nStdout: ${agent_pool.stdout}
         ...    next_steps=Review the preflight access check results in the report for identity and permission details. Check Azure DevOps API availability for organization `${AZURE_DEVOPS_ORG}`. Verify network connectivity from the runner to dev.azure.com. Review Azure DevOps service health at https://status.dev.azure.com.
     END
 
@@ -132,6 +132,8 @@ Check for Failed Pipelines Across Projects in `${AZURE_DEVOPS_ORG}`
         
         IF    len(@{issue_list}) > 0
             FOR    ${issue}    IN    @{issue_list}
+                ${next_steps}=    Get From Dictionary    ${issue}    next_steps    Review the failed run, recent commits on the branch, and pipeline configuration in Azure DevOps.
+                ${resource_url}=    Get From Dictionary    ${issue}    resource_url    ${EMPTY}
                 RW.Core.Add Issue
                 ...    severity=${issue['severity']}
                 ...    expected=Pipeline should complete successfully in project `${project}`
@@ -139,8 +141,8 @@ Check for Failed Pipelines Across Projects in `${AZURE_DEVOPS_ORG}`
                 ...    title=${issue['title']} (Project: ${project})
                 ...    reproduce_hint=${failed_pipelines.cmd}
                 ...    details=${issue['details']}
-                ...    next_steps=${issue['next_steps']}
-                ...    resource_url=${issue['resource_url']}
+                ...    next_steps=${next_steps}
+                ...    resource_url=${resource_url}
             END
         END
     END
@@ -182,6 +184,8 @@ Check for Long-Running Pipelines Across Projects in `${AZURE_DEVOPS_ORG}` (Thres
         
         IF    len(@{issue_list}) > 0
             FOR    ${issue}    IN    @{issue_list}
+                ${next_steps}=    Get From Dictionary    ${issue}    next_steps    Investigate why the pipeline is taking longer than expected. Check for resource constraints or inefficient tasks.
+                ${resource_url}=    Get From Dictionary    ${issue}    resource_url    ${EMPTY}
                 RW.Core.Add Issue
                 ...    severity=${issue['severity']}
                 ...    expected=Pipeline should complete within the expected time frame (${DURATION_THRESHOLD}) in project `${project}`
@@ -189,8 +193,8 @@ Check for Long-Running Pipelines Across Projects in `${AZURE_DEVOPS_ORG}` (Thres
                 ...    title=${issue['title']} (Project: ${project})
                 ...    reproduce_hint=${long_running.cmd}
                 ...    details=${issue['details']}
-                ...    next_steps=${issue['next_steps']}
-                ...    resource_url=${issue['resource_url']}
+                ...    next_steps=${next_steps}
+                ...    resource_url=${resource_url}
             END
         END
     END
@@ -232,6 +236,8 @@ Check for Queued Pipelines Across Projects in `${AZURE_DEVOPS_ORG}` (Threshold: 
         
         IF    len(@{issue_list}) > 0
             FOR    ${issue}    IN    @{issue_list}
+                ${next_steps}=    Get From Dictionary    ${issue}    next_steps    Check agent pool capacity and availability. Consider adding more agents or optimizing pipeline concurrency limits.
+                ${resource_url}=    Get From Dictionary    ${issue}    resource_url    ${EMPTY}
                 RW.Core.Add Issue
                 ...    severity=${issue['severity']}
                 ...    expected=Pipeline should start execution promptly (within ${QUEUE_THRESHOLD}) in project `${project}`
@@ -239,8 +245,8 @@ Check for Queued Pipelines Across Projects in `${AZURE_DEVOPS_ORG}` (Threshold: 
                 ...    title=${issue['title']} (Project: ${project})
                 ...    reproduce_hint=${queued_pipelines.cmd}
                 ...    details=${issue['details']}
-                ...    next_steps=${issue['next_steps']}
-                ...    resource_url=${issue['resource_url']}
+                ...    next_steps=${next_steps}
+                ...    resource_url=${resource_url}
             END
         END
     END
@@ -254,7 +260,7 @@ Check Repository Branch Policies Across Projects in `${AZURE_DEVOPS_ORG}`
         ...    bash_file=repo-policies.sh
         ...    env=${env}
         ...    secret__azure_devops_pat=${AZURE_DEVOPS_PAT}
-        ...    timeout_seconds=180
+        ...    timeout_seconds=300
         ...    include_in_history=false
         ...    show_in_rwl_cheatsheet=true
         ...    cmd_override=AZURE_DEVOPS_PROJECT="${project}" ./repo-policies.sh


### PR DESCRIPTION
…ance and caching

- Introduced a shared agent cache directory across multiple scripts to optimize agent fetching and reduce redundant API calls.
- Implemented a time-to-live (TTL) mechanism for cached agent data, allowing subsequent tasks to reuse fresh fetch results within a specified timeframe.
- Updated `agent-pool-capacity.sh` and `platform-issue-investigation.sh` to limit the number of pools scanned in large organizations, ensuring tasks complete within their timeout limits.
- Enhanced error handling and reporting for job-request queues, focusing on pools with zero online agents to improve outage detection accuracy.
- Increased timeout settings in the runbook to accommodate longer execution times for comprehensive analysis.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only monitoring scripts and runbook timeout/reporting tweaks; behavior changes are performance bounds and clearer advisories, not auth or data mutation.
> 
> **Overview**
> Speeds up Azure DevOps org/project health runs on large tenants by **caching agent list fetches** (shared `.ado_agent_cache`, **600s TTL** skip in parallel workers) and **reusing cache** between org tasks like `agent-pool-capacity` and `platform-issue-investigation`.
> 
> **Caps deep scans** with `MAX_POOLS` (500) and `MAX_REPOS` (200), preferring self-hosted pools first and emitting severity-4 “bounded scan” advisories when truncated.
> 
> **Cuts API load** by prefetching job-request queues only for pools with **zero online agents** (`pools_with_zero_online`), not every self-hosted pool.
> 
> Runbooks raise bash timeouts (**600s** org agent/platform tasks; project agent pools/repo policies) and improve failure reporting (platform investigation issue; optional `next_steps` / `resource_url` on pipeline runbook issues; build link on capped pipeline-log investigations).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98c9c67d5ba48c038ddd7816d158ae35aa30726f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->