### PR TITLE
docs(gcp): document required IAM permissions in GCP codebundle READMEs

### DIFF
--- a/codebundles/curl-gmp-kong-ingress-inspection/README.md
+++ b/codebundles/curl-gmp-kong-ingress-inspection/README.md
@@ -21,7 +21,19 @@ The TaskSet requires initialization to import necessary secrets, services, and u
 
 ## Notes
 
-The `gcp_credentials` service account will need view and list permissions on the GCP logging API.
+The `gcp_credentials` service account queries Google Managed Prometheus (GMP) metrics through the Cloud Monitoring API.
+
+## Requirements
+
+This codebundle authenticates with a GCP service account (`gcp_credentials`, activated via `gcloud auth activate-service-account`) scoped to `${GCP_PROJECT_ID}`, and queries Google Managed Prometheus through the Cloud Monitoring `prometheus/api/v1/query` endpoint. The following IAM permission is required on the service account:
+
+**Granular IAM permissions**
+- `monitoring.timeSeries.list` — run the PromQL queries against the GMP / Cloud Monitoring query endpoint
+
+**Suggested predefined role**
+- `roles/monitoring.viewer` — covers `monitoring.timeSeries.list` (least-privilege fit)
+
+> Requires the Cloud Monitoring API (`monitoring.googleapis.com`) enabled on the project, with Google Managed Prometheus ingesting the Kong ingress metrics (`kong_http_requests_total`, `kong_request_latency_ms_bucket`, `kong_upstream_target_health`).
 
 ## TODO
 - [ ] Add documentation

--- a/codebundles/curl-gmp-nginx-ingress-inspection/README.md
+++ b/codebundles/curl-gmp-nginx-ingress-inspection/README.md
@@ -25,8 +25,25 @@ The TaskSet requires initialization to import necessary secrets, services, and u
 
 ## Notes
 
-The `gcp_credentials` service account will need view and list permissions on the GCP logging API.
+The `gcp_credentials` service account queries Google Managed Prometheus (GMP) metrics through the Cloud Monitoring API.
 The `kubectl secret` will need to get|list the ingress object, services, pods, deployments, relicasets, statefulsets and so on in the namespace. 
+
+## Requirements
+
+This codebundle uses two independent credentials:
+
+1. A GCP service account (`gcp_credentials`, activated via `gcloud auth activate-service-account`) scoped to `${GCP_PROJECT_ID}`, used to query Google Managed Prometheus through the Cloud Monitoring `prometheus/api/v1/query` endpoint.
+2. A `kubeconfig` with Kubernetes RBAC read (get/list) access to Ingress, Service, Endpoints, Pod, and ReplicaSet objects in the target namespace.
+
+The following GCP IAM permission is required on the service account:
+
+**Granular IAM permissions**
+- `monitoring.timeSeries.list` — run the PromQL query against the GMP / Cloud Monitoring query endpoint (metric `nginx_ingress_controller_requests`)
+
+**Suggested predefined role**
+- `roles/monitoring.viewer` — covers `monitoring.timeSeries.list` (least-privilege fit)
+
+> Requires the Cloud Monitoring API (`monitoring.googleapis.com`) enabled on the project, with Google Managed Prometheus ingesting the ingress-nginx metrics. Kubernetes access is authenticated separately via the `kubeconfig` secret (no GKE `container.*` IAM permission is consumed).
 
 ## TODO
 - [ ] Add documentation

--- a/codebundles/gcloud-log-inspection/README.md
+++ b/codebundles/gcloud-log-inspection/README.md
@@ -19,6 +19,19 @@ The TaskSet requires initialization to import necessary secrets, services, and u
 
 The `gcp_credentials` service account will need view and list permissions on the GCP logging API.
 
+## Requirements
+
+This codebundle authenticates with a GCP service account (`gcp_credentials`, activated via `gcloud auth activate-service-account`) scoped to `${GCP_PROJECT_ID}`, and reads log entries via `gcloud logging read`. The following IAM permission is required on the service account:
+
+**Granular IAM permissions**
+- `logging.logEntries.list` — `gcloud logging read` calls the Cloud Logging `entries.list` method
+
+**Suggested predefined role(s)**
+- `roles/logging.viewer` — covers `logging.logEntries.list` (least-privilege fit for standard logs)
+- `roles/logging.privateLogViewer` — only if the query must also return Data Access / private audit logs (adds `logging.privateLogEntries.list`)
+
+> Requires the Cloud Logging API (`logging.googleapis.com`) enabled on the project.
+
 ## TODO
 - [ ] Add documentation
 - [ ] Add IAM settings examples

