### PR TITLE
refactor: update cluster connection checks to use 'version' command i…

### DIFF
--- a/codebundles/k8s-istio-system-health/analyze_istio_configurations.sh
+++ b/codebundles/k8s-istio-system-health/analyze_istio_configurations.sh
@@ -21,7 +21,7 @@ check_command_exists "$KUBERNETES_DISTRIBUTION_BINARY"
 
 # Check cluster connection
 function check_cluster_connection() {
-    if ! "${KUBERNETES_DISTRIBUTION_BINARY}" cluster-info --context="${CONTEXT}" >/dev/null 2>&1; then
+    if ! "${KUBERNETES_DISTRIBUTION_BINARY}" version --context="${CONTEXT}" >/dev/null 2>&1; then
         echo "Error: Unable to connect to cluster context '${CONTEXT}'"
         exit 1
     fi

--- a/codebundles/k8s-istio-system-health/check_istio_injection.sh
+++ b/codebundles/k8s-istio-system-health/check_istio_injection.sh
@@ -18,17 +18,8 @@ function check_cluster_connection() {
         exit 1
     fi
     
-    # Try cluster-info
-    if ! "${KUBERNETES_DISTRIBUTION_BINARY}" cluster-info --context="${CONTEXT}" 2>&1 >/dev/null; then
-        echo "=== Cluster Info ==="
-        "${KUBERNETES_DISTRIBUTION_BINARY}" cluster-info --context="${CONTEXT}"
+    if ! "${KUBERNETES_DISTRIBUTION_BINARY}" version --context="${CONTEXT}" &>/dev/null; then
         echo "Error: Unable to connect to the cluster. Please check your kubeconfig and cluster status."
-        exit 1
-    fi
-    
-    # Check API server availability
-    if ! "${KUBERNETES_DISTRIBUTION_BINARY}" get --raw="/api" --context="${CONTEXT}" 2>&1 >/dev/null; then
-        echo "Error: Unable to reach Kubernetes API server"
         exit 1
     fi
 }

--- a/codebundles/k8s-istio-system-health/istio_controlplane_logs.sh
+++ b/codebundles/k8s-istio-system-health/istio_controlplane_logs.sh
@@ -26,12 +26,8 @@ check_cluster_connection() {
         echo "Error: Unable to get cluster contexts"
         exit 1
     fi
-    if ! "${KUBERNETES_DISTRIBUTION_BINARY}" cluster-info --context="${CONTEXT}" &>/dev/null; then
+    if ! "${KUBERNETES_DISTRIBUTION_BINARY}" version --context="${CONTEXT}" &>/dev/null; then
         echo "Error: Unable to connect to the cluster."
-        exit 1
-    fi
-    if ! "${KUBERNETES_DISTRIBUTION_BINARY}" get --raw="/api" --context="${CONTEXT}" &>/dev/null; then
-        echo "Error: Unable to reach Kubernetes API server"
         exit 1
     fi
 }

--- a/codebundles/k8s-istio-system-health/istio_installation_verify.sh
+++ b/codebundles/k8s-istio-system-health/istio_installation_verify.sh
@@ -23,12 +23,8 @@ check_cluster_connection() {
         echo "Error: Unable to get cluster contexts"
         exit 1
     fi
-    if ! "${KUBERNETES_DISTRIBUTION_BINARY}" cluster-info --context="${CONTEXT}" &>/dev/null; then
+    if ! "${KUBERNETES_DISTRIBUTION_BINARY}" version --context="${CONTEXT}" &>/dev/null; then
         echo "Error: Unable to connect to the cluster"
-        exit 1
-    fi
-    if ! "${KUBERNETES_DISTRIBUTION_BINARY}" get --raw="/api" --context="${CONTEXT}" &>/dev/null; then
-        echo "Error: Unable to reach Kubernetes API server"
         exit 1
     fi
 }

--- a/codebundles/k8s-istio-system-health/istio_mtls_check.sh
+++ b/codebundles/k8s-istio-system-health/istio_mtls_check.sh
@@ -25,7 +25,7 @@ check_command_exists() {
 }
 
 check_cluster_connection() {
-    if ! "${KUBERNETES_DISTRIBUTION_BINARY}" cluster-info --context="${CONTEXT}" &>/dev/null; then
+    if ! "${KUBERNETES_DISTRIBUTION_BINARY}" version --context="${CONTEXT}" &>/dev/null; then
         echo "Error: Unable to connect to cluster context '${CONTEXT}'"
         exit 1
     fi

--- a/codebundles/k8s-istio-system-health/istio_proxy_logs.sh
+++ b/codebundles/k8s-istio-system-health/istio_proxy_logs.sh
@@ -20,10 +20,8 @@ check_command_exists() { command -v "$1" &>/dev/null || { echo "Error: $1 not fo
 check_cluster_connection() {
   "${KUBERNETES_DISTRIBUTION_BINARY}" config get-contexts "${CONTEXT}" --no-headers &>/dev/null \
     || { echo "Error: unable to get contexts"; exit 1; }
-  "${KUBERNETES_DISTRIBUTION_BINARY}" cluster-info --context="${CONTEXT}" &>/dev/null \
+  "${KUBERNETES_DISTRIBUTION_BINARY}" version --context="${CONTEXT}" &>/dev/null \
     || { echo "Error: unable to connect to cluster"; exit 1; }
-  "${KUBERNETES_DISTRIBUTION_BINARY}" get --raw="/api" --context="${CONTEXT}" &>/dev/null \
-    || { echo "Error: unable to reach API server"; exit 1; }
 }
 
 check_command_exists "${KUBERNETES_DISTRIBUTION_BINARY}"

--- a/codebundles/k8s-istio-system-health/istio_sidecar_resource_usage.sh
+++ b/codebundles/k8s-istio-system-health/istio_sidecar_resource_usage.sh
@@ -16,10 +16,8 @@ check_command_exists() { command -v "$1" &>/dev/null || { echo "Error: $1 not fo
 check_cluster_connection() {
   "${KUBERNETES_DISTRIBUTION_BINARY}" config get-contexts "${CONTEXT}" --no-headers &>/dev/null \
     || { echo "Error: unable to get contexts"; exit 1; }
-  "${KUBERNETES_DISTRIBUTION_BINARY}" cluster-info --context="${CONTEXT}" &>/dev/null \
+  "${KUBERNETES_DISTRIBUTION_BINARY}" version --context="${CONTEXT}" &>/dev/null \
     || { echo "Error: unable to connect to cluster"; exit 1; }
-  "${KUBERNETES_DISTRIBUTION_BINARY}" get --raw="/api" --context="${CONTEXT}" &>/dev/null \
-    || { echo "Error: unable to reach API server"; exit 1; }
 }
 
 check_command_exists "${KUBERNETES_DISTRIBUTION_BINARY}"

--- a/codebundles/k8s-karpenter-autoscaling-health/check-karpenter-nodepool-nodeclaim-status.sh
+++ b/codebundles/k8s-karpenter-autoscaling-health/check-karpenter-nodepool-nodeclaim-status.sh
@@ -69,8 +69,8 @@ if ! command -v jq &>/dev/null; then
   exit 0
 fi
 
-if ! $KUBECTL --context "$CONTEXT" cluster-info &>/dev/null; then
-  add_issue "Cannot Reach Kubernetes API for Context \`${CONTEXT}\`" "kubectl cluster-info failed; verify kubeconfig and context name." 4 "Confirm CONTEXT matches an entry in kubeconfig and credentials are valid."
+if ! $KUBECTL version --context "$CONTEXT" &>/dev/null; then
+  add_issue "Cannot Reach Kubernetes API for Context \`${CONTEXT}\`" "kubectl version failed; verify kubeconfig and context name." 4 "Confirm CONTEXT matches an entry in kubeconfig and credentials are valid."
   echo "$issues_json" >"$OUTPUT_FILE"
   exit 0
 fi

--- a/codebundles/k8s-karpenter-autoscaling-health/sli-karpenter-autoscaling-score.sh
+++ b/codebundles/k8s-karpenter-autoscaling-health/sli-karpenter-autoscaling-score.sh
@@ -17,7 +17,7 @@ if ! command -v jq &>/dev/null; then
   exit 0
 fi
 
-if ! $KUBECTL --context "$CONTEXT" cluster-info &>/dev/null; then
+if ! $KUBECTL version --context "$CONTEXT" &>/dev/null; then
   echo '{"d_nodepool":0,"d_pending":0,"d_stuck":0,"error":"api"}'
   exit 0
 fi

--- a/libraries/RW/K8sHelper/k8s_helper.py
+++ b/libraries/RW/K8sHelper/k8s_helper.py
@@ -24,7 +24,7 @@ def verify_cluster_connectivity(
     **kwargs,
 ):
     """
-    Verifies connectivity to a Kubernetes cluster by running 'cluster-info'.
+    Verifies connectivity to a Kubernetes cluster by running 'version'.
     If the cluster is unreachable, raises a severity 3 issue and aborts the suite
     with a Fatal Error.
 
@@ -40,7 +40,7 @@ def verify_cluster_connectivity(
     binary = _normalize_k8s_binary(binary)
     cli = BuiltIn().get_library_instance('RW.CLI')
     result = cli.run_cli(
-        cmd=f"{binary} cluster-info --context {context}",
+        cmd=f"{binary} version --context {context} --request-timeout={timeout_seconds}s",
         env=env,
         include_in_history=False,
         timeout_seconds=timeout_seconds,
@@ -66,7 +66,7 @@ def verify_cluster_connectivity(
                 expected=f"Kubernetes cluster should be reachable via configured kubeconfig and context `{context}`",
                 actual=f"Unable to connect to Kubernetes cluster with context `{context}`",
                 title=f"Kubernetes Cluster Connectivity Check Failed for Context `{context}`",
-                reproduce_hint=f"{binary} cluster-info --context {context}",
+                reproduce_hint=f"{binary} version --context {context}",
                 details=details,
                 next_steps=next_steps,
             )


### PR DESCRIPTION
…nstead of 'cluster-info' in multiple health scripts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Connectivity-only refactor in health scripts and suite init; no change to Istio/Karpenter business logic, though failure timing may differ slightly because `version` uses an explicit request timeout in Python.
> 
> **Overview**
> **Standardizes pre-flight cluster checks** across Istio and Karpenter health codebundles and the shared `verify_cluster_connectivity` helper by replacing `kubectl cluster-info` (and in several scripts a follow-up `get --raw="/api"`) with `kubectl version --context …`.
> 
> Several Istio scripts now rely on a single `version` probe instead of two-step API checks; `check_istio_injection.sh` no longer dumps `cluster-info` output on failure. Karpenter scripts update connectivity failure text to reference `version`. **`k8s_helper.py`** runs `version` with `--request-timeout` aligned to the existing timeout and updates docstrings, CLI command, and `reproduce_hint` accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8cf8bcbe8abc3a0ca2966516a2bcb66b4e632a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->