### PR TITLE
refactor: replace match_resource.resource.metadata.name with namespace.name in multiple templates

### DIFF
--- a/codebundles/k8s-image-check/.runwhen/templates/k8s-image-check-slx.yaml
+++ b/codebundles/k8s-image-check/.runwhen/templates/k8s-image-check-slx.yaml
@@ -12,7 +12,7 @@ spec:
   asMeasuredBy: Images & their tags running in the namespace for all containers in pods. 
   configProvided:
   - name: OBJECT_NAME
-    value: {{match_resource.resource.metadata.name}}
+    value: {{namespace.name}}
   owners:
   - {{workspace.owner_email}}
   statement: List details about images running in the namespace.

--- a/codebundles/k8s-image-check/.runwhen/templates/k8s-image-check-taskset.yaml
+++ b/codebundles/k8s-image-check/.runwhen/templates/k8s-image-check-taskset.yaml
@@ -22,7 +22,7 @@ spec:
     pathToRobot: codebundles/k8s-image-check/runbook.robot
   configProvided:
     - name: NAMESPACE
-      value: '{{match_resource.resource.metadata.name}}'
+      value: '{{namespace.name}}'
     - name: CONTEXT
       value: {{context}}
     - name: KUBERNETES_DISTRIBUTION_BINARY

--- a/codebundles/k8s-namespace-healthcheck/.runwhen/templates/k8s-namespace-healthcheck-sli.yaml
+++ b/codebundles/k8s-namespace-healthcheck/.runwhen/templates/k8s-namespace-healthcheck-sli.yaml
@@ -30,7 +30,7 @@ spec:
     - name: EVENT_TYPE
       value: Warning
     - name: NAMESPACE
-      value: {{match_resource.resource.metadata.name}}
+      value: {{namespace.name}}
     - name: CONTEXT
       value: {{context}}
     - name: DISTRIBUTION

--- a/codebundles/k8s-namespace-healthcheck/.runwhen/templates/k8s-namespace-healthcheck-slx.yaml
+++ b/codebundles/k8s-namespace-healthcheck/.runwhen/templates/k8s-namespace-healthcheck-slx.yaml
@@ -12,7 +12,7 @@ spec:
   asMeasuredBy: Aggregate score based on Kubernetes API Server queries
   configProvided:
   - name: OBJECT_NAME
-    value: {{match_resource.resource.metadata.name}}
+    value: {{namespace.name}}
   owners:
   - {{workspace.owner_email}}
   statement: Overall health for {{namespace.name}} should be 1, 99% of the time. 

--- a/codebundles/k8s-namespace-healthcheck/.runwhen/templates/k8s-namespace-healthcheck-taskset.yaml
+++ b/codebundles/k8s-namespace-healthcheck/.runwhen/templates/k8s-namespace-healthcheck-taskset.yaml
@@ -24,7 +24,7 @@ spec:
     - name: KUBERNETES_DISTRIBUTION_BINARY
       value: {{custom.kubernetes_distribution_binary | default("kubectl")}}
     - name: NAMESPACE
-      value: {{match_resource.resource.metadata.name}}
+      value: {{namespace.name}}
     - name: CONTEXT
       value: {{context}}
     - name: ANOMALY_THRESHOLD

--- a/codebundles/k8s-podresources-health/.runwhen/templates/k8s-pod-resources-slx.yaml
+++ b/codebundles/k8s-podresources-health/.runwhen/templates/k8s-pod-resources-slx.yaml
@@ -12,7 +12,7 @@ spec:
   asMeasuredBy: Kubectl get and Kubectl Top
   configProvided:
   - name: OBJECT_NAME
-    value: {{match_resource.resource.metadata.name}}
+    value: {{namespace.name}}
   owners:
   - {{workspace.owner_email}}
   statement: Pods should have resources configured, and resource usage should not be exceeded.  

--- a/codebundles/k8s-podresources-health/.runwhen/templates/k8s-pod-resources-taskset.yaml
+++ b/codebundles/k8s-podresources-health/.runwhen/templates/k8s-pod-resources-taskset.yaml
@@ -24,7 +24,7 @@ spec:
     - name: KUBERNETES_DISTRIBUTION_BINARY
       value: {{custom.kubernetes_distribution_binary | default("kubectl")}}
     - name: NAMESPACE
-      value: {{match_resource.resource.metadata.name}}
+      value: {{namespace.name}}
     - name: CONTEXT
       value: {{context}}
   secretsProvided:

--- a/codebundles/k8s-serviceaccount-check/.runwhen/templates/k8s-serviceaccount-check-slx.yaml
+++ b/codebundles/k8s-serviceaccount-check/.runwhen/templates/k8s-serviceaccount-check-slx.yaml
@@ -13,7 +13,7 @@ spec:
   asMeasuredBy: A temporary curl pod using a namespaced service account to interact with the API server. 
   configProvided:
   - name: OBJECT_NAME
-    value: {{match_resource.resource.metadata.name}}
+    value: {{namespace.name}}
   owners:
   - {{workspace.owner_email}}
   statement: Pods should be able to contact the Kubernetes API server. 

--- a/codebundles/k8s-serviceaccount-check/.runwhen/templates/k8s-serviceaccount-check-taskset.yaml
+++ b/codebundles/k8s-serviceaccount-check/.runwhen/templates/k8s-serviceaccount-check-taskset.yaml
@@ -25,7 +25,7 @@ spec:
     - name: DISTRIBUTION
       value: {{custom.kubernetes_distribution}}
     - name: NAMESPACE
-      value: '{{match_resource.resource.metadata.name}}'
+      value: '{{namespace.name}}'
     - name: CONTEXT
       value: {{context}}
     - name: KUBERNETES_DISTRIBUTION_BINARY


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Wrong namespace in SLIs/runbooks if `namespace.name` diverges from prior `match_resource` naming in some workspace render paths; otherwise this is a targeted template-variable fix with no auth or logic changes.
> 
> **Overview**
> Namespace-scoped Kubernetes codebundle Runwhen templates now pass **`namespace.name`** instead of **`match_resource.resource.metadata.name`** into **`OBJECT_NAME`** (SLX) and **`NAMESPACE`** (runbooks/SLI) across **k8s-image-check**, **k8s-namespace-healthcheck**, **k8s-podresources-health**, and **k8s-serviceaccount-check**.
> 
> This aligns generated config with the namespace context already used in aliases and statements, rather than the matched resource’s metadata name. **`match_resource.qualified_name`** and other fields are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit feab8039e5a463a4a2de08df823a23549e074b00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->