--- a/codebundles/gcp-bigquery-dataset-health/README.md
+++ b/codebundles/gcp-bigquery-dataset-health/README.md
@@ -49,11 +49,21 @@ Produces a consolidated dataset health summary including total datasets/tables, 
 
 ## Requirements
 
-The following GCP IAM roles are required on the service account:
-- `roles/bigquery.metadataViewer`
-- `roles/bigquery.dataViewer`
-- `roles/iam.securityReviewer`
-- `roles/logging.configViewer`
+This codebundle authenticates with a GCP service account (`gcp_credentials`, activated via `gcloud auth activate-service-account`; the `bq` CLI inherits the same credentials) scoped to `${GCP_PROJECT_ID}`. It performs read-only metadata operations only (`bq ls` / `bq show`) — it runs **no** queries, so no `bigquery.jobs.create` / data-read permission is needed.
+
+**Granular IAM permissions**
+- `bigquery.datasets.get` — `bq ls` (dataset enumeration) and `bq show <dataset>` (reads the `.access` ACL and default expiration)
+- `bigquery.tables.list` — `bq ls <dataset>` (enumerate tables)
+- `bigquery.tables.get` — `bq show <dataset.table>` (table metadata: size, expiration, partitioning, clustering)
+- `resourcemanager.projects.getIamPolicy` — `gcloud projects get-iam-policy` (audit-logging check)
+- `logging.sinks.list` — `gcloud logging sinks list` (audit-logging check)
+
+**Suggested predefined role(s)**
+- `roles/bigquery.metadataViewer` — covers `bigquery.datasets.get`, `bigquery.tables.list`, `bigquery.tables.get` (metadata only, no row-data access)
+- `roles/iam.securityReviewer` — covers `resourcemanager.projects.getIamPolicy`
+- `roles/logging.viewer` — covers `logging.sinks.list` (`roles/logging.configViewer` also works)
+
+> Requires the BigQuery (`bigquery.googleapis.com`), Cloud Resource Manager (`cloudresourcemanager.googleapis.com`), and Cloud Logging (`logging.googleapis.com`) APIs enabled on the project.
 
 ## Platform Tools
 

--- a/codebundles/gcp-bucket-health/README.md
+++ b/codebundles/gcp-bucket-health/README.md
@@ -17,13 +17,24 @@ The Taskset lists provides the following tasks:
 - Check GCP Bucket Security Configuration for `${PROJECT_IDS}`
 
 ## Requirements
-The following roles are useful on the GCP service account used with the gcloud utility: 
 
-- Viewer
-- Security Reviewer
+This codebundle authenticates with a GCP service account (`gcp_credentials`, activated via `gcloud auth activate-service-account`) and inspects every project listed in `${PROJECT_IDS}` using `gcloud storage`, `gsutil`, and the Cloud Monitoring API. All operations are read-only. The permissions below must be granted in **each** target project (or a shared ancestor folder/org).
 
-## TODO 
-Update required GCP SA permissions. 
+**Granular IAM permissions**
+- `storage.buckets.list` — `gsutil ls -p <project>` (enumerate buckets)
+- `storage.buckets.get` — `gcloud storage buckets describe` (bucket metadata / encryption / IAM config)
+- `storage.buckets.getIamPolicy` — `gcloud storage buckets get-iam-policy` and `gsutil acl get` (public-access / security check)
+- `storage.objects.list` — `gsutil du -s gs://<bucket>` (object-size fallback when the Monitoring API is disabled)
+- `monitoring.timeSeries.list` — Cloud Monitoring PromQL queries for bucket size and read/write op rates
+- `serviceusage.services.list` — `gcloud services list --enabled` (detect whether the Monitoring API is on)
+
+**Suggested predefined role(s)**
+- `roles/iam.securityReviewer` — covers `storage.buckets.list/get/getIamPolicy` (bucket + IAM/ACL reads with no write access)
+- `roles/storage.objectViewer` — covers `storage.objects.list` (the `gsutil du` size fallback)
+- `roles/monitoring.viewer` — covers `monitoring.timeSeries.list`
+- `roles/serviceusage.serviceUsageViewer` — covers `serviceusage.services.list`
+
+> `roles/storage.admin` is **not** needed — nothing here writes, deletes, or sets IAM. Requires the Cloud Storage, Cloud Monitoring, and Service Usage APIs enabled on each project.
 
 ## Local testing
 - need `gcloud` SDK in the test-bed(docker container)

