### PR TITLE
chore: add self-hosted Renovate workflow and config

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,49 @@
+name: Renovate
+
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: 'Log level'
+        required: false
+        default: 'info'
+        type: choice
+        options:
+          - info
+          - debug
+          - trace
+      overrideSchedule:
+        description: 'Override schedule'
+        required: false
+        default: false
+        type: boolean
+
+env:
+  LOG_LEVEL: ${{ inputs.logLevel || 'info' }}
+  RENOVATE_AUTODISCOVER: true
+  RENOVATE_AUTODISCOVER_FILTER: ${{ github.repository }}
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  renovate:
+    name: Renovate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Self-hosted Renovate
+        uses: renovatebot/github-action@v41.0.0
+        with:
+          configurationFile: renovate.json
+          token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          RENOVATE_REPOSITORIES: ${{ github.repository }}
+          RENOVATE_FORCE: ${{ github.event.inputs.overrideSchedule == 'true' && '{}'  || '' }}
+          LOG_LEVEL: ${{ env.LOG_LEVEL }}

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,101 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Renovate configuration for rw-cli-codecollection",
+  "extends": [
+    "config:recommended",
+    ":dependencyDashboard",
+    ":semanticCommits",
+    ":automergeDigest",
+    ":automergeBranch"
+  ],
+  "timezone": "America/New_York",
+  "schedule": [
+    "before 10am on monday"
+  ],
+  "labels": [
+    "dependencies"
+  ],
+  "assignees": [
+    "@runwhen-contrib/maintainers"
+  ],
+  "reviewers": [
+    "@runwhen-contrib/maintainers"
+  ],
+  "prConcurrentLimit": 5,
+  "prHourlyLimit": 2,
+  "packageRules": [
+    {
+      "description": "Group Python dependencies",
+      "matchManagers": [
+        "pip_requirements"
+      ],
+      "groupName": "Python dependencies",
+      "schedule": [
+        "before 10am on monday"
+      ],
+      "automerge": false,
+      "reviewersFromCodeOwners": true
+    },
+    {
+      "description": "Group GitHub Actions",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "groupName": "GitHub Actions",
+      "automerge": true,
+      "matchUpdateTypes": [
+        "patch",
+        "pin",
+        "digest"
+      ]
+    },
+    {
+      "description": "Separate major updates",
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "automerge": false,
+      "schedule": [
+        "before 10am on monday"
+      ],
+      "labels": [
+        "dependencies",
+        "major-update"
+      ],
+      "reviewersFromCodeOwners": true
+    }
+  ],
+  "pip_requirements": {
+    "enabled": true,
+    "fileMatch": [
+      "(^|/)requirements\\.txt$"
+    ]
+  },
+  "vulnerabilityAlerts": {
+    "enabled": false
+  },
+  "osvVulnerabilityAlerts": true,
+  "dependencyDashboard": true,
+  "dependencyDashboardTitle": "Dependency Dashboard",
+  "dependencyDashboardHeader": "This issue lists Renovate updates and detected dependencies.",
+  "dependencyDashboardFooter": "- [ ] <!-- rebase-check -->If you want to rebase/retry any failed PRs, check this box",
+  "dockerfile": {
+    "enabled": true
+  },
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Update Python version in Dockerfile FROM statement",
+      "fileMatch": [
+        "/\\\\.dockerfile$/",
+        "/Dockerfile$"
+      ],
+      "matchStrings": [
+        "FROM python:(?<currentValue>[\\\\d.]+)(?:-alpine|-slim|-buster)?\\\\s"
+      ],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "python",
+      "extractVersionTemplate": "^(?<version>.*)$"
+    }
+  ]
+}


### PR DESCRIPTION
Add Renovate dependency management with self-hosted runner pattern.

- `renovate.json`: pip_requirements + github-actions (+ dockerfile where applicable) package rules, custom regex manager for Python version in Dockerfiles, vulnerability alerts (OSV), dependency dashboard
- `.github/workflows/renovate.yml`: renovatebot/github-action@v41.0.0, runs daily at 6 AM UTC, permissions: contents/pull-requests/issues: write

Pattern sourced from runwhen-contrib/rw-base-runtime (proven working).