### PR TITLE
Refactor Azure DevOps health scripts to cluster agent pool findings

### DIFF
--- a/codebundles/azure-devops-organization-health/agent-pool-capacity.sh
+++ b/codebundles/azure-devops-organization-health/agent-pool-capacity.sh
@@ -147,6 +147,14 @@ pools_with_issues=0
 elastic_pools=0
 ephemeral_pools=0
 
+# Clustered findings: emitting one issue per pool floods the report on orgs with
+# hundreds of pools. Accumulate low-signal/uniform findings and emit ONE issue
+# per category after the loop. Genuine, rare signals (aging queued work, work
+# assigned to offline agents) stay per-pool below.
+declare -a elastic_idle=()        # elastic/ephemeral scaled to zero (expected, sev 4)
+declare -a cap_lines_sev2=()      # static pools with reduced/lost capacity (sev 2)
+declare -a cap_lines_sev3=()      # static pools with no agents configured (sev 3)
+
 # Analyze each agent pool
 for ((i=0; i<pool_count; i++)); do
     pool_json=$(jq -c ".[${i}]" agent_pools.json)
@@ -282,19 +290,10 @@ for ((i=0; i<pool_count; i++)); do
                 pools_with_issues=$((pools_with_issues + 1))
                 echo "  $pool_kind pool $pool_name: work assigned to offline agents -> sev 3."
             else
-                pool_details=$(ado_pool_issue_details \
-                    "Pool scaled to zero: 0 online, $offline_count expected offline churn, no queued work and no assignedRequest." \
-                    "$pool_name" "$pool_id" "$pool_type" "$pool_kind" "$agent_count" "$online_count" \
-                    "$offline_count" "$busy_count" "$expected_offline" \
-                    "Advisory only -- expected dynamic scale-down. No pipelines are waiting on this pool." "" \
-                    "$POOL_KIND_REASON" "$queue_status")
-                capacity_json=$(echo "$capacity_json" | jq \
-                    --arg title "Agent Pool \`$pool_name\` Scaled To Zero (Expected Dynamic Scale-Down)" \
-                    --arg details "$pool_details" \
-                    --arg severity "4" \
-                    --arg nextStep "No action needed -- a dynamic pool idle at 0 online agents is expected. If builds later queue without starting, investigate autoscale/VMSS/KEDA and service connections." \
-                    '. += [{"title": $title, "details": $details, "next_steps": $nextStep, "severity": ($severity | tonumber)}]')
-                echo "  $pool_kind pool $pool_name scaled to zero: sev-4 advisory (expected)."
+                # Expected idle autoscaling: cluster into ONE sev-4 advisory after
+                # the loop instead of an issue per pool.
+                elastic_idle+=("\`$pool_name\` (id=$pool_id, $pool_kind): 0 online, $offline_count offline churn${queue_status:+; $queue_status}")
+                echo "  $pool_kind pool $pool_name scaled to zero: clustered sev-4 advisory (expected)."
             fi
         else
             pool_issues+=("All agents offline")
@@ -329,57 +328,50 @@ for ((i=0; i<pool_count; i++)); do
         echo "  NOTE: $offline_count offline registrations are expected for a $pool_kind pool (torn-down scale-set/ephemeral agents). Not flagged as a capacity issue."
     fi
 