--- a/codebundles/gcp-cloud-function-health/README.md
+++ b/codebundles/gcp-cloud-function-health/README.md
@@ -23,12 +23,23 @@ The Taskset provides the following tasks:
 - **Check Cloud Function Scaling and Timeout Configuration** — long HTTP timeouts, gen2 functions without a max instance cap
 
 ## Requirements
-The following permissions are required on the GCP service account used with the gcloud utility:
+This codebundle authenticates with a GCP service account (`gcp_credentials`, activated via `gcloud auth activate-service-account`) scoped to `${GCP_PROJECT_ID}`. All operations are read-only.
 
- - `cloudfunctions.functions.get`
- - `cloudfunctions.functions.list`
- - `cloudfunctions.functions.getIamPolicy`
- - `run.services.get`
+**Granular IAM permissions**
+
+ - `cloudfunctions.functions.get` — `gcloud functions describe` (config / scaling)
+ - `cloudfunctions.functions.list` — `gcloud functions list`
+ - `cloudfunctions.functions.getIamPolicy` — `gcloud functions get-iam-policy` (public-invoker check)
+ - `run.services.get` — `gcloud run services describe` (gen2 backing Cloud Run service)
  - `run.services.list`
- - `cloudbuild.builds.list`
- - `logging.logEntries.list`
+ - `cloudbuild.builds.list` — `gcloud builds list` (failed-build detection)
+ - `logging.logEntries.list` — `gcloud logging read` (ERROR logs)
+
+**Suggested predefined role(s)**
+
+ - `roles/cloudfunctions.viewer` — covers `cloudfunctions.functions.get/list/getIamPolicy`
+ - `roles/run.viewer` — covers `run.services.get/list` (gen2 Cloud Run describe)
+ - `roles/cloudbuild.builds.viewer` — covers `cloudbuild.builds.list`
+ - `roles/logging.viewer` — covers `logging.logEntries.list`
+
+> Requires the Cloud Functions, Cloud Run, Cloud Build, and Cloud Logging APIs enabled on the project.

--- a/codebundles/gcp-cloud-loadbalancer-health/README.md
+++ b/codebundles/gcp-cloud-loadbalancer-health/README.md
@@ -61,16 +61,20 @@ Aggregates findings from all previous checks into a consolidated health summary 
 
 ## Requirements
 
-The following IAM permissions are required on the service account (via a custom role, or `roles/compute.viewer` + `roles/monitoring.viewer`):
+This codebundle authenticates with a GCP service account (`gcp_credentials`, activated via `gcloud auth activate-service-account`) scoped to `${GCP_PROJECT_ID}`. It discovers load balancers with `gcloud compute` and reads metrics from the Cloud Monitoring API. All operations are read-only.
 
-- `compute.forwardingRules.list`
-- `compute.backendServices.getHealth`
-- `compute.sslCertificates.list`
-- `compute.targetHttpsProxies.list`
-- `compute.targetSslProxies.list`
-- `compute.targetHttpProxies.list`
-- `compute.targetTcpProxies.list`
-- `monitoring.metricDescriptors.list`
-- `monitoring.timeSeries.list`
+**Granular IAM permissions**
+- `compute.forwardingRules.list` — `gcloud compute forwarding-rules list` (LB discovery)
+- `compute.backendServices.list` — `gcloud compute backend-services list`
+- `compute.backendServices.get` — backend-service describe / get-health
+- `compute.backendServices.getHealth` — `gcloud compute backend-services get-health` (backend health)
+- `compute.targetHttpsProxies.get` — `gcloud compute target-https-proxies describe`
+- `compute.targetSslProxies.get` — `gcloud compute target-ssl-proxies describe`
+- `compute.sslCertificates.get` — `gcloud compute ssl-certificates describe` (expiry check)
+- `monitoring.timeSeries.list` — Cloud Monitoring `timeSeries` queries (error-rate + latency metrics)
 
