### PR TITLE
Improve spend health reporting and key aggregation

### DIFF
--- a/codebundles/openrouter-spend-health/analyze-openrouter-spend-by-model.sh
+++ b/codebundles/openrouter-spend-health/analyze-openrouter-spend-by-model.sh
@@ -86,6 +86,10 @@ echo "Total spend across all models: \$$total_spend"
 
 echo "$model_spend" | jq -r '.[] | "\(.model): $\(.total_spend) (\(.request_count) requests)"'
 
+model_share=$(echo "$model_spend" | jq --argjson total "$total_spend" '
+  map(. + {spend_pct: (if $total > 0 then ((.total_spend / $total) * 100) else 0 end)})
+')
+
 if [ "$(echo "$total_spend > 0" | bc -l)" -eq 1 ]; then
   top_model_name=$(echo "$model_spend" | jq -r '.[0].model // empty')
   top_model_spend=$(echo "$model_spend" | jq -r '.[0].total_spend // 0')
@@ -104,6 +108,9 @@ if [ "$(echo "$total_spend > 0" | bc -l)" -eq 1 ]; then
     fi
   fi
 fi
+
+echo "=== REPORT: MODEL SPEND SHARE (JSON) ==="
+echo "$model_share" | jq '.'
 
 echo "$issues_json" > "$OUTPUT_FILE"
 echo "Model spend analysis completed. Results saved to $OUTPUT_FILE"

--- a/codebundles/openrouter-spend-health/check-openrouter-balance.sh
+++ b/codebundles/openrouter-spend-health/check-openrouter-balance.sh
@@ -24,6 +24,11 @@ get_with_status() {
 
 echo "Checking OpenRouter account balance..."
 
+keys_response='{"data":[]}'
+workspaces_response='{"data":[]}'
+keys_available=0
+workspaces_available=0
+
 key_result=$(get_with_status "/key")
 http_code=$(echo "$key_result" | sed -n '1p')
 api_response=$(echo "$key_result" | sed -n '2,$p')
@@ -60,11 +65,52 @@ ACCOUNT_BALANCE_USD="null"
 ACCOUNT_BALANCE_SOURCE="key_limit_remaining"
 
 if [ "$is_management_key" = "true" ]; then
-  keys_result=$(get_with_status "/keys?include_disabled=true&offset=0&limit=100")
-  keys_http_code=$(echo "$keys_result" | sed -n '1p')
-  keys_response=$(echo "$keys_result" | sed -n '2,$p')
+  workspaces_result=$(get_with_status "/workspaces?offset=0&limit=100")
+  workspaces_http_code=$(echo "$workspaces_result" | sed -n '1p')
+  workspaces_response=$(echo "$workspaces_result" | sed -n '2,$p')
 
-  if [ "$keys_http_code" = "200" ] && echo "$keys_response" | jq -e '.data' >/dev/null 2>&1; then
+  if [ "$workspaces_http_code" = "200" ] && echo "$workspaces_response" | jq -e '.data' >/dev/null 2>&1; then
+    workspaces_available=1
+    workspace_count=$(echo "$workspaces_response" | jq '(.data // []) | length')
+    echo "Workspace count: $workspace_count"
+
+    if [ "$workspace_count" -eq 0 ]; then
+      issues_json=$(echo "$issues_json" | jq \
+        --arg title "No OpenRouter Workspaces Found" \
+        --arg details "The management key can authenticate, but /workspaces returned zero entries." \
+        --arg severity "2" \
+        --arg next_steps "Verify organization/workspace setup in https://openrouter.ai/settings." \
+        '. += [{"title": $title, "details": $details, "severity": ($severity | tonumber), "next_steps": $next_steps}]')
+    fi
+
+    all_keys='[]'
+    while IFS= read -r ws_id; do
+      [ -z "$ws_id" ] && continue
+      ws_keys_result=$(get_with_status "/keys?include_disabled=true&workspace_id=$ws_id&offset=0&limit=100")
+      ws_keys_http_code=$(echo "$ws_keys_result" | sed -n '1p')
+      ws_keys_response=$(echo "$ws_keys_result" | sed -n '2,$p')
+
+      if [ "$ws_keys_http_code" = "200" ] && echo "$ws_keys_response" | jq -e '.data' >/dev/null 2>&1; then
+        ws_batch=$(echo "$ws_keys_response" | jq '.data // []')
+        all_keys=$(echo "$all_keys" | jq --argjson batch "$ws_batch" '. + $batch')
+      fi
+    done < <(echo "$workspaces_response" | jq -r '.data[]?.id')
+
+    keys_response=$(jq -n --argjson data "$all_keys" '{data: $data}')
+    keys_available=1
+  fi
+
+  # Fallback: if workspace-scoped key listing failed, try default /keys listing.
+  if [ "$keys_available" -eq 0 ]; then
+    keys_result=$(get_with_status "/keys?include_disabled=true&offset=0&limit=100")
+    keys_http_code=$(echo "$keys_result" | sed -n '1p')
+    keys_response=$(echo "$keys_result" | sed -n '2,$p')
+    if [ "$keys_http_code" = "200" ] && echo "$keys_response" | jq -e '.data' >/dev/null 2>&1; then
+      keys_available=1
+    fi
+  fi
+
+  if [ "$keys_available" -eq 1 ]; then
     credits=$(echo "$keys_response" | jq '[.data[]? | (.limit_remaining // 0)] | add // 0')
     usage=$(echo "$keys_response" | jq '[.data[]? | (.usage // 0)] | add // 0')
     inactive_keys=$(echo "$keys_response" | jq '[.data[]? | select((.disabled // false) == true)] | length')
@@ -105,22 +151,6 @@ if [ "$is_management_key" = "true" ]; then
   else
     BALANCE_UNKNOWN=1
   fi
-
-  workspaces_result=$(get_with_status "/workspaces?offset=0&limit=100")
-  workspaces_http_code=$(echo "$workspaces_result" | sed -n '1p')
-  workspaces_response=$(echo "$workspaces_result" | sed -n '2,$p')
-  if [ "$workspaces_http_code" = "200" ] && echo "$workspaces_response" | jq -e '.data' >/dev/null 2>&1; then
-    workspace_count=$(echo "$workspaces_response" | jq '(.data // []) | length')
-    echo "Workspace count: $workspace_count"
-    if [ "$workspace_count" -eq 0 ]; then
-      issues_json=$(echo "$issues_json" | jq \
-        --arg title "No OpenRouter Workspaces Found" \
-        --arg details "The management key can authenticate, but /workspaces returned zero entries." \
-        --arg severity "2" \
-        --arg next_steps "Verify organization/workspace setup in https://openrouter.ai/settings." \
-        '. += [{"title": $title, "details": $details, "severity": ($severity | tonumber), "next_steps": $next_steps}]')
-    fi
-  fi
 fi
 
 # Management-level credit totals (/credits): this is the true account-level remaining balance.
@@ -143,6 +173,83 @@ if [ "$ACCOUNT_BALANCE_USD" = "null" ]; then
 fi
 
 echo "Account: key_limit_remaining=$credits, usage=$usage, account_remaining=$ACCOUNT_BALANCE_USD, balance_source=$ACCOUNT_BALANCE_SOURCE, min_threshold=$OPENROUTER_MIN_BALANCE_USD"
+
+if [ "$is_management_key" = "true" ] && [ "$keys_available" -eq 1 ]; then
+  key_usage_snapshot=$(echo "$keys_response" | jq '
+    [.data[]? |
+      {
+        key_name: (.name // .label // "(unnamed key)"),
+        key_hash: (.hash // null),
+        workspace_id: (.workspace_id // null),
+        disabled: (.disabled // false),
+        limit: (.limit // null),
+        limit_remaining: (.limit_remaining // null),
+        usage: (.usage // 0),
+        usage_daily: (.usage_daily // null),
+        usage_weekly: (.usage_weekly // null),
+        usage_monthly: (.usage_monthly // null)
+      }
+    ] | sort_by(-(.usage // 0))
+  ')
+
+  echo "=== REPORT: API KEY USAGE SNAPSHOT (JSON) ==="
+  echo "$key_usage_snapshot" | jq '.'
+
+  if [ "$workspaces_available" -eq 1 ]; then
+    workspace_usage_snapshot=$(jq -n --argjson ws "$workspaces_response" --argjson keys "$keys_response" '
+      ($keys.data // []) as $k |
+      ($ws.data // [])
+      | map(
+          . as $w
+          | {
+              workspace_id: ($w.id // null),
+              workspace_name: ($w.name // $w.slug // $w.id // "unknown"),
+              workspace_slug: ($w.slug // null),
+              key_count: ([ $k[] | select((.workspace_id // "") == ($w.id // "")) ] | length),
+              disabled_key_count: ([ $k[] | select((.workspace_id // "") == ($w.id // "") and ((.disabled // false) == true)) ] | length),
+              unlimited_key_count: ([ $k[] | select((.workspace_id // "") == ($w.id // "") and (.limit == null)) ] | length),
+              key_usage_total: ([ $k[] | select((.workspace_id // "") == ($w.id // "")) | (.usage // 0) ] | add // 0),
+              key_usage_monthly_total: ([ $k[] | select((.workspace_id // "") == ($w.id // "")) | (.usage_monthly // .usage // 0) ] | add // 0),
+              key_limit_remaining_total: ([ $k[] | select((.workspace_id // "") == ($w.id // "")) | (.limit_remaining // 0) ] | add // 0)
+            }
+        )
+      | sort_by(-.key_usage_total)
+    ')
+
+    echo "=== REPORT: WORKSPACE USAGE SNAPSHOT (JSON) ==="
+    echo "$workspace_usage_snapshot" | jq '.'
+  fi
+else
+  key_snapshot=$(echo "$api_response" | jq '{
+    key_label: (.data.label // null),
+    is_management_key: (.data.is_management_key // false),
+    limit: (.data.limit // null),
+    limit_remaining: (.data.limit_remaining // null),
+    usage: (.data.usage // 0),
+    usage_daily: (.data.usage_daily // null),
+    usage_weekly: (.data.usage_weekly // null),
+    usage_monthly: (.data.usage_monthly // null)
+  }')
+  echo "=== REPORT: CURRENT KEY SNAPSHOT (JSON) ==="
+  echo "$key_snapshot" | jq '.'
+fi
+
+account_snapshot=$(jq -n \
+  --arg account_balance_usd "$ACCOUNT_BALANCE_USD" \
+  --arg account_balance_source "$ACCOUNT_BALANCE_SOURCE" \
+  --arg key_limit_remaining "$credits" \
+  --arg key_usage_total "$usage" \
+  --arg min_balance_threshold "$OPENROUTER_MIN_BALANCE_USD" \
+  '{
+    account_balance_usd: ($account_balance_usd | tonumber? // null),
+    account_balance_source: $account_balance_source,
+    key_limit_remaining_aggregate: ($key_limit_remaining | tonumber? // null),
+    key_usage_total_aggregate: ($key_usage_total | tonumber? // null),
+    min_balance_threshold: ($min_balance_threshold | tonumber? // null)
+  }')
+
+echo "=== REPORT: ACCOUNT BALANCE SNAPSHOT (JSON) ==="
+echo "$account_snapshot" | jq '.'
 
 if [ "$BALANCE_UNKNOWN" -eq 1 ] || [ "$ACCOUNT_BALANCE_USD" = "null" ]; then
   issues_json=$(echo "$issues_json" | jq \

--- a/codebundles/openrouter-spend-health/check-openrouter-budget.sh
+++ b/codebundles/openrouter-spend-health/check-openrouter-budget.sh
@@ -64,18 +64,63 @@ usage_total=$(echo "$api_response" | jq -r '.data.usage // 0')
 limit_remaining=$(echo "$api_response" | jq -r '.data.limit_remaining // "null"')
 
 if [ "$is_management_key" = "true" ]; then
-  keys_result=$(get_with_status "/keys?include_disabled=true&offset=0&limit=100")
-  keys_http_code=$(echo "$keys_result" | sed -n '1p')
-  keys_response=$(echo "$keys_result" | sed -n '2,$p')
+  workspaces_result=$(get_with_status "/workspaces?offset=0&limit=100")
+  workspaces_http_code=$(echo "$workspaces_result" | sed -n '1p')
+  workspaces_response=$(echo "$workspaces_result" | sed -n '2,$p')
 
-  if [ "$keys_http_code" = "200" ] && echo "$keys_response" | jq -e '.data' >/dev/null 2>&1; then
-    usage_period=$(echo "$keys_response" | jq '[.data[]? | (.usage_monthly // .usage // 0)] | add // 0')
-    usage_total=$(echo "$keys_response" | jq '[.data[]? | (.usage // 0)] | add // 0')
-    limit_remaining=$(echo "$keys_response" | jq '[.data[]? | (.limit_remaining // 0)] | add // 0')
+  all_keys='[]'
+  keys_available=0
+
+  if [ "$workspaces_http_code" = "200" ] && echo "$workspaces_response" | jq -e '.data' >/dev/null 2>&1; then
+    while IFS= read -r ws_id; do
+      [ -z "$ws_id" ] && continue
+      ws_keys_result=$(get_with_status "/keys?include_disabled=true&workspace_id=$ws_id&offset=0&limit=100")
+      ws_keys_http_code=$(echo "$ws_keys_result" | sed -n '1p')
+      ws_keys_response=$(echo "$ws_keys_result" | sed -n '2,$p')
+
+      if [ "$ws_keys_http_code" = "200" ] && echo "$ws_keys_response" | jq -e '.data' >/dev/null 2>&1; then
+        ws_batch=$(echo "$ws_keys_response" | jq '.data // []')
+        all_keys=$(echo "$all_keys" | jq --argjson batch "$ws_batch" '. + $batch')
+        keys_available=1
+      fi
+    done < <(echo "$workspaces_response" | jq -r '.data[]?.id')
+  fi
+
+  if [ "$keys_available" -eq 0 ]; then
+    keys_result=$(get_with_status "/keys?include_disabled=true&offset=0&limit=100")
+    keys_http_code=$(echo "$keys_result" | sed -n '1p')
+    keys_response=$(echo "$keys_result" | sed -n '2,$p')
+    if [ "$keys_http_code" = "200" ] && echo "$keys_response" | jq -e '.data' >/dev/null 2>&1; then
+      all_keys=$(echo "$keys_response" | jq '.data // []')
+      keys_available=1
+    fi
+  fi
+
+  if [ "$keys_available" -eq 1 ]; then
+    usage_period=$(echo "$all_keys" | jq '[.[]? | (.usage_monthly // .usage // 0)] | add // 0')
+    usage_total=$(echo "$all_keys" | jq '[.[]? | (.usage // 0)] | add // 0')
+    limit_remaining=$(echo "$all_keys" | jq '[.[]? | (.limit_remaining // 0)] | add // 0')
   fi
 fi
 
 echo "Account: period_usage=$usage_period, total_usage=$usage_total, remaining_limit=$limit_remaining, budget=$budget"
+
+budget_snapshot=$(jq -n \
+  --arg usage_period "$usage_period" \
+  --arg usage_total "$usage_total" \
+  --arg limit_remaining "$limit_remaining" \
+  --arg budget "$budget" \
+  --arg is_management_key "$is_management_key" \
+  '{
+    is_management_key: ($is_management_key == "true"),
+    usage_period: ($usage_period | tonumber? // null),
+    usage_total: ($usage_total | tonumber? // null),
+    limit_remaining: ($limit_remaining | tonumber? // null),
+    budget: ($budget | tonumber? // null)
+  }')
+
+echo "=== REPORT: BUDGET SNAPSHOT (JSON) ==="
+echo "$budget_snapshot" | jq '.'
 
 if [ "$(echo "$usage_period > $budget" | bc -l)" -eq 1 ]; then
   issues_json=$(echo "$issues_json" | jq \

--- a/codebundles/openrouter-spend-health/detect-openrouter-spend-anomalies.sh
+++ b/codebundles/openrouter-spend-health/detect-openrouter-spend-anomalies.sh
@@ -108,6 +108,23 @@ fi
 
 echo "Mean daily spend: \$$mean, StdDev: \$$stddev"
 
+zscores=$(echo "$daily_spend" | jq --arg mean "$mean" --arg stddev "$stddev" '
+  map(
+    . as $d
+    | $d + {
+        z_score: (
+          if ($stddev | tonumber) > 0
+          then (($d.total_spend - ($mean | tonumber)) / ($stddev | tonumber))
+          else 0
+          end
+        )
+      }
+  )
+')
+
+echo "=== REPORT: ANOMALY INPUT SERIES (JSON) ==="
+echo "$zscores" | jq '.'
+
 spike_detected=0
 acceleration_detected=0
 

--- a/codebundles/openrouter-spend-health/forecast-openrouter-spend.sh
+++ b/codebundles/openrouter-spend-health/forecast-openrouter-spend.sh
@@ -117,6 +117,27 @@ echo "Daily spend standard deviation: \$$stddev"
 echo "Projected weekly spend: \$$projected_weekly"
 echo "Projected monthly spend: \$$projected_monthly"
 
+forecast_snapshot=$(jq -n \
+  --argjson daily_spend "$daily_spend" \
+  --arg avg_daily_burn "$avg_daily_burn" \
+  --arg stddev "$stddev" \
+  --arg projected_weekly "$projected_weekly" \
+  --arg projected_monthly "$projected_monthly" \
+  --arg lookback_days "$OPENROUTER_LOOKBACK_DAYS" \
+  --arg budget "$OPENROUTER_BUDGET_USD" \
+  '{
+    lookback_days: ($lookback_days | tonumber? // null),
+    daily_spend: $daily_spend,
+    avg_daily_burn: ($avg_daily_burn | tonumber? // null),
+    stddev_daily_spend: ($stddev | tonumber? // null),
+    projected_weekly_spend: ($projected_weekly | tonumber? // null),
+    projected_monthly_spend: ($projected_monthly | tonumber? // null),
+    configured_budget: ($budget | tonumber? // null)
+  }')
+
+echo "=== REPORT: FORECAST SNAPSHOT (JSON) ==="
+echo "$forecast_snapshot" | jq '.'
+
 budget=$(echo "$OPENROUTER_BUDGET_USD" | jq -r '. // 0')
 if [ "$(echo "$budget > 0 && $projected_monthly > $budget" | bc -l)" -eq 1 ]; then
   issues_json=$(echo "$issues_json" | jq \

--- a/codebundles/openrouter-spend-health/review-openrouter-spend-history.sh
+++ b/codebundles/openrouter-spend-health/review-openrouter-spend-history.sh
@@ -89,6 +89,51 @@ daily_totals=$(echo "$all_activity" | jq '
 echo "Daily spend breakdown:"
 echo "$daily_totals" | jq -r '.[] | "\(.date): $\(.total_spend) (\(.count) requests)"'
 
+model_breakdown=$(echo "$all_activity" | jq '
+  group_by(.model // "unknown") |
+  map({
+    model: (.[0].model // "unknown"),
+    spend: (map(.usage // 0) | add // 0),
+    requests: (map(.requests // 0) | add // 0)
+  }) |
+  sort_by(-.spend)
+')
+
+provider_breakdown=$(echo "$all_activity" | jq '
+  group_by(.provider_name // "unknown") |
+  map({
+    provider: (.[0].provider_name // "unknown"),
+    spend: (map(.usage // 0) | add // 0),
+    requests: (map(.requests // 0) | add // 0)
+  }) |
+  sort_by(-.spend)
+')
+
+endpoint_breakdown=$(echo "$all_activity" | jq '
+  group_by(.endpoint_id // "unknown") |
+  map({
+    endpoint_id: (.[0].endpoint_id // "unknown"),
+    primary_model: (.[0].model // "unknown"),
+    primary_provider: (.[0].provider_name // "unknown"),
+    model_count: ([.[].model // "unknown"] | unique | length),
+    provider_count: ([.[].provider_name // "unknown"] | unique | length),
+    top_models: (
+      group_by(.model // "unknown")
+      | map({
+          model: (.[0].model // "unknown"),
+          spend: (map(.usage // 0) | add // 0),
+          requests: (map(.requests // 0) | add // 0)
+        })
+      | sort_by(-.spend)
+      | .[:3]
+    ),
+    spend: (map(.usage // 0) | add // 0),
+    requests: (map(.requests // 0) | add // 0)
+  }) |
+  sort_by(-.spend) |
+  .[:20]
+')
+
 daily_dates=$(echo "$daily_totals" | jq -r '.[].date')
 for d in $(seq 1 "$OPENROUTER_LOOKBACK_DAYS"); do
   check_date=$(python3 -c "from datetime import datetime, timedelta, timezone; print((datetime.now(timezone.utc)-timedelta(days=$d)).strftime('%Y-%m-%d'))")
@@ -104,6 +149,18 @@ done
 
 cumulative_spend=$(echo "$daily_totals" | jq '[.[].total_spend] | add // 0')
 echo "Total cumulative spend in lookback window: \$$cumulative_spend"
+
+echo "=== REPORT: DAILY SPEND TOTALS (JSON) ==="
+echo "$daily_totals" | jq '.'
+
+echo "=== REPORT: MODEL BREAKDOWN (JSON) ==="
+echo "$model_breakdown" | jq '.'
+
+echo "=== REPORT: PROVIDER BREAKDOWN (JSON) ==="
+echo "$provider_breakdown" | jq '.'
+
+echo "=== REPORT: TOP ENDPOINT BREAKDOWN (JSON, TOP 20; WITH MODEL/PROVIDER CONTEXT) ==="
+echo "$endpoint_breakdown" | jq '.'
 
 echo "$issues_json" > "$OUTPUT_FILE"
 echo "Spend history review completed. Results saved to $OUTPUT_FILE"

--- a/codebundles/openrouter-spend-health/runbook.robot
+++ b/codebundles/openrouter-spend-health/runbook.robot
@@ -50,6 +50,7 @@ Check OpenRouter Account Balance for Account `${OPENROUTER_API_KEY_LABEL}`
         END
     END
     RW.Core.Add Pre To Report    Balance check results:\n${result.stdout}
+    RW.Core.Add Pre To Report    Balance issues JSON:\n${issues.stdout}
 
 Review OpenRouter Spend History for Account `${OPENROUTER_API_KEY_LABEL}`
     [Documentation]    Fetches recent activity rows from /api/v1/activity, aggregates spend by day for the lookback window, and flags gaps in reporting data.
@@ -85,6 +86,7 @@ Review OpenRouter Spend History for Account `${OPENROUTER_API_KEY_LABEL}`
         END
     END
     RW.Core.Add Pre To Report    Spend history review:\n${result.stdout}
+    RW.Core.Add Pre To Report    Spend history issues JSON:\n${issues.stdout}
 
 Analyze OpenRouter Spend by Model for Account `${OPENROUTER_API_KEY_LABEL}`
     [Documentation]    Breaks down spend per model from the /api/v1/activity endpoint. Identifies the top-N most expensive models and flags any model whose share exceeds a configured concentration threshold.
@@ -120,6 +122,7 @@ Analyze OpenRouter Spend by Model for Account `${OPENROUTER_API_KEY_LABEL}`
         END
     END
     RW.Core.Add Pre To Report    Model spend analysis:\n${result.stdout}
+    RW.Core.Add Pre To Report    Model spend issues JSON:\n${issues.stdout}
 
 Check OpenRouter Budget Status for Account `${OPENROUTER_API_KEY_LABEL}`
     [Documentation]    Compares total cumulative spend against a configured budget threshold. Raises an issue if spend exceeds the budget or is projected to exceed it before the next reset period.
@@ -155,6 +158,7 @@ Check OpenRouter Budget Status for Account `${OPENROUTER_API_KEY_LABEL}`
         END
     END
     RW.Core.Add Pre To Report    Budget status check:\n${result.stdout}
+    RW.Core.Add Pre To Report    Budget issues JSON:\n${issues.stdout}
 
 Forecast OpenRouter Spend Trend for Account `${OPENROUTER_API_KEY_LABEL}`
     [Documentation]    Computes average daily burn rate from the last N days of spend history, projects spend for the next period, and flags if projected spend would exceed the configured budget.
@@ -190,6 +194,7 @@ Forecast OpenRouter Spend Trend for Account `${OPENROUTER_API_KEY_LABEL}`
         END
     END
     RW.Core.Add Pre To Report    Spend forecast:\n${result.stdout}
+    RW.Core.Add Pre To Report    Forecast issues JSON:\n${issues.stdout}
 
 Detect OpenRouter Spend Anomalies for Account `${OPENROUTER_API_KEY_LABEL}`
     [Documentation]    Analyzes daily spend totals for statistical outliers using a z-score method. Flags days where spend deviates from the baseline by more than the configured threshold.
@@ -225,6 +230,7 @@ Detect OpenRouter Spend Anomalies for Account `${OPENROUTER_API_KEY_LABEL}`
         END
     END
     RW.Core.Add Pre To Report    Anomaly detection results:\n${result.stdout}
+    RW.Core.Add Pre To Report    Anomaly issues JSON:\n${issues.stdout}
 
 
 *** Keywords ***


### PR DESCRIPTION
Add structured JSON report sections across spend, anomaly, forecast, budget, and history checks to improve runbook diagnostics.

For management keys, aggregate key data per workspace with a fallback to global `/keys`, and surface workspace/issue details more clearly in the Robot report output.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only reporting and API aggregation changes in operational scripts; no auth or payment logic changes, with fallback preserving prior `/keys` behavior.
> 
> **Overview**
> Adds **machine-readable `=== REPORT: … (JSON) ===` sections** across the spend-health bash checks so runbook stdout carries structured diagnostics (model share %, budget/forecast/anomaly series, spend history breakdowns, balance/key/workspace snapshots).
> 
> For **management keys**, balance and budget checks now **list keys per workspace** (`/workspaces` then `/keys?workspace_id=…`), merge results, and **fall back to global `/keys`** when workspace listing fails—replacing a single flat `/keys` call. Balance reporting adds per-key and per-workspace usage snapshots plus an account balance snapshot.
> 
> **Spend history** gains model, provider, and top-20 endpoint breakdowns (with model/provider context on endpoints). **Anomaly detection** emits the daily series with computed z-scores. **`runbook.robot`** appends each task’s issues JSON file to the report alongside existing stdout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9cb6794c39aeb0ea494971a0979bef6e8e31a07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->