### PR TITLE
Fix/template-sub-for-limited-ns-scope

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,11 @@ USER root
 # gcp:adc / gcp:sa provider match in fetchsecrets.read_secret(). This
 # force-reinstalls from the fix branch so the runner can import GCP
 # kubeconfig secrets. Remove once the fix is merged and published to PyPI.
+#
+# Pinned to a commit SHA (not branch name) so Docker layer cache busts
+# when the fix is updated — branch-name pins reuse stale cached layers.
 RUN pip3 install --no-cache-dir --force-reinstall --no-deps \
-    git+https://github.com/runwhen-contrib/rw-core-keywords.git@update/google-adc
+    git+https://github.com/runwhen-contrib/rw-core-keywords.git@d12e37b
 
 ENV RUNWHEN_HOME=/home/runwhen
 ENV PATH "$PATH:/usr/local/bin:/home/runwhen/.local/bin"

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ USER root
 # Pinned to a commit SHA (not branch name) so Docker layer cache busts
 # when the fix is updated — branch-name pins reuse stale cached layers.
 RUN pip3 install --no-cache-dir --force-reinstall --no-deps \
-    git+https://github.com/runwhen-contrib/rw-core-keywords.git@d12e37b
+    git+https://github.com/runwhen-contrib/rw-core-keywords.git@7545b53
 
 ENV RUNWHEN_HOME=/home/runwhen
 ENV PATH "$PATH:/usr/local/bin:/home/runwhen/.local/bin"

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,14 @@ ARG BASE_IMAGE=ghcr.io/runwhen-contrib/rw-base-runtime:latest
 FROM ${BASE_IMAGE}
 USER root
 
+# Override rw-core-keywords with the GCP ADC provider fix branch.
+# The base image ships rw-core-keywords from PyPI, which is missing the
+# gcp:adc / gcp:sa provider match in fetchsecrets.read_secret(). This
+# force-reinstalls from the fix branch so the runner can import GCP
+# kubeconfig secrets. Remove once the fix is merged and published to PyPI.
+RUN pip3 install --no-cache-dir --force-reinstall --no-deps \
+    git+https://github.com/runwhen-contrib/rw-core-keywords.git@update/google-adc
+
 ENV RUNWHEN_HOME=/home/runwhen
 ENV PATH "$PATH:/usr/local/bin:/home/runwhen/.local/bin"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,4 +67,4 @@ ENV TMPDIR=/var/tmp/runwhen
 RUN chown runwhen:0 -R $RUNWHEN_HOME/collection
 
 # Switch to runwhen user
-USER runwhen# bump: rebuild for gcp_utils.py ADC fix
+USER runwhen

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ USER root
 # Pinned to a commit SHA (not branch name) so Docker layer cache busts
 # when the fix is updated — branch-name pins reuse stale cached layers.
 RUN pip3 install --no-cache-dir --force-reinstall --no-deps \
-    git+https://github.com/runwhen-contrib/rw-core-keywords.git@14ca83c
+    git+https://github.com/runwhen-contrib/rw-core-keywords.git@9e4f92a
 
 ENV RUNWHEN_HOME=/home/runwhen
 ENV PATH "$PATH:/usr/local/bin:/home/runwhen/.local/bin"

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ USER root
 # Pinned to a commit SHA (not branch name) so Docker layer cache busts
 # when the fix is updated — branch-name pins reuse stale cached layers.
 RUN pip3 install --no-cache-dir --force-reinstall --no-deps \
-    git+https://github.com/runwhen-contrib/rw-core-keywords.git@12e9a14
+    git+https://github.com/runwhen-contrib/rw-core-keywords.git@14ca83c
 
 ENV RUNWHEN_HOME=/home/runwhen
 ENV PATH "$PATH:/usr/local/bin:/home/runwhen/.local/bin"

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,4 +67,4 @@ ENV TMPDIR=/var/tmp/runwhen
 RUN chown runwhen:0 -R $RUNWHEN_HOME/collection
 
 # Switch to runwhen user
-USER runwhen
+USER runwhen# bump: rebuild for gcp_utils.py ADC fix

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ USER root
 # Pinned to a commit SHA (not branch name) so Docker layer cache busts
 # when the fix is updated — branch-name pins reuse stale cached layers.
 RUN pip3 install --no-cache-dir --force-reinstall --no-deps \
-    git+https://github.com/runwhen-contrib/rw-core-keywords.git@7545b53
+    git+https://github.com/runwhen-contrib/rw-core-keywords.git@12e9a14
 
 ENV RUNWHEN_HOME=/home/runwhen
 ENV PATH "$PATH:/usr/local/bin:/home/runwhen/.local/bin"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Overrides a core system dependency at image build time with `--no-deps`, which can drift from the base runtime’s tested stack until the fix is published and this layer is removed.
> 
> **Overview**
> **Docker image build** now **force-reinstalls `rw-core-keywords` from a pinned Git commit** (`9e4f92a`) on top of `rw-base-runtime`, because the PyPI version in the base image does not handle `gcp:adc` / `gcp:sa` in `fetchsecrets.read_secret()`—needed so runners can load GCP kubeconfig secrets.
> 
> The install uses `--force-reinstall --no-deps` and documents that the SHA pin is intentional for **Docker layer cache invalidation** when the fix moves forward; the block is meant to be removed after the fix ships on PyPI.
> 
> Also restores a proper final `USER runwhen` line (newline at end of file).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 659f41d21e126b46dd689788a8bfb40f82cfc476. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->