-The `gcloud`, `jq`, and `curl` CLI tools are required at runtime. The Compute Engine and Cloud Monitoring APIs must be enabled for the project.
+**Suggested predefined role(s)**
+- `roles/compute.viewer` — covers all the `compute.*` reads above. (`roles/compute.networkViewer` is tighter but does **not** grant `compute.backendServices.getHealth`, so `roles/compute.viewer` is the reliable least-privilege choice.)
+- `roles/monitoring.viewer` — covers `monitoring.timeSeries.list`
+
+> The `gcloud`, `jq`, and `curl` CLI tools are required at runtime. The Compute Engine (`compute.googleapis.com`) and Cloud Monitoring (`monitoring.googleapis.com`) APIs must be enabled for the project.

--- a/codebundles/gcp-project-cost-health/README.md
+++ b/codebundles/gcp-project-cost-health/README.md
@@ -128,6 +128,16 @@ gcloud beta billing accounts add-iam-policy-binding BILLING_ACCOUNT_ID \
 - Recommender API permissions are project-level; grant them on each project you want to analyze for cost optimization opportunities.
 - Billing account permissions are optional and only needed for organization-wide CUD recommendations.
 
+#### Granular Permissions (reference)
+
+The predefined roles above map to these underlying permissions:
+
+**BigQuery** (on the billing-export host project) — `bigquery.jobs.create` (`bq query`), `bigquery.datasets.get`, `bigquery.tables.list`, `bigquery.tables.get`, `bigquery.tables.getData` (read the billing export rows). Note `billing.resourceCosts.get` is **not** required — cost figures come from the BigQuery export, not the Cloud Billing API.
+
+**Recommender** (project level; also billing-account level for CUD/commitment recommenders) — `recommender.*.list` / `recommender.*.get` for the requested recommenders (e.g. `recommender.computeInstanceMachineTypeRecommendations.list`, `recommender.commitmentUtilizationRecommendations.list`), plus `recommender.recommenders.list` (best-effort).
+
+**Resource Manager / Compute / Service Usage / Billing** — `resourcemanager.projects.get`, `resourcemanager.projects.list`, `compute.instances.list` (derive active regions for CUD locations), `serviceusage.services.list` (checks whether `recommender.googleapis.com` is enabled), `billing.accounts.list` (billing-account level). `resourcemanager.organizations.get` is optional (org-level recommender coverage; the scripts tolerate denial).
+
 ### 3. Required Tools
 
 - `gcloud` CLI (Google Cloud SDK)

--- a/codebundles/gcp-vertex-modelgarden-health/README.md
+++ b/codebundles/gcp-vertex-modelgarden-health/README.md
@@ -76,8 +76,9 @@ This codebundle requires specific IAM roles and permissions to access Google Clo
 
 #### Optional IAM Roles
 
-**Enhanced Vertex AI Access:**
-- **`roles/aiplatform.user`** - Optional, for additional Vertex AI operations and enhanced monitoring
+**Vertex AI Model/Endpoint Discovery** (proactive discovery via `gcloud ai endpoints list/describe`; not needed if discovery is skipped):
+- **`roles/aiplatform.viewer`** - Recommended read-only role covering `aiplatform.endpoints.list` and `aiplatform.endpoints.get`
+- **`roles/aiplatform.user`** - Broader alternative, for additional Vertex AI operations and enhanced monitoring
 
 #### Detailed Permission Requirements
 
@@ -99,6 +100,12 @@ logging.privateLogEntries.list
 ```
 serviceusage.services.list
 serviceusage.services.get
+```
+
+**For Model/Endpoint Discovery (optional, `gcloud ai endpoints list/describe`):**
+```
+aiplatform.endpoints.list
+aiplatform.endpoints.get
 ```
 
 #### Permission Validation

--- a/codebundles/gke-cluster-health/README.md
+++ b/codebundles/gke-cluster-health/README.md
@@ -153,3 +153,31 @@ This ensures that critical events affecting instance groups are no longer missed
    * Add more environment vars to `env` for specialised tooling (e.g. custom `KUBECONFIG`).  
 
 With one run you get a comprehensive, read‑only audit covering IAM gaps, GCP recommendations, pod/node health, quota risks, right‑sizing guidance, and **critical node pool issues like region exhaustion** for every GKE cluster in your project.
+
+## Requirements
+
+This codebundle authenticates with a GCP service account (`gcp_credentials`, activated via `gcloud auth activate-service-account`) scoped to `${GCP_PROJECT_ID}`. It reads cluster/compute state via `gcloud`, fetches Recommender tips, audits node-pool service-account IAM, and connects to each cluster with `gcloud container clusters get-credentials` for read-only `kubectl` checks. All operations are read-only.
+
+**Granular IAM permissions**
+- `container.clusters.list` — `gcloud container clusters list`
+- `container.clusters.get` — `clusters describe`, `get-credentials`, `node-pools list/describe`, `get-server-config`, and kubectl auth
+- `container.operations.list` — `gcloud container operations list`
+- `recommender.containerDiagnosisRecommendations.list` — `gcloud recommender recommendations list` (google.container.DiagnosisRecommender)
+- `compute.machineTypes.list` — `gcloud compute machine-types list` (node sizing)
+- `compute.instances.list` — `gcloud compute instances list` / managed-IG `list-instances`
+- `compute.instanceGroupManagers.list` — `gcloud compute instance-groups managed list`
+- `compute.instanceGroupManagers.get` — `gcloud compute instance-groups managed list-instances`
+- `compute.zoneOperations.list`, `compute.regionOperations.list`, `compute.globalOperations.list` — `gcloud compute operations list` (aggregated)
+- `compute.regions.get` — `gcloud compute regions describe` (quota/usage)
+- `resourcemanager.projects.get` — `gcloud projects describe` (project number)
+- `resourcemanager.projects.getIamPolicy` — `gcloud projects get-iam-policy` (node-pool SA audit)
+- `iam.roles.get` — `gcloud iam roles describe` (inspect role permissions)
+
+**Suggested predefined role(s)**
+- `roles/container.viewer` — covers `container.*` reads plus read-only Kubernetes RBAC for the `kubectl` calls (get nodes/pods/events, top nodes)
+- `roles/compute.viewer` — covers the `compute.*` reads (instances, instance-group managers, operations, machine types, region quota)
+- `roles/recommender.viewer` — covers the Recommender list calls (`roles/recommender.containerDiagnosisViewer` is a narrower alternative)
+- `roles/iam.securityReviewer` — covers `resourcemanager.projects.getIamPolicy` and `iam.roles.get` used by the service-account audit
+- `roles/browser` (or `roles/viewer`) — covers `resourcemanager.projects.get`
+
+> Least-privilege combo: `roles/container.viewer` + `roles/compute.viewer` + `roles/recommender.viewer` + `roles/iam.securityReviewer` + `roles/browser`. A single project-level `roles/viewer` covers every read here **except** `resourcemanager.projects.getIamPolicy` and `iam.roles.get`, so `roles/iam.securityReviewer` must still be added for the service-account audit. The write permissions referenced inside `sa_check.sh` (e.g. `logging.logEntries.create`) are permissions it *checks for* on the node-pool SAs — they are **not** required by the runner service account. Requires the Kubernetes Engine, Compute Engine, Recommender, IAM, and Cloud Resource Manager APIs enabled on the project.

--- a/codebundles/k8s-ingress-gce-healthcheck/README.md
+++ b/codebundles/k8s-ingress-gce-healthcheck/README.md
@@ -26,6 +26,30 @@ The TaskSet requires initialization to import necessary secrets, services, and u
 - `gcp_credentials`: The name of the secret that contains GCP service account json details with project `Viewer` access. 
 
 
+## Requirements
+
+This codebundle uses two independent credentials:
+
+1. A GCP service account (`gcp_credentials`, activated via `gcloud auth activate-service-account`) scoped to `${GCP_PROJECT_ID}`, used to inspect the GCE (Ingress-GCE) load-balancer resources backing the Ingress and to read network error logs.
+2. A `kubeconfig` with Kubernetes RBAC read (get/list) access to Ingress, Service, and Event objects in the target namespace (the GCE resource names are read from the Ingress annotations).
+
+The following GCP IAM permissions are required on the service account (all read-only):
+
+**Granular IAM permissions**
+- `compute.forwardingRules.get` — `gcloud compute forwarding-rules describe`
+- `compute.urlMaps.get` — `gcloud compute url-maps describe`
+- `compute.targetHttpsProxies.get` — `gcloud compute target-https-proxies describe`
+- `compute.targetHttpProxies.get` — `gcloud compute target-http-proxies describe`
+- `compute.backendServices.get` — `gcloud compute backend-services get-health` (reads the backend service)
+- `compute.backendServices.getHealth` — `gcloud compute backend-services get-health` (backend health status)
+- `logging.logEntries.list` — `gcloud logging read` (GCE network error logs)
+
+**Suggested predefined role(s)**
+- `roles/compute.viewer` — covers all the `compute.*` reads above
+- `roles/logging.viewer` — covers `logging.logEntries.list`
+
+> Requires the Compute Engine (`compute.googleapis.com`) and Cloud Logging (`logging.googleapis.com`) APIs enabled on the project. Kubernetes access is authenticated separately via the `kubeconfig` secret — GCP IAM does not grant cluster RBAC.
+
 ## TODO
 - [ ] Add documentation
 - [ ] Add github integration with source code vs image comparison


### PR DESCRIPTION
## What

Scanned every GCP codebundle (those that actually invoke `gcloud` / `gsutil` / `bq`) and documented the **granular IAM permissions** each one needs to run, along with **suggested least-privilege predefined roles**, in a consistent `## Requirements` section of each README.

## Why

Permission requirements were inconsistent or missing across GCP codebundles: some had accurate granular lists (e.g. `gcp-cloud-function-health`), others said only "Viewer / Security Reviewer", carried stale `TODO: update required GCP SA permissions` placeholders, or (for the GMP bundles) referenced the wrong API entirely. Operators setting up service accounts had no reliable per-bundle least-privilege reference.

## How

Each codebundle's scripts (`*.robot`, `*.sh`, `*.py`) were analyzed to extract every `gcloud`/`gsutil`/`bq` command and REST endpoint, then mapped to the minimal IAM permission(s) and a covering predefined role.

## Codebundles updated (11)

| Codebundle | Suggested roles |
|---|---|
| `curl-gmp-kong-ingress-inspection` | `monitoring.viewer` |
| `curl-gmp-nginx-ingress-inspection` | `monitoring.viewer` (+ kubeconfig RBAC) |
| `gcloud-log-inspection` | `logging.viewer` |
| `gcp-bigquery-dataset-health` | `bigquery.metadataViewer`, `iam.securityReviewer`, `logging.viewer` |
| `gcp-bucket-health` | `iam.securityReviewer`, `storage.objectViewer`, `monitoring.viewer`, `serviceusage.serviceUsageViewer` |
| `gcp-cloud-function-health` | `cloudfunctions.viewer`, `run.viewer`, `cloudbuild.builds.viewer`, `logging.viewer` |
| `gcp-cloud-loadbalancer-health` | `compute.viewer`, `monitoring.viewer` |
| `gcp-project-cost-health` | `bigquery.jobUser` + `bigquery.dataViewer`, `recommender.viewer`, `billing.viewer`, `compute.viewer`, `serviceusage.serviceUsageViewer`, `viewer` |
| `gcp-vertex-modelgarden-health` | `monitoring.viewer`, `logging.privateLogViewer`, `serviceusage.serviceUsageConsumer`, `aiplatform.viewer` (discovery) |
| `gke-cluster-health` | `container.viewer`, `compute.viewer`, `recommender.viewer`, `iam.securityReviewer`, `browser` |
| `k8s-ingress-gce-healthcheck` | `compute.viewer`, `logging.viewer` (+ kubeconfig RBAC) |

## Notable corrections

- **GMP bundles** (`curl-gmp-*`): the old note claimed the SA needs "GCP logging API" access — they actually query **Cloud Monitoring** (`monitoring.timeSeries.list`). Fixed.
- **`gcp-bucket-health`**: replaced vague "Viewer / Security Reviewer" and removed the stale `TODO: Update required GCP SA permissions`.
- **`gcp-bigquery-dataset-health`**: dropped `bigquery.dataViewer` — the bundle runs no queries (metadata-only `bq ls`/`bq show`), so `bigquery.metadataViewer` suffices.
- **`gke-cluster-health`**: clarified that the write permissions in `sa_check.sh` are permissions it *audits on node-pool SAs*, not permissions the runner SA needs.

Notes: `access:read-only` throughout — no write/mutate permissions are documented. Scope was limited to GCP per request; AWS/Azure/k8s codebundles are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)