-    # Add pool analysis to results - only create issues for pools with actual problems
+    # Accumulate per-pool problems into severity-bucketed clusters (emitted once
+    # after the loop) instead of one issue per pool.
     if [ ${#pool_issues[@]} -gt 0 ]; then
         pools_with_issues=$((pools_with_issues + 1))
         issues_summary=$(IFS='; '; echo "${pool_issues[*]}")
-        title="Agent Pool Capacity Issue: $pool_name"
-        # A short sample of offline agent names so a human can see whether they are
-        # generated/ephemeral or named persistent hosts.
-        offline_sample=$(echo "$agents" | jq -r '[.[] | select(.status == "offline") | .name][:5] | join(", ")' 2>/dev/null || true)
-        pool_details=$(ado_pool_issue_details \
-            "Capacity issues: $issues_summary" \
-            "$pool_name" "$pool_id" "$pool_type" "$pool_kind" "$agent_count" "$online_count" \
-            "$offline_count" "$busy_count" "$expected_offline" \
-            "Utilization (online agents only): ${utilization}%" "$offline_sample" \
-            "$POOL_KIND_REASON" "")
-        
-        capacity_json=$(echo "$capacity_json" | jq \
-            --arg title "$title" \
-            --arg pool_name "$pool_name" \
-            --arg pool_id "$pool_id" \
-            --arg pool_type "$pool_type" \
-            --arg pool_kind "$pool_kind" \
-            --arg agent_count "$agent_count" \
-            --arg online_count "$online_count" \
-            --arg offline_count "$offline_count" \
-            --arg expected_offline "$expected_offline" \
-            --arg busy_count "$busy_count" \
-            --arg utilization "$utilization" \
-            --arg issues_summary "$issues_summary" \
-            --arg details "$pool_details" \
-            --arg severity "$severity" \
-            '. += [{
-               "title": $title,
-               "pool_name": $pool_name,
-               "pool_id": $pool_id,
-               "pool_type": $pool_type,
-               "pool_kind": $pool_kind,
-               "total_agents": ($agent_count | tonumber),
-               "online_agents": ($online_count | tonumber),
-               "offline_agents": ($offline_count | tonumber),
-               "expected_offline_agents": ($expected_offline | tonumber),
-               "busy_agents": ($busy_count | tonumber),
-               "utilization_percent": $utilization,
-               "issues_summary": $issues_summary,
-               "severity": ($severity | tonumber),
-               "details": $details,
-               "next_steps": "Review agent pool \($pool_name) online capacity. For elastic/VMSS pools, verify the scale-set can provision agents; for static pools, investigate the offline agents and add capacity if utilization is high."
-             }]')
+        line="\`$pool_name\` (id=$pool_id, $pool_kind): $issues_summary [${online_count}/${agent_count} online, ${utilization}% util]"
+        if [ "$severity" -le 2 ]; then
+            cap_lines_sev2+=("$line")
+        else
+            cap_lines_sev3+=("$line")
+        fi
     else
         echo "  Pool $pool_name capacity appears normal"
     fi
 done
+
+# --- Clustered agent-pool findings (one issue per category, not per pool) ---
+if [ "${#cap_lines_sev2[@]}" -gt 0 ]; then
+    cluster_list=$(printf '  - %s\n' "${cap_lines_sev2[@]}")
+    capacity_json=$(echo "$capacity_json" | jq \
+        --arg title "Static Agent Pools With Reduced Or Lost Capacity (${#cap_lines_sev2[@]} pools)" \
+        --arg details "$( printf '%s self-hosted pool(s) have capacity problems (all agents offline, high offline ratio, high utilization, or only 1 agent online):\n%s' "${#cap_lines_sev2[@]}" "$cluster_list" )" \
+        --arg severity "2" \
+        --arg nextStep "For each pool: if active, restart the offline agent services, confirm hosts are powered on and can reach dev.azure.com, and verify agent credentials/PAT. If utilization is high, add agents. If a pool is retired, delete it so it stops being reported." \
+        '. += [{"title": $title, "details": $details, "next_steps": $nextStep, "severity": ($severity | tonumber)}]')
+fi
+if [ "${#cap_lines_sev3[@]}" -gt 0 ]; then
+    cluster_list=$(printf '  - %s\n' "${cap_lines_sev3[@]}")
+    capacity_json=$(echo "$capacity_json" | jq \
+        --arg title "Static Agent Pools With No Agents Configured (${#cap_lines_sev3[@]} pools)" \
+        --arg details "$( printf '%s self-hosted pool(s) have zero agents registered:\n%s' "${#cap_lines_sev3[@]}" "$cluster_list" )" \
+        --arg severity "3" \
+        --arg nextStep "Register agents for these pools if they are still in use, or delete the empty pools to keep the inventory clean." \
+        '. += [{"title": $title, "details": $details, "next_steps": $nextStep, "severity": ($severity | tonumber)}]')
+fi
+if [ "${#elastic_idle[@]}" -gt 0 ]; then
+    cluster_list=$(printf '  - %s\n' "${elastic_idle[@]}")
+    capacity_json=$(echo "$capacity_json" | jq \
+        --arg title "Elastic Pools Scaled To Zero (Expected) (${#elastic_idle[@]} pools)" \
+        --arg details "$( printf '%s elastic/ephemeral pool(s) are idle at 0 online agents with no queued work (expected autoscaling):\n%s' "${#elastic_idle[@]}" "$cluster_list" )" \
+        --arg severity "4" \
+        --arg nextStep "No action needed -- dynamic pools idle at 0 online agents are expected. If builds later queue without starting on any of these, investigate autoscale/VMSS/KEDA and service connections." \
+        '. += [{"title": $title, "details": $details, "next_steps": $nextStep, "severity": ($severity | tonumber)}]')
+fi
 
 # Calculate overall organization capacity metrics
 if [ "$total_online" -gt 0 ]; then

--- a/codebundles/azure-devops-organization-health/agent-pool-capacity.sh
+++ b/codebundles/azure-devops-organization-health/agent-pool-capacity.sh
@@ -152,7 +152,8 @@ ephemeral_pools=0
 # per category after the loop. Genuine, rare signals (aging queued work, work
 # assigned to offline agents) stay per-pool below.
 declare -a elastic_idle=()        # elastic/ephemeral scaled to zero (expected, sev 4)
-declare -a cap_lines_sev2=()      # static pools with reduced/lost capacity (sev 2)
+declare -a cap_lines_sev2=()      # STATIC pools with reduced/lost capacity (sev 2)
+declare -a cap_lines_dyn_sev2=()  # elastic/ephemeral pools at high utilization (sev 2)
 declare -a cap_lines_sev3=()      # static pools with no agents configured (sev 3)
 
 # Analyze each agent pool
@@ -335,7 +336,15 @@ for ((i=0; i<pool_count; i++)); do
         issues_summary=$(IFS='; '; echo "${pool_issues[*]}")
         line="\`$pool_name\` (id=$pool_id, $pool_kind): $issues_summary [${online_count}/${agent_count} online, ${utilization}% util]"
         if [ "$severity" -le 2 ]; then
-            cap_lines_sev2+=("$line")
+            # The static-pool cluster carries restart/PAT remediation that does not
+            # apply to elastic/ephemeral pools. The only sev-2 problem a dynamic
+            # pool can hit here is high utilization, so route it to its own
+            # scaler-oriented cluster.
+            if [ "$pool_kind" = "static" ]; then
+                cap_lines_sev2+=("$line")
+            else
+                cap_lines_dyn_sev2+=("$line")
+            fi
         else
             cap_lines_sev3+=("$line")
         fi
@@ -352,6 +361,15 @@ if [ "${#cap_lines_sev2[@]}" -gt 0 ]; then
         --arg details "$( printf '%s self-hosted pool(s) have capacity problems (all agents offline, high offline ratio, high utilization, or only 1 agent online):\n%s' "${#cap_lines_sev2[@]}" "$cluster_list" )" \
         --arg severity "2" \
         --arg nextStep "For each pool: if active, restart the offline agent services, confirm hosts are powered on and can reach dev.azure.com, and verify agent credentials/PAT. If utilization is high, add agents. If a pool is retired, delete it so it stops being reported." \
+        '. += [{"title": $title, "details": $details, "next_steps": $nextStep, "severity": ($severity | tonumber)}]')
+fi
+if [ "${#cap_lines_dyn_sev2[@]}" -gt 0 ]; then
+    cluster_list=$(printf '  - %s\n' "${cap_lines_dyn_sev2[@]}")
+    capacity_json=$(echo "$capacity_json" | jq \
+        --arg title "Elastic/Ephemeral Agent Pools At High Utilization (${#cap_lines_dyn_sev2[@]} pools)" \
+        --arg details "$( printf '%s elastic/ephemeral pool(s) are running at or above the utilization threshold -- the scaler may not be provisioning agents fast enough to keep up with demand:\n%s' "${#cap_lines_dyn_sev2[@]}" "$cluster_list" )" \
+        --arg severity "2" \
+        --arg nextStep "These are dynamically-scaled pools -- do NOT restart agents. Increase the elastic pool maximum size, check the backing Azure VMSS / Kubernetes (KEDA) scaler health and quotas, and verify the service connection so the pool can provision more agents under load." \
         '. += [{"title": $title, "details": $details, "next_steps": $nextStep, "severity": ($severity | tonumber)}]')
 fi
 if [ "${#cap_lines_sev3[@]}" -gt 0 ]; then

--- a/codebundles/azure-devops-organization-health/platform-issue-investigation.sh
+++ b/codebundles/azure-devops-organization-health/platform-issue-investigation.sh
@@ -91,6 +91,14 @@ if agent_pools=$(az pipelines pool list --output json 2>/dev/null); then
         [ -n "$queue_probe_ids" ] && fetch_pool_job_requests_parallel "$queue_probe_ids" "$AGENT_CACHE_DIR"
     fi
 
+    # Clustered findings: emit one issue per category after the loop instead of
+    # one per pool (an org with hundreds of pools otherwise floods the report).
+    # Genuine, rare signals (aging queued work, work assigned to offline agents)
+    # stay per-pool below.
+    declare -a static_offline=()    # static pools with offline agents (lost capacity)
+    declare -a elastic_idle=()      # elastic/ephemeral scaled to zero (expected)
+    declare -a outdated_agents=()   # pools running outdated agent versions
+
     for ((i=0; i<pool_count; i++)); do
         pool_json=$(jq -c ".[${i}]" <<< "$agent_pools")
         pool_name=$(echo "$pool_json" | jq -r '.name')
@@ -179,54 +187,63 @@ if agent_pools=$(az pipelines pool list --output json 2>/dev/null); then
                         --arg next_steps "Confirm the scaler replaced the torn-down agents. If the assignedRequest persists, re-queue the job or verify the backing VMSS/Kubernetes infrastructure." \
                         '. += [{"title": $title, "details": $details, "severity": ($severity | tonumber), "next_steps": $next_steps}]')
                 else
-                    pool_details=$(ado_pool_issue_details \
-                        "Pool scaled to zero with $offline_count expected offline registrations; no queued work and no assignedRequest." \
-                        "$pool_name" "$pool_id" "$pool_type" "$pool_kind" "$agent_count" "$online_count" \
-                        "$offline_count" "$busy_count" "$offline_count" \
-                        "Advisory only -- expected dynamic scale-down. No pipelines are waiting on this pool." "" \
-                        "$POOL_KIND_REASON" "$queue_status")
-                    investigation_json=$(echo "$investigation_json" | jq \
-                        --arg title "Elastic Pool Scaled To Zero (Expected Dynamic Scale-Down): $pool_name" \
-                        --arg details "$pool_details" \
-                        --arg severity "4" \
-                        --arg next_steps "No action needed -- a dynamic pool idle at 0 online agents is expected. If builds later queue without starting, investigate autoscale/VMSS/KEDA." \
-                        '. += [{"title": $title, "details": $details, "severity": ($severity | tonumber), "next_steps": $next_steps}]')
+                    # Expected idle autoscaling: cluster into ONE sev-4 advisory.
+                    elastic_idle+=("\`$pool_name\` (id=$pool_id, $pool_kind): 0 online, $offline_count offline churn${queue_status:+; $queue_status}")
                 fi
             fi
         elif [ "$offline_count" -gt 0 ]; then
-            # Static pool: offline agents are genuine lost capacity. Cap the
-            # enumerated detail to avoid pathological output sizes.
+            # Static pool: offline agents are lost capacity, but full outage
+            # (0 online) vs reduced capacity (online>0) get different severity
+            # when clustered below.
             offline_details=$(echo "$agents" | jq -r --argjson n "$MAX_OFFLINE_DETAIL" \
-                '[.[] | select(.status == "offline")][:$n][] | "Agent: \(.name), Version: \(.version // "unknown"), Last Contact: \(.statusChangedOn // "unknown")"' \
-                | paste -sd'; ' -)
+                '[.[] | select(.status == "offline")][:$n][] | .name' | paste -sd', ' -)
             if [ "$offline_count" -gt "$MAX_OFFLINE_DETAIL" ]; then
-                offline_details="$offline_details; ... and $((offline_count - MAX_OFFLINE_DETAIL)) more"
+                offline_details="$offline_details, ... +$((offline_count - MAX_OFFLINE_DETAIL)) more"
             fi
-
-            pool_details=$(ado_pool_issue_details \
-                "Static pool has $offline_count offline agents out of $agent_count total (actionable lost capacity)." \
-                "$pool_name" "$pool_id" "${pool_type:-unknown}" "$pool_kind" "$agent_count" "$online_count" \
-                "$offline_count" "$busy_count" "0" "" "$offline_details" \
-                "$POOL_KIND_REASON" "")
-            investigation_json=$(echo "$investigation_json" | jq \
-                --arg title "Offline Agents in Pool: $pool_name" \
-                --arg details "$pool_details" \
-                --arg severity "3" \
-                --arg next_steps "These are persistent/static agents: restart the agent service on each offline host, confirm the host is powered on and can reach dev.azure.com, and verify the agent credentials/PAT have not expired." \
-                '. += [{"title": $title, "details": $details, "severity": ($severity | tonumber), "next_steps": $next_steps}]')
+            if [ "$online_count" -eq 0 ]; then
+                static_offline+=("OUTAGE \`$pool_name\` (id=$pool_id): $offline_count of $agent_count offline, 0 online -- offline: $offline_details")
+            else
+                static_offline+=("REDUCED \`$pool_name\` (id=$pool_id): $offline_count of $agent_count offline, $online_count still online")
+            fi
         fi
 
         # Outdated agents (applies to any non-hosted pool with persistent agents)
         outdated_count=$(echo "$agents" | jq '[.[] | select(.version != null and (.version | split(".")[0] | tonumber) < 2)] | length')
         if [ "$outdated_count" -gt 0 ]; then
-            investigation_json=$(echo "$investigation_json" | jq \
-                --arg title "Outdated Agents in Pool: $pool_name" \
-                --arg details "Pool $pool_name has $outdated_count agents running outdated versions" \
-                --arg severity "2" \
-                --arg next_steps "Update agent software to latest version for security and compatibility" \
-                '. += [{"title": $title, "details": $details, "severity": ($severity | tonumber), "next_steps": $next_steps}]')
+            outdated_agents+=("\`$pool_name\` (id=$pool_id): $outdated_count agent(s) on a major version < 2")
         fi
     done
+
+    # --- Clustered agent-pool findings (one issue per category, not per pool) ---
+    if [ "${#static_offline[@]}" -gt 0 ]; then
+        n_outage=$(printf '%s\n' "${static_offline[@]}" | grep -c '^OUTAGE ' || true)
+        cluster_list=$(printf '  - %s\n' "${static_offline[@]}")
+        sev=3; [ "${n_outage:-0}" -gt 0 ] && sev=2
+        investigation_json=$(echo "$investigation_json" | jq \
+            --arg title "Static Agent Pools With Offline Agents (${#static_offline[@]} pools, ${n_outage:-0} with no online capacity)" \
+            --arg details "$( printf 'Self-hosted pools with offline agents (OUTAGE = 0 online; REDUCED = capacity remains):\n%s' "$cluster_list" )" \
+            --arg severity "$sev" \
+            --arg next_steps "For OUTAGE pools (highest priority): restart the offline agent services, confirm hosts are powered on and can reach dev.azure.com, and verify agent credentials/PAT. For REDUCED pools, restore agents at convenience. Delete retired pools so they stop being reported." \
+            '. += [{"title": $title, "details": $details, "severity": ($severity | tonumber), "next_steps": $next_steps}]')
+    fi
+    if [ "${#elastic_idle[@]}" -gt 0 ]; then
+        cluster_list=$(printf '  - %s\n' "${elastic_idle[@]}")
+        investigation_json=$(echo "$investigation_json" | jq \
+            --arg title "Elastic Pools Scaled To Zero (Expected) (${#elastic_idle[@]} pools)" \
+            --arg details "$( printf '%s elastic/ephemeral pool(s) are idle at 0 online agents with no queued work (expected autoscaling):\n%s' "${#elastic_idle[@]}" "$cluster_list" )" \
+            --arg severity "4" \
+            --arg next_steps "No action needed -- dynamic pools idle at 0 online agents are expected. If builds later queue without starting on any of these, investigate autoscale/VMSS/KEDA." \
+            '. += [{"title": $title, "details": $details, "severity": ($severity | tonumber), "next_steps": $next_steps}]')
+    fi
+    if [ "${#outdated_agents[@]}" -gt 0 ]; then
+        cluster_list=$(printf '  - %s\n' "${outdated_agents[@]}")
+        investigation_json=$(echo "$investigation_json" | jq \
+            --arg title "Agent Pools Running Outdated Agent Versions (${#outdated_agents[@]} pools)" \
+            --arg details "$( printf '%s pool(s) have agents on an outdated major version:\n%s' "${#outdated_agents[@]}" "$cluster_list" )" \
+            --arg severity "2" \
+            --arg next_steps "Update agent software to the latest version for security and compatibility." \
+            '. += [{"title": $title, "details": $details, "severity": ($severity | tonumber), "next_steps": $next_steps}]')
+    fi
 else
     investigation_json=$(echo "$investigation_json" | jq \
         --arg title "Cannot Access Agent Pools for Investigation" \

--- a/codebundles/azure-devops-organization-health/sli.robot
+++ b/codebundles/azure-devops-organization-health/sli.robot
@@ -1,5 +1,5 @@
 *** Settings ***
-Documentation       Cheap Azure DevOps organization-health SLI. Derives four binary {0,1} sub-scores from lightweight, time-sensitive org signals — no active platform incident, pool capacity OK (queue-derived, ephemeral scaled-to-zero excluded), license headroom within budget, and required org security policy present — then averages them into a primary health score between 0 (failing) and 1 (healthy). Intended to run hourly; the heavy license cost / inactive-user / cross-project scans stay in the daily deep runbook. Its SLO breach triggers this SLX's organization runbook.
+Documentation       Cheap Azure DevOps organization-health SLI. Averages THREE binary {0,1} availability sub-scores from lightweight, time-sensitive org signals — no active platform incident, pool capacity OK (queue-derived, ephemeral scaled-to-zero excluded), and required org security policy present — into a primary health score between 0 (failing) and 1 (healthy). A fourth signal, license_headroom_ok, is pushed as an informational sub-metric only (license saturation is a cost/procurement concern, not an availability incident, so it does not drive the SLO). Intended to run hourly; the heavy license cost / inactive-user / cross-project scans stay in the daily deep runbook. Its SLO breach triggers this SLX's organization runbook.
 Metadata            Author    runwhen
 Metadata            Display Name    Azure DevOps Organization Health SLI
 Metadata            Supports    AzureDevOps    Organization    Health    SLI
@@ -16,7 +16,7 @@ Suite Setup         Suite Initialization
 
 *** Tasks ***
 Score Azure DevOps Organization Health for `${AZURE_DEVOPS_ORG}`
-    [Documentation]    Runs the lightweight org scorer and pushes the four sub-scores: platform_incident_ok, pool_capacity_ok (queue-derived, bounded), license_headroom_ok (single userentitlementsummary call), and org_policy_ok. Convention is "score 0 only for what we measure and confirm bad, 1 for what we cannot measure".
+    [Documentation]    Runs the lightweight org scorer and pushes the sub-scores: platform_incident_ok, pool_capacity_ok (queue-derived, bounded), and org_policy_ok (these three drive the composite), plus license_headroom_ok (single userentitlementsummary call) as an informational-only sub-metric. Convention is "score 0 only for what we measure and confirm bad, 1 for what we cannot measure".
     [Tags]    Organization    AzureDevOps    sli    access:read-only    data:metrics
     ${score_env}=    Create Dictionary
     ...    AZURE_DEVOPS_ORG=${AZURE_DEVOPS_ORG}
@@ -62,12 +62,12 @@ Score Azure DevOps Organization Health for `${AZURE_DEVOPS_ORG}`
     RW.Core.Add To Report    ${ctx}
 
 Generate Aggregate Azure DevOps Organization Health Score for `${AZURE_DEVOPS_ORG}`
-    [Documentation]    Averages the four sub-scores (platform_incident_ok, pool_capacity_ok, license_headroom_ok, org_policy_ok) into the primary SLI metric. A breach of this SLI's SLO triggers this SLX's deep organization runbook.
+    [Documentation]    Averages the three AVAILABILITY sub-scores (platform_incident_ok, pool_capacity_ok, org_policy_ok) into the primary SLI metric. license_headroom_ok is pushed as an informational sub-metric only and is intentionally EXCLUDED from the health score: license saturation is a cost/procurement concern (e.g. 149/149 seats assigned) that would otherwise hold the SLI red indefinitely without indicating any availability impact. License capacity is tracked in the daily deep runbook instead. A breach of this SLI's SLO triggers this SLX's deep organization runbook.
     [Tags]    Organization    AzureDevOps    sli    access:read-only    data:metrics
-    ${total}=    Evaluate    int(${score_platform}) + int(${score_pool}) + int(${score_license}) + int(${score_policy})
-    ${health_score}=    Evaluate    ${total} / 4.0
+    ${total}=    Evaluate    int(${score_platform}) + int(${score_pool}) + int(${score_policy})
+    ${health_score}=    Evaluate    ${total} / 3.0
     ${health_score}=    Convert To Number    ${health_score}    2
-    ${report_msg}=    Set Variable    Azure DevOps organization health score: ${health_score} (platform_incident_ok=${score_platform}, pool_capacity_ok=${score_pool}, license_headroom_ok=${score_license}, org_policy_ok=${score_policy})
+    ${report_msg}=    Set Variable    Azure DevOps organization health score: ${health_score} (platform_incident_ok=${score_platform}, pool_capacity_ok=${score_pool}, org_policy_ok=${score_policy}; informational: license_headroom_ok=${score_license})
     RW.Core.Add To Report    ${report_msg}
     RW.Core.Push Metric    ${health_score}
 

--- a/codebundles/azure-devops-project-health/agent-pools.sh
+++ b/codebundles/azure-devops-project-health/agent-pools.sh
@@ -114,6 +114,16 @@ if [[ "${CHECK_QUEUE_ON_ZERO:-true}" == "true" ]]; then
     [ -n "$queue_probe_ids" ] && fetch_pool_job_requests_parallel "$queue_probe_ids" "$AGENT_CACHE_DIR"
 fi
 
+# Clustered findings: on large orgs (hundreds of pools) emitting one issue per
+# pool floods the report. Accumulate low-signal findings and emit ONE clustered
+# issue per category after the loop. Genuine, rare signals (elastic pool with
+# aging queued work, work bound to offline agents, high utilization) stay
+# per-pool below.
+declare -a static_full_outage=()    # static pools with 0 online (all agents offline)
+declare -a static_partial=()        # static pools with online>0 but some offline (capacity remains)
+declare -a elastic_idle=()          # elastic/ephemeral scaled to zero (expected)
+declare -a disabled_offline_lines=()
+
 # Process each agent pool using a for loop instead of pipe to while
 for ((i=0; i<pool_count; i++)); do
     pool_json=$(jq -c ".[$i]" pools.json)
@@ -215,26 +225,19 @@ for ((i=0; i<pool_count; i++)); do
                     --arg nextStep "Confirm the scaler replaced the torn-down agents. If the assignedRequest persists, re-queue the job or verify the backing VMSS/Kubernetes infrastructure." \
                     '. += [{"title": $title, "details": $details, "next_steps": $nextStep, "severity": ($severity | tonumber)}]')
             else
-                pool_details=$(ado_pool_issue_details \
-                    "Elastic/ephemeral pool is scaled to zero (0 online, $offline_count offline registrations). No queued work and no assignedRequest detected." \
-                    "$pool_name" "$pool_id" "$pool_type" "$pool_kind" "$agent_count" "$online_count" \
-                    "$offline_count" "$busy_count" "$offline_count" \
-                    "Advisory only -- expected idle autoscaling. No pipelines are waiting on this pool." "" \
-                    "$POOL_KIND_REASON" "$queue_status")
-                issues_json=$(echo "$issues_json" | jq \
-                    --arg title "Elastic Pool \`$pool_name\` Scaled To Zero (Expected Dynamic Scale-Down)" \
-                    --arg details "$pool_details" \
-                    --arg severity "4" \
-                    --arg nextStep "No action needed -- a dynamic pool idle at 0 online agents is expected. If builds later queue without starting, verify autoscale rules, backing VMSS/Kubernetes health, and service connections." \
-                    '. += [{"title": $title, "details": $details, "next_steps": $nextStep, "severity": ($severity | tonumber)}]')
-                echo "  Elastic/ephemeral pool \`$pool_name\` scaled to zero: sev-4 advisory (expected, no queued work)."
+                # Expected idle autoscaling: accumulate into ONE clustered sev-4
+                # advisory instead of an issue per pool.
+                elastic_idle+=("\`$pool_name\` (id=$pool_id): 0 online, $offline_count offline registration(s)${queue_status:+; $queue_status}")
+                echo "  Elastic/ephemeral pool \`$pool_name\` scaled to zero: clustered sev-4 advisory (expected, no queued work)."
             fi
         else
             echo "  Elastic/ephemeral pool healthy: $online_count online agent(s); ignoring $offline_count expected offline registrations."
         fi
     elif [[ "$offline_count" -gt 0 ]]; then
-        # Static pool: offline agents are genuine lost capacity. Cap the
-        # enumerated name list to keep output bounded.
+        # Static pool with offline agents. Severity depends on whether ANY online
+        # capacity remains: a pool with online agents still serving work is an
+        # advisory, not an outage. Both are accumulated and clustered after the
+        # loop so a large org produces a couple of issues, not dozens.
         max_names="${MAX_OFFLINE_DETAIL:-20}"
         # Match classify_pool_agents' offline definition (status == "offline")
         # so the enumerated names are consistent with $offline_count.
@@ -243,30 +246,18 @@ for ((i=0; i<pool_count; i++)); do
         if [[ "$offline_count" -gt "$max_names" ]]; then
             offline_names="$offline_names, ... (+$((offline_count - max_names)) more)"
         fi
-        pool_details=$(ado_pool_issue_details \
-            "Static pool has $offline_count of $agent_count agents offline (actionable lost capacity)." \
-            "$pool_name" "$pool_id" "$pool_type" "$pool_kind" "$agent_count" "$online_count" \
-            "$offline_count" "$busy_count" "0" "" "$offline_names" \
-            "$POOL_KIND_REASON" "")
-
-        issues_json=$(echo "$issues_json" | jq \
-            --arg title "Offline Agents Found in Pool \`$pool_name\` ($offline_count of $agent_count agents)" \
-            --arg details "$pool_details" \
-            --arg severity "3" \
-            --arg nextStep "These are persistent/static agents: restart the agent service on each offline host, confirm the host is powered on and can reach dev.azure.com, and verify the agent credentials/PAT have not expired. If this is actually an autoscaled VMSS pool, configure Azure DevOps to remove torn-down agents automatically." \
-            '. += [{"title": $title, "details": $details, "next_steps": $nextStep, "severity": ($severity | tonumber)}]')
+        if [[ "$online_count" -eq 0 ]]; then
+            static_full_outage+=("\`$pool_name\` (id=$pool_id): $offline_count of $agent_count agents offline, 0 online -- offline: $offline_names")
+        else
+            static_partial+=("\`$pool_name\` (id=$pool_id): $offline_count of $agent_count offline, $online_count still online")
+        fi
 
         # Disabled AND offline agents (static pools only)
         disabled_offline_count=$(echo "$agents" | jq '[.[] | select(.enabled == false and .status == "offline")] | length')
         if [[ "$disabled_offline_count" -gt 0 ]]; then
             disabled_names=$(echo "$agents" | jq -r --argjson n "$max_names" \
                 '[.[] | select(.enabled == false and .status == "offline")][:$n][].name' | tr '\n' ',' | sed 's/,$//; s/,/, /g')
-            issues_json=$(echo "$issues_json" | jq \
-                --arg title "Disabled and Offline Agents in Pool \`$pool_name\` ($disabled_offline_count agents)" \
-                --arg details "Pool \`$pool_name\` has $disabled_offline_count agents that are both disabled and offline: $disabled_names. These agents are not contributing to pool capacity." \
-                --arg severity "4" \
-                --arg nextStep "Enable and restart these agents if they should be available, or remove them from the pool if no longer needed." \
-                '. += [{"title": $title, "details": $details, "next_steps": $nextStep, "severity": ($severity | tonumber)}]')
+            disabled_offline_lines+=("\`$pool_name\` ($disabled_offline_count): $disabled_names")
         fi
     fi
 
@@ -283,6 +274,44 @@ for ((i=0; i<pool_count; i++)); do
         fi
     fi
 done
+
+# --- Clustered agent-pool findings (one issue per category, not per pool) ---
+if [ "${#static_full_outage[@]}" -gt 0 ]; then
+    cluster_list=$(printf '  - %s\n' "${static_full_outage[@]}")
+    issues_json=$(echo "$issues_json" | jq \
+        --arg title "Static Agent Pools With No Online Agents (${#static_full_outage[@]} pools)" \
+        --arg details "$( printf '%s static pool(s) have ALL agents offline (no servable capacity):\n%s' "${#static_full_outage[@]}" "$cluster_list" )" \
+        --arg severity "3" \
+        --arg nextStep "For each pool, confirm whether it is still in use. If active: restart the agent service on the offline hosts, confirm they are powered on and can reach dev.azure.com, and verify agent credentials/PAT have not expired. If retired: delete the pool/agents so it stops being reported." \
+        '. += [{"title": $title, "details": $details, "next_steps": $nextStep, "severity": ($severity | tonumber)}]')
+fi
+if [ "${#static_partial[@]}" -gt 0 ]; then
+    cluster_list=$(printf '  - %s\n' "${static_partial[@]}")
+    issues_json=$(echo "$issues_json" | jq \
+        --arg title "Static Agent Pools With Some Offline Agents (Online Capacity Remains) (${#static_partial[@]} pools)" \
+        --arg details "$( printf '%s static pool(s) have offline agents but still retain online capacity (reduced, not lost):\n%s' "${#static_partial[@]}" "$cluster_list" )" \
+        --arg severity "4" \
+        --arg nextStep "Advisory -- these pools can still run work. Restore the offline agents at convenience to recover full capacity, or remove permanently-offline agents to keep the inventory clean." \
+        '. += [{"title": $title, "details": $details, "next_steps": $nextStep, "severity": ($severity | tonumber)}]')
+fi
+if [ "${#elastic_idle[@]}" -gt 0 ]; then
+    cluster_list=$(printf '  - %s\n' "${elastic_idle[@]}")
+    issues_json=$(echo "$issues_json" | jq \
+        --arg title "Elastic Pools Scaled To Zero (Expected) (${#elastic_idle[@]} pools)" \
+        --arg details "$( printf '%s elastic/ephemeral pool(s) are idle at 0 online agents with no queued work (expected autoscaling):\n%s' "${#elastic_idle[@]}" "$cluster_list" )" \
+        --arg severity "4" \
+        --arg nextStep "No action needed -- dynamic pools idle at 0 online agents are expected. If builds later queue without starting on any of these, verify autoscale rules, backing VMSS/Kubernetes health, and service connections." \
+        '. += [{"title": $title, "details": $details, "next_steps": $nextStep, "severity": ($severity | tonumber)}]')
+fi
+if [ "${#disabled_offline_lines[@]}" -gt 0 ]; then
+    cluster_list=$(printf '  - %s\n' "${disabled_offline_lines[@]}")
+    issues_json=$(echo "$issues_json" | jq \
+        --arg title "Disabled And Offline Agents (${#disabled_offline_lines[@]} pools)" \
+        --arg details "$( printf 'Agents that are both disabled and offline (not contributing to capacity):\n%s' "$cluster_list" )" \
+        --arg severity "4" \
+        --arg nextStep "Enable and restart these agents if they should be available, or remove them from the pool if no longer needed." \
+        '. += [{"title": $title, "details": $details, "next_steps": $nextStep, "severity": ($severity | tonumber)}]')
+fi
 
 # Write final JSON (temp files removed by EXIT trap)
 echo "$issues_json" > "$OUTPUT_FILE"

--- a/codebundles/azure-devops-project-health/sli-project-health-score.sh
+++ b/codebundles/azure-devops-project-health/sli-project-health-score.sh
@@ -15,7 +15,12 @@ set -uo pipefail
 # Sub-scores (1 = healthy; convention: score 0 ONLY for what we measure and
 # confirm bad; score 1 for what we cannot measure):
 #   pipeline_failure_ratio_ok   failed/total completed builds in the window
-#                               <= SLI_MAX_FAILURE_RATIO (0 runs => 1)
+#                               <= SLI_MAX_FAILURE_RATIO. Scored 1 (unmeasurable)
+#                               when fewer than SLI_MIN_COMPLETED builds completed
+#                               in the window -- a 30m window on a low-traffic
+#                               project sees 1-2 builds, where a single failure
+#                               swings the ratio to 50-100% and produces a
+#                               permanently-red, statistically meaningless signal.
 #   protected_branch_failures_ok no protected-branch (main/master/develop/
 #                               release/*) pipeline failing 100% of its runs
 #                               in the window
@@ -39,6 +44,8 @@ set -uo pipefail
 # OPTIONAL ENV VARS:
 #   RW_LOOKBACK_WINDOW          windowed-sub-score lookback (default 45m)
 #   SLI_MAX_FAILURE_RATIO       max failed/total ratio (default 0.50)
+#   SLI_MIN_COMPLETED           min completed builds in the window required to
+#                               score the failure ratio at all (default 5)
 #   QUEUE_THRESHOLD             queued-build aging threshold (default 30m)
 #   DURATION_THRESHOLD          in-flight long-running threshold (default 60m)
 #   SLI_MAX_LONGRUNNING         allowed in-flight long-running builds (default 1)
@@ -55,6 +62,7 @@ set -uo pipefail
 : "${AZURE_DEVOPS_PROJECT:?Must set AZURE_DEVOPS_PROJECT}"
 : "${RW_LOOKBACK_WINDOW:=45m}"
 : "${SLI_MAX_FAILURE_RATIO:=0.50}"
+: "${SLI_MIN_COMPLETED:=5}"
 : "${QUEUE_THRESHOLD:=30m}"
 : "${DURATION_THRESHOLD:=60m}"
 : "${SLI_MAX_LONGRUNNING:=1}"
@@ -121,6 +129,7 @@ scores=$(jq -n \
     --argjson qthr "$QUEUE_MIN" \
     --argjson dthr "$DURATION_MIN" \
     --argjson maxlr "$SLI_MAX_LONGRUNNING" \
+    --argjson mincompleted "$SLI_MIN_COMPLETED" \
     --arg maxratio "$SLI_MAX_FAILURE_RATIO" \
     --arg protpat "$SLI_PROTECTED_BRANCH_PATTERN" '
     def parsedate: (sub("\\.[0-9]+";"") | sub("(Z|[+-][0-9][0-9]:?[0-9][0-9])$";"")) + "Z" | (try fromdateiso8601 catch null);
@@ -131,7 +140,9 @@ scores=$(jq -n \
     | ($done | length) as $total
     | ([ $done[] | select(.result == "failed") ] | length) as $failed
     | (if $total == 0 then 0 else ($failed / $total) end) as $ratio
-    | (if $total == 0 then 1 elif $ratio <= $maxr then 1 else 0 end) as $failure_ratio_ok
+    # Below the minimum sample the ratio is statistical noise (one failed build in
+    # a 2-build window = 50%); treat it as unmeasurable (1) rather than red.
+    | (if $total < $mincompleted then 1 elif $ratio <= $maxr then 1 else 0 end) as $failure_ratio_ok
     # --- windowed: protected-branch pipelines failing 100% in window -------
     | ([ $done[] | select((.sourceBranch // "") | test($protpat)) ]
         | group_by(.definition.id)
@@ -146,11 +157,17 @@ scores=$(jq -n \
           | (($now - $qt) / 60)
           | select(. >= $qthr) ] | length) as $aged_q
     | (if $aged_q > 0 then 0 else 1 end) as $queue_ok
-    # --- point-in-time: in-flight builds running past threshold ------------
+    # --- point-in-time: in-flight builds ACTUALLY EXECUTING past threshold --
+    # A build only counts as long-running once it has genuinely started on an
+    # agent: status inProgress AND a startTime that is strictly after its
+    # queueTime. A build still waiting for a starved agent has no real start
+    # (or startTime stamped at queue time); counting it here would double-vote
+    # the same agent-starvation already captured by queue_aging_ok.
     | ([ $b[]
           | select(.status == "inProgress" and (.startTime // null) != null)
           | (.startTime | parsedate) as $st
-          | select($st != null)
+          | ((.queueTime // null) | parsedate) as $qt2
+          | select($st != null and ($qt2 == null or $st > $qt2))
           | (($now - $st) / 60)
           | select(. >= $dthr) ] | length) as $lr
     | (if $lr <= $maxlr then 1 else 0 end) as $long_ok
@@ -165,6 +182,8 @@ scores=$(jq -n \
           failed_in_window:     $failed,
           failure_ratio:        (($ratio * 1000 | floor) / 1000),
           max_failure_ratio:    $maxr,
+          min_completed_for_ratio: $mincompleted,
+          failure_ratio_scored: ($total >= $mincompleted),
           protected_pipelines_failing_100pct: ($prot_bad | length),
           queued_aging_builds:  $aged_q,
           queue_threshold_min:  $qthr,


### PR DESCRIPTION
- Updated `agent-pool-capacity.sh`, `platform-issue-investigation.sh`, and `agent-pools.sh` to accumulate low-signal findings and emit a single issue per category instead of one per pool, reducing report clutter for organizations with many pools.
- Enhanced handling of elastic and static pools, categorizing issues based on online capacity and offline agent counts.
- Improved documentation in `sli.robot` to clarify the scoring methodology and the exclusion of certain metrics from the health score.
- Introduced new environment variables in `sli-project-health-score.sh` to manage minimum completed builds for scoring failure ratios, enhancing the robustness of health assessments.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect on-call signals (org/project SLI math and issue cardinality/severity grouping); behavior is intentional but reviewers should confirm clustered issues still surface outages and SLOs match operator expectations.
> 
> **Overview**
> Agent pool health scripts (`agent-pool-capacity.sh`, `platform-issue-investigation.sh`, `agent-pools.sh`) now **batch** repetitive findings into **one issue per category** (static capacity loss, elastic idle scale-to-zero, outdated agents, etc.) instead of one JSON issue per pool, while **per-pool** issues remain for high-signal cases like aging queued work, work stuck on offline agents, and high utilization.
> 
> **Org SLI** (`sli.robot`) averages **three** availability sub-scores (`platform_incident_ok`, `pool_capacity_ok`, `org_policy_ok`); `license_headroom_ok` is still emitted but **no longer** affects the composite score.
> 
> **Project SLI** (`sli-project-health-score.sh`) treats failure ratio as **unmeasurable** (healthy) when completed builds in the window are below `SLI_MIN_COMPLETED` (default 5), and tightens **long-running** detection to `inProgress` builds whose `startTime` is after `queueTime` so queue starvation is not double-counted with `queue_aging_ok`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94c3a182722b7bd90ee6f7c614cb84becca1f8ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->