### PR TITLE
Use gcp-auth.yaml in GCP runbook taskset templates

### DIFF
--- a/codebundles/gcp-bucket-health/.runwhen/templates/gcp-bucket-health-taskset.yaml
+++ b/codebundles/gcp-bucket-health/.runwhen/templates/gcp-bucket-health-taskset.yaml
@@ -31,5 +31,9 @@ spec:
     - name: PUBLIC_ACCESS_BUCKET_THRESHOLD
       value: "0"
   secretsProvided:
+  {% if wb_version %}
+    {% include "gcp-auth.yaml" ignore missing %}
+  {% else %}
     - name: gcp_credentials
-      workspaceKey: {{custom.gcp_ops_suite_sa}}
+      workspaceKey: AUTH DETAILS NOT FOUND
+  {% endif %}

--- a/codebundles/gcp-cloud-function-health/.runwhen/templates/gcp-cloud-function-health-taskset.yaml
+++ b/codebundles/gcp-cloud-function-health/.runwhen/templates/gcp-cloud-function-health-taskset.yaml
@@ -27,5 +27,9 @@ spec:
     - name: GCP_PROJECT_ID
       value: {{match_resource.resource.project_id}}
   secretsProvided:
+  {% if wb_version %}
+    {% include "gcp-auth.yaml" ignore missing %}
+  {% else %}
     - name: gcp_credentials
-      workspaceKey: {{custom.gcp_ops_suite_sa}}
+      workspaceKey: AUTH DETAILS NOT FOUND
+  {% endif %}

--- a/codebundles/gke-cluster-health/.runwhen/templates/gke-cluster-health-taskset.yaml
+++ b/codebundles/gke-cluster-health/.runwhen/templates/gke-cluster-health-taskset.yaml
@@ -25,5 +25,9 @@ spec:
     - name: GCP_PROJECT_ID
       value: {{match_resource.resource.project_id}}
   secretsProvided:
+  {% if wb_version %}
+    {% include "gcp-auth.yaml" ignore missing %}
+  {% else %}
     - name: gcp_credentials
-      workspaceKey: {{custom.gcp_ops_suite_sa}}
+      workspaceKey: AUTH DETAILS NOT FOUND
+  {% endif %}

--- a/codebundles/k8s-ingress-gce-healthcheck/.runwhen/templates/k8s-ingress-gce-healthcheck-taskset.yaml
+++ b/codebundles/k8s-ingress-gce-healthcheck/.runwhen/templates/k8s-ingress-gce-healthcheck-taskset.yaml
@@ -34,9 +34,10 @@ spec:
   secretsProvided:
   {% if wb_version %}
     {% include "kubernetes-auth.yaml" ignore missing %}
+    {% include "gcp-auth.yaml" ignore missing %}
   {% else %}
     - name: kubeconfig
       workspaceKey: {{custom.kubeconfig_secret_name}}
-  {% endif %}
     - name: gcp_credentials
-      workspaceKey: {{custom.gcp_ops_suite_sa}}
+      workspaceKey: AUTH DETAILS NOT FOUND
+  {% endif %}


### PR DESCRIPTION
## Summary
- Switch gcp-bucket-health, gcp-cloud-function-health, gke-cluster-health, and k8s-ingress-gce-healthcheck runbook tasksets to `{% include "gcp-auth.yaml" %}`
- Fixes runbooks rendering `gcp_credentials.workspaceKey: none` when chart default `gcp_ops_suite_sa: none` merges into workspaceInfo but `gcp_credentials_key` is set

## Test plan
- [ ] Workspace-builder upload for stg-shared regenerates bucket-health runbook with `ops-suite-sa` (or file-style secret per gcp-auth)


Made with [Cursor](https://cursor